### PR TITLE
fix: datasets are not validated

### DIFF
--- a/datasets_service/app/api/routers/datasets.py
+++ b/datasets_service/app/api/routers/datasets.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Depends, UploadFile, File, Form
-from typing import List, Annotated
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
 
 from app.logs import get_logger
-from app.core.filesystem import ArchiveManager
 from app.core.services import DatasetManager
+from app.core.exception.base import CoreException
 from app.api.deps import get_dataset_manager
 from app.api.schemas.dataset import DatasetMetadata
 from app.api.schemas.dataset_new import NewDataset
@@ -65,7 +65,6 @@ def delete_dataset(dataset_id: str, dm: DatasetManager = Depends(get_dataset_man
 
 @router.post(
     "/new", 
-    response_model=bool,
     summary="Создать датасет",
     description="Создаёт новый датасет из загружает файл данных.",
     response_description="True, если датасет успешно создан",
@@ -74,6 +73,12 @@ def create_dataset(
     new_dataset: NewDataset, 
     dm: DatasetManager = Depends(get_dataset_manager),
 ):
-    dm.add_new_dataset(new_dataset)
-    return True
-
+    try:
+        dm.add_new_dataset(new_dataset)
+        return True
+    except CoreException as e:
+        logger.error(f"\nОшибка: {e.message}\nДетали: {e.detail}")
+        return HTTPException(
+            status_code=e.status_code, 
+            detail=e.message
+        )

--- a/datasets_service/app/core/exception/version.py
+++ b/datasets_service/app/core/exception/version.py
@@ -18,11 +18,10 @@ class VersionValidationError(CoreException):
             reason: str, 
             version_id: str | None = None
     ):
-        msg = f"Ошибка валидации датасета"
+        msg = f"Ошибка валидации датасета: "
         
         if version_id:
-            msg += f" '{version_id}'"    
-        msg += f": {reason}"
+            msg += f" '{version_id}'."    
         
         super().__init__(
             message=msg,

--- a/datasets_service/app/core/filesystem/fsm.py
+++ b/datasets_service/app/core/filesystem/fsm.py
@@ -2,8 +2,12 @@ import shutil
 from contextlib import contextmanager
 from pathlib import Path
 
-IMAGE_SUFFIXES = {'.jpg', '.png'}
+from app.core.exception.version import VersionValidationError
+from app.logs import get_logger
 
+logger = get_logger(__name__)
+
+IMAGE_SUFFIXES = {'.jpg', '.png', '.jpeg'}
 
 class FileSystemManager:
     def __init__(
@@ -191,16 +195,34 @@ class FileSystemManager:
 
     # ================ Работа с изображениями ================
 
-    def all_file_is_image(self, recursive: bool = False) -> bool:
+
+    # __WARNING__ ПЕРЕСМОТРЕТЬ ИСПОЛЬЗОВАНИЕ ЭТОГО МЕТОДА И ПЕРЕДЕЛАТЬ !!!!
+
+    def all_file_is_image(
+            self, 
+            recursive: bool = False,
+            info: str | None = None
+        ) -> bool:
         """
         Проверяет, что все файлы в папке являются изображениями
+        
+        Args:
             recursive=True → проверяет и вложенные папки
+            info - в какой директории проверяются файлы
         """
         def is_image(p: Path) -> bool:
             return p.is_file() and p.suffix.lower() in IMAGE_SUFFIXES
 
         if recursive:
-            return all(is_image(p) for p in self.worker_path.rglob("*") if p.is_file())
+            for p in self.worker_path.rglob("*"):
+                if p.is_file(): 
+                    if is_image(p) == True:
+                        continue
+                    else:
+                        raise VersionValidationError(
+                            f"В папке {self.worker_path} файл {p.name} являются изображениями.",
+                        )
+            return True
         else:
             return all(is_image(p) for p in self.worker_path.iterdir() if p.is_file())
 

--- a/datasets_service/app/core/services/validation/__init__.py
+++ b/datasets_service/app/core/services/validation/__init__.py
@@ -41,11 +41,9 @@ def new_dataset(
                 type_task_supported()
             )
 
-        logger.debug(
-            f'| Поддержка тип и задачи'
-            f'| 🟩 Тип:    {dsn.type}'
-            f'| 🟩 Задача: {dsn.task}'
-        )
+        logger.debug('| Поддержка тип и задачи')
+        logger.debug(f'| 🟩 Тип:    {dsn.type}')
+        logger.debug(f'| 🟩 Задача: {dsn.task}')
 
         dsm = processor(dsn, fsm)
 

--- a/datasets_service/app/core/services/validation/image_classification.py
+++ b/datasets_service/app/core/services/validation/image_classification.py
@@ -86,11 +86,7 @@ def version_validation_and_create_metadata(
                         nv.version_id
                     )
 
-                if not fsm.all_file_is_image():
-                    raise VersionValidationError(
-                        f"В папке {dir_selection}/{dir_class} не все файлы являются изображениями.",
-                        nv.version_id
-                    )
+                fsm.all_file_is_image()    
                 
                 count_files_in_class = len(fsm.get_all_files())
                 if count_files_in_class == 0:


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
- В [datasets_service/app/core/filesystem/fsm.py](https://github.com/kisinwi-dev/kisinwi-plt/compare/datasets_service/fix/uploads?expand=1#diff-2db55388c3122f3f1fb3bf9a5d4768953708929d474f33bc1219d71b4cc9fa0a) отсутствовал формат изображений `.jpeg`
- В [datasets_service/app/api/routers/datasets.py](https://github.com/kisinwi-dev/kisinwi-plt/compare/datasets_service/fix/uploads?expand=1#diff-ffd12eb99e744c74d5aae98e5c33f3f80020c82e5d0d505708e6e69df38c838c) роутер в случае ошибки выдаёт ошибку на выход с её описанием