### PR TITLE
Agent/feat/improve history integration

### DIFF
--- a/services/agents/app/api/routers/analytic.py
+++ b/services/agents/app/api/routers/analytic.py
@@ -1,10 +1,11 @@
 from typing import List
 from fastapi import APIRouter, Query, HTTPException
 
-from app.core.crews.metrics_analyst import run_metrics_analyst
-from app.core.crews.dataset_analyst import run_dataset_analyst
-from app.core.crews.reporter import run_reporter
+from app.core.crews.metrics_analyst import run_metrics_analyst, AGENT_ROLE as METRICS_ANALYST_ROLE
+from app.core.crews.dataset_analyst import run_dataset_analyst, AGENT_ROLE as DATASET_ANALYST_ROLE
+from app.core.crews.reporter import run_reporter, AGENT_ROLE as REPORTER_ROLE
 from app.core.memory import discussion_context, models_context
+from app.services.agent_history import agent_history_client
 
 routers = APIRouter(
     prefix='/analytics',
@@ -23,6 +24,7 @@ def analyze_datasets(
     try:
 
         discussion_context.set(discussion_id)
+        agent_history_client.create_discussion(discussion_id, pipeline="dataset_analyst", agent_roles=[DATASET_ANALYST_ROLE])
 
         result = run_dataset_analyst(
             dataset_id=dataset_id,
@@ -52,6 +54,7 @@ def analyze_ml_metric(
     try:
         
         discussion_context.set(discussion_id)
+        agent_history_client.create_discussion(discussion_id, pipeline="metrics_analyst", agent_roles=[METRICS_ANALYST_ROLE])
 
         result = run_metrics_analyst(
             business_goal=business_goal,
@@ -81,7 +84,8 @@ def reporter(
     try:
         
         discussion_context.set(discussion_id)
-        for model_id in models_id: 
+        agent_history_client.create_discussion(discussion_id, pipeline="reporter", agent_roles=[REPORTER_ROLE])
+        for model_id in models_id:
             models_context.add_model(model_id)
 
         result = run_reporter(

--- a/services/agents/app/api/routers/full_pipeline.py
+++ b/services/agents/app/api/routers/full_pipeline.py
@@ -34,7 +34,7 @@ def development(
     deployment_constraints: str = Query(..., description="Технические возможности прода"),
     business_requirements: str = Query(..., description="Описание бизнес требований"),
     denied_hypotheses_info: List[str] = Query(default_factory=list, description="Гипотезы и практики, которые нужно избегать"),
-    max_iter: int = Query("", description="Количество попыток обучения")
+    max_iter: int = Query(2, description="Количество попыток обучения")
 ):
     try:
         discussion_id = str(uuid4())
@@ -46,7 +46,7 @@ def development(
             agent_roles=_DEVELOPMENT_AGENT_ROLES,
         )
 
-        return development_models(
+        result = development_models(
             dataset_id=dataset_id,
             dataset_version_id=version_id,
             model_name=model_name,
@@ -55,7 +55,12 @@ def development(
             denied_hypotheses_info=denied_hypotheses_info,
             max_iter=max_iter,
         )
+        if result is None:
+            raise HTTPException(status_code=422, detail="Пайплайн завершился без результата")
+        return result
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=500,

--- a/services/agents/app/api/routers/full_pipeline.py
+++ b/services/agents/app/api/routers/full_pipeline.py
@@ -4,10 +4,24 @@ from fastapi import APIRouter, Query, HTTPException
 
 from app.core import development_models
 from app.core.memory import discussion_context, models_context
+from app.services.agent_history import agent_history_client
+from app.core.crews.dataset_analyst import AGENT_ROLE as DATASET_ANALYST_ROLE
+from app.core.crews.researcher import AGENT_ROLE as RESEARCHER_ROLE
+from app.core.crews.ml_engeneer import AGENT_ROLE as ML_ENGINEER_ROLE
+from app.core.crews.ml_debuger import AGENT_ROLE as ML_DEBUGER_ROLE
+from app.core.crews.reporter import AGENT_ROLE as REPORTER_ROLE
 
 routers = APIRouter(
     tags=['pipeline']
 )
+
+_DEVELOPMENT_AGENT_ROLES = [
+    DATASET_ANALYST_ROLE,
+    RESEARCHER_ROLE,
+    ML_ENGINEER_ROLE,
+    ML_DEBUGER_ROLE,
+    REPORTER_ROLE,
+]
 
 @routers.get(
         "/development",
@@ -23,7 +37,14 @@ def development(
     max_iter: int = Query("", description="Количество попыток обучения")
 ):
     try:
-        discussion_context.set(str(uuid4()))
+        discussion_id = str(uuid4())
+        discussion_context.set(discussion_id)
+
+        agent_history_client.create_discussion(
+            discussion_id=discussion_id,
+            pipeline="development",
+            agent_roles=_DEVELOPMENT_AGENT_ROLES,
+        )
 
         return development_models(
             dataset_id=dataset_id,

--- a/services/agents/app/api/routers/ml_engin.py
+++ b/services/agents/app/api/routers/ml_engin.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Query, HTTPException
 
-from app.core.crews.ml_engeneer import run_ml_engineering
-from app.core.crews.ml_debuger import run_ml_debug
+from app.core.crews.ml_engeneer import run_ml_engineering, AGENT_ROLE as ML_ENGINEER_ROLE
+from app.core.crews.ml_debuger import run_ml_debug, AGENT_ROLE as ML_DEBUGER_ROLE
 from app.core.memory import discussion_context
+from app.services.agent_history import agent_history_client
 
 routers = APIRouter(
     tags=['engineering']
@@ -22,6 +23,7 @@ def run_etp(
     try:
         
         discussion_context.set(discussion_id)
+        agent_history_client.create_discussion(discussion_id, pipeline="ml_engineer", agent_roles=[ML_ENGINEER_ROLE])
 
         result = run_ml_engineering(
             dataset_info=dataset_info,
@@ -52,6 +54,7 @@ def run_ed(
     try:
     
         discussion_context.set(discussion_id)
+        agent_history_client.create_discussion(discussion_id, pipeline="ml_debuger", agent_roles=[ML_DEBUGER_ROLE])
 
         result = run_ml_debug(
             error=error,

--- a/services/agents/app/api/routers/researcher.py
+++ b/services/agents/app/api/routers/researcher.py
@@ -1,8 +1,9 @@
 from typing import List
 from fastapi import APIRouter, Query, HTTPException
 
-from app.core.crews.researcher import run_researcher, ResearcherOutput
+from app.core.crews.researcher import run_researcher, ResearcherOutput, AGENT_ROLE as RESEARCHER_ROLE
 from app.core.memory import discussion_context
+from app.services.agent_history import agent_history_client
 
 routers = APIRouter(
     prefix='/research',
@@ -23,6 +24,7 @@ def praxis_in_internet(
     try:
 
         discussion_context.set(discussion_id)
+        agent_history_client.create_discussion(discussion_id, pipeline="researcher", agent_roles=[RESEARCHER_ROLE])
 
         result = run_researcher(
             business_requirements=business_requirements,

--- a/services/agents/app/api/routers/searcher.py
+++ b/services/agents/app/api/routers/searcher.py
@@ -1,9 +1,10 @@
 from typing import List
 from fastapi import APIRouter, Query, HTTPException
 
-from app.core.crews.praxis_searcher import run_praxis_searcher, PraxisSearchOutput
-from app.core.crews.ml_models_searcher import run_ml_models_searcher, MLModelsSearcherOutput
+from app.core.crews.praxis_searcher import run_praxis_searcher, PraxisSearchOutput, AGENT_ROLE as PRAXIS_SEARCHER_ROLE
+from app.core.crews.ml_models_searcher import run_ml_models_searcher, MLModelsSearcherOutput, AGENT_ROLE as ML_MODELS_SEARCHER_ROLE
 from app.core.memory import discussion_context
+from app.services.agent_history import agent_history_client
 
 routers = APIRouter(
     prefix='/searcher',
@@ -23,6 +24,7 @@ def praxis_in_internet(
     try:
 
         discussion_context.set(discussion_id)
+        agent_history_client.create_discussion(discussion_id, pipeline="praxis_searcher", agent_roles=[PRAXIS_SEARCHER_ROLE])
 
         result = run_praxis_searcher(
             search_query=search_query,
@@ -52,6 +54,7 @@ def get_info_ml_models(
     try:
 
         discussion_context.set(discussion_id)
+        agent_history_client.create_discussion(discussion_id, pipeline="ml_models_searcher", agent_roles=[ML_MODELS_SEARCHER_ROLE])
 
         result = run_ml_models_searcher(
             model_ids=model_ids,

--- a/services/agents/app/core/__init__.py
+++ b/services/agents/app/core/__init__.py
@@ -3,7 +3,7 @@ from typing import List
 from app.logs import get_logger
 from app.core.crews.dataset_analyst import run_dataset_analyst
 from app.core.crews.reporter import run_reporter
-from app.core.memory import discussion_context
+from app.core.memory import discussion_context, iteration_context
 from app.services.agent_history import agent_history_client
 from .pipeline import (
     train_and_debug, reasoning,
@@ -51,6 +51,7 @@ def development_models(
     version_model=0
 
     for iter in range(1, max_iter+1):
+        iteration_context.set(iter)
         version_model+=1
 
         info_start_iter = f"Полный цикл обучения №{iter} из {max_iter}"
@@ -122,6 +123,7 @@ def development_models(
         verbose=verbose
     )
 
+    iteration_context.clear()
     agent_history_client.update_discussion_meta(discussion_context.get(), status="completed")
     return result
 

--- a/services/agents/app/core/__init__.py
+++ b/services/agents/app/core/__init__.py
@@ -3,8 +3,10 @@ from typing import List
 from app.logs import get_logger
 from app.core.crews.dataset_analyst import run_dataset_analyst
 from app.core.crews.reporter import run_reporter
+from app.core.memory import discussion_context
+from app.services.agent_history import agent_history_client
 from .pipeline import (
-    train_and_debug, reasoning, 
+    train_and_debug, reasoning,
     TrainingInput
 )
 
@@ -42,6 +44,7 @@ def development_models(
     )
     if not dataset_analyst_out.readiness_assessment:
         logger.info("🟥 Анализ датасета показал, что данные не готовы к обучению")
+        agent_history_client.update_discussion_meta(discussion_context.get(), status="failed")
         return None
 
     logger.info("✅ Анализ датасета")
@@ -69,6 +72,7 @@ def development_models(
         if not ml_engin_out.decision:
             logger.info("🟥 МЛ инженер и исследователь не смогли придти к общему мнению.")
             logger.warning("🟥 Обучение остановлено")
+            agent_history_client.update_discussion_meta(discussion_context.get(), status="failed")
             return None
         logger.info("✅ Конец рассуждений.")
 
@@ -118,5 +122,6 @@ def development_models(
         verbose=verbose
     )
 
+    agent_history_client.update_discussion_meta(discussion_context.get(), status="completed")
     return result
 

--- a/services/agents/app/core/crews/dataset_analyst/__init__.py
+++ b/services/agents/app/core/crews/dataset_analyst/__init__.py
@@ -1,3 +1,3 @@
-from .dataset_analyst import run_dataset_analyst
+from .dataset_analyst import run_dataset_analyst, AGENT_ROLE
 
-__all__ = ['run_dataset_analyst']
+__all__ = ['run_dataset_analyst', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/dataset_analyst/dataset_analyst.py
+++ b/services/agents/app/core/crews/dataset_analyst/dataset_analyst.py
@@ -1,15 +1,13 @@
 from pathlib import Path
 from typing import List
 from pydantic import BaseModel, Field
-from crewai import Agent, Crew, Process, Task, CrewOutput
+from crewai import Agent, Crew, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 from crewai.tools import tool
 
 from .tools import get_tools
-from ..utils import track_agent, get_agent_role_from_config
-from app.services.metrics import add_agent_in_metrics
-from app.services.agent_history import agent_history_client
+from ..utils import get_agent_role_from_config, run_crew_with_tracking
 from app.logs import get_logger
 from app.core.llm import llm
 
@@ -104,7 +102,6 @@ class DatasetAnalystCrew:
             verbose=verbose
         )
 
-@track_agent(agent_role=AGENT_ROLE)
 def run_dataset_analyst(
         dataset_id: str,
         dataset_version_id: str,
@@ -117,22 +114,19 @@ def run_dataset_analyst(
         dataset_id: id датасета
         dataset_version_id: id версии датасета
         verbose: логирование в консоли
-
-    * Автоматически записывает метрики использования агента, а так же
-    записывает в историю дискусии.
     """
     crew = DatasetAnalystCrew().crew(verbose=verbose)
 
-    crew_output = crew.kickoff(
+    crew_output = run_crew_with_tracking(
+        crew=crew,
+        agent_role=AGENT_ROLE,
         inputs={
             "dataset_id": dataset_id,
             "dataset_version_id": dataset_version_id,
-        }
+        },
     )
 
-    result: DatasetAnalystOut
-
-    if not isinstance(crew_output, CrewOutput):
+    if crew_output is None:
         return DatasetAnalystOut(
             brief_description="Не получилось обработать результат ответа агента.",
             quality_assessment="",
@@ -142,31 +136,18 @@ def run_dataset_analyst(
         )
 
     try:
-
-        task_output = crew_output.tasks_output[0]
-        result = task_output.pydantic # type: ignore[index]
-
+        result = crew_output.tasks_output[0].pydantic  # type: ignore[index]
     except Exception as e:
         logger.warning(f"Не удалось получить pydantic output: {e}. Используем fallback.")
-        raw_text = extract_result(crew_output)
         result = DatasetAnalystOut(
-            brief_description=raw_text,
+            brief_description=extract_result(crew_output),
             quality_assessment="",
             found_issues="",
             recommendations="Не удалось обработать ответ агента в 'pydantic' схему",
             readiness_assessment=False
         )
 
-    # Сохраняем метрики и историю
-    add_agent_in_metrics(crew=crew)
-
-    agent_history_client.agent_succeed(
-        response_id=str(crew.id),
-        agent_role=AGENT_ROLE,
-        text=result.get_summary()  # сохраняем основной текст
-    )
-
-    logger.info(f"Аналитик датасетов отработал")
+    logger.info("Аналитик датасетов отработал")
     return result
 
 

--- a/services/agents/app/core/crews/metrics_analyst/__init__.py
+++ b/services/agents/app/core/crews/metrics_analyst/__init__.py
@@ -1,3 +1,3 @@
-from .metrics_analyst import run_metrics_analyst
+from .metrics_analyst import run_metrics_analyst, AGENT_ROLE
 
-__all__ = ['run_metrics_analyst']
+__all__ = ['run_metrics_analyst', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/metrics_analyst/metrics_analyst.py
+++ b/services/agents/app/core/crews/metrics_analyst/metrics_analyst.py
@@ -6,9 +6,7 @@ from crewai.project import CrewBase, agent, crew, task
 from crewai.tools import tool
 
 from .tools import get_tools
-from ..utils import track_agent, get_agent_role_from_config
-from app.services.metrics import add_agent_in_metrics
-from app.services.agent_history import agent_history_client
+from ..utils import get_agent_role_from_config, run_crew_with_tracking
 from app.logs import get_logger
 from app.core.llm import llm
 
@@ -57,7 +55,6 @@ class MetricAnalystCrew:
             verbose=verbose
         )
 
-@track_agent(agent_role=AGENT_ROLE)
 def run_metrics_analyst(
         model_id: str,
         business_goal: str,
@@ -70,32 +67,16 @@ def run_metrics_analyst(
         model_id: Id модели для анализа
         business_goal: Требования бизнеса
         verbose: Логирование в консоли
-
-    * Автоматически записывает метрики использования агента, а так же
-    записывает в историю дискусии.
     """
     crew = MetricAnalystCrew().crew(verbose=verbose)
 
-    crew_output = crew.kickoff(
-        inputs={
-            "model_id": model_id,
-            "business_goal": business_goal
-        }
-    )
-
-    result = extract_result(crew_output)
-
-    add_agent_in_metrics(
-        crew=crew
-    )
-
-    agent_history_client.agent_succeed(
-        response_id=str(crew.id),
+    crew_output = run_crew_with_tracking(
+        crew=crew,
         agent_role=AGENT_ROLE,
-        text=result
+        inputs={"model_id": model_id, "business_goal": business_goal},
     )
 
-    return result
+    return extract_result(crew_output) if crew_output is not None else ""
 
 
 def extract_result(crew_output):

--- a/services/agents/app/core/crews/ml_debuger/__init__.py
+++ b/services/agents/app/core/crews/ml_debuger/__init__.py
@@ -1,3 +1,3 @@
-from .ml_debuger import run_ml_debug, MlDebugerOut
+from .ml_debuger import run_ml_debug, MlDebugerOut, AGENT_ROLE
 
-__all__ = ['run_ml_debug', 'MlDebugerOut']
+__all__ = ['run_ml_debug', 'MlDebugerOut', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/ml_debuger/ml_debuger.py
+++ b/services/agents/app/core/crews/ml_debuger/ml_debuger.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 from typing import List
 from pydantic import BaseModel, Field
-from crewai import Agent, Crew, Process, Task, CrewOutput
+from crewai import Agent, Crew, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 
 from .tools import get_tools
-from ..utils import track_agent, get_agent_role_from_config
-from app.services.metrics import add_agent_in_metrics
-from app.services.agent_history import agent_history_client
+from ..utils import get_agent_role_from_config, run_crew_with_tracking
 from app.logs import get_logger
 from app.core.llm import llm
 
@@ -67,7 +65,6 @@ class MLDebugerCrew:
             verbose=verbose
         )
 
-@track_agent(agent_role=AGENT_ROLE)
 def run_ml_debug(
         error: str,
         config: str,
@@ -80,50 +77,25 @@ def run_ml_debug(
         error: Ошибка полученная от сервиса обучения
         config: Конфиг отправленный в сервис обучения
         verbose: логирование в консоли
-
-    * Автоматически записывает метрики использования агента, а так же
-    записывает в историю дискусии.
     """
     crew = MLDebugerCrew().crew(verbose=verbose)
 
-    crew_output = crew.kickoff(
-        inputs={
-            "error": error,
-            "config": config
-        }
+    crew_output = run_crew_with_tracking(
+        crew=crew,
+        agent_role=AGENT_ROLE,
+        inputs={"error": error, "config": config},
     )
 
-    result: MlDebugerOut
-
-    if not isinstance(crew_output, CrewOutput):
-        return MlDebugerOut(
-            decision=False,
-            reason="",
-        )
+    if crew_output is None:
+        return MlDebugerOut(decision=False, reason="")
 
     try:
-
-        task_output = crew_output.tasks_output[0]
-        result = task_output.pydantic # type: ignore[index]
-
+        result = crew_output.tasks_output[0].pydantic  # type: ignore[index]
     except Exception as e:
         logger.warning(f"Не удалось получить pydantic output: {e}. Используем fallback.")
-        raw_text = extract_result(crew_output)
-        result = MlDebugerOut(
-            decision=False,
-            reason=raw_text,
-        )
+        result = MlDebugerOut(decision=False, reason=extract_result(crew_output))
 
-    # Сохраняем метрики и историю
-    add_agent_in_metrics(crew=crew)
-
-    agent_history_client.agent_succeed(
-        response_id=str(crew.id),
-        agent_role=AGENT_ROLE,
-        text=result.reason  # сохраняем основной текст
-    )
-
-    logger.info(f"ML Engineer отработал | Задача принята в обработку: {result.decision}")
+    logger.info(f"ML Debuger отработал | Можем исправить: {result.decision}")
     return result
 
 def extract_result(crew_output):

--- a/services/agents/app/core/crews/ml_engeneer/__init__.py
+++ b/services/agents/app/core/crews/ml_engeneer/__init__.py
@@ -1,3 +1,3 @@
-from .ml_engeneer import run_ml_engineering, MlEngineerResponse
+from .ml_engeneer import run_ml_engineering, MlEngineerResponse, AGENT_ROLE
 
-__all__ = ['run_ml_engineering', 'MlEngineerResponse']
+__all__ = ['run_ml_engineering', 'MlEngineerResponse', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/ml_engeneer/ml_engeneer.py
+++ b/services/agents/app/core/crews/ml_engeneer/ml_engeneer.py
@@ -1,15 +1,13 @@
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel, Field
-from crewai import Agent, Crew, Process, Task, CrewOutput
+from crewai import Agent, Crew, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 from crewai.tools import tool
 
 from .tools import get_tools
-from ..utils import track_agent, get_agent_role_from_config
-from app.services.metrics import add_agent_in_metrics
-from app.services.agent_history import agent_history_client
+from ..utils import get_agent_role_from_config, run_crew_with_tracking
 from app.logs import get_logger
 from app.core.llm import llm
 
@@ -73,7 +71,6 @@ class MLEngineerCrew:
             verbose=verbose
         )
 
-@track_agent(agent_role=AGENT_ROLE)
 def run_ml_engineering(
         dataset_info: str,
         business_requirements: str,
@@ -90,24 +87,21 @@ def run_ml_engineering(
         deployment_constraints: Технические требования
         researcher_proposals: Предложение от ресерчера
         verbose: логирование в консоли
-
-    * Автоматически записывает метрики использования агента, а так же
-    записывает в историю дискусии.
     """
     crew = MLEngineerCrew().crew(verbose=verbose)
 
-    crew_output = crew.kickoff(
+    crew_output = run_crew_with_tracking(
+        crew=crew,
+        agent_role=AGENT_ROLE,
         inputs={
             "dataset_info": dataset_info,
             "business_requirements": business_requirements,
             "deployment_constraints": deployment_constraints,
-            "researcher_proposals": researcher_proposals
-        }
+            "researcher_proposals": researcher_proposals,
+        },
     )
 
-    result: MlEngineerResponse
-
-    if not isinstance(crew_output, CrewOutput):
+    if crew_output is None:
         return MlEngineerResponse(
             decision=False,
             reason="",
@@ -115,27 +109,14 @@ def run_ml_engineering(
         )
 
     try:
-
-        task_output = crew_output.tasks_output[0]
-        result = task_output.pydantic # type: ignore[index]
-
+        result = crew_output.tasks_output[0].pydantic  # type: ignore[index]
     except Exception as e:
         logger.warning(f"Не удалось получить pydantic output: {e}. Используем fallback.")
-        raw_text = extract_result(crew_output)
         result = MlEngineerResponse(
             decision=False,
-            reason=raw_text,
+            reason=extract_result(crew_output),
             recommendations="Ошибка при обработке ответа ML Enginner, предупреди пользователя"
         )
-
-    # Сохраняем метрики и историю
-    add_agent_in_metrics(crew=crew)
-
-    agent_history_client.agent_succeed(
-        response_id=str(crew.id),
-        agent_role=AGENT_ROLE,
-        text=result.reason  # сохраняем основной текст
-    )
 
     logger.info(f"ML Engineer отработал | Задача принята в обработку: {result.decision}")
     return result

--- a/services/agents/app/core/crews/ml_models_searcher/__init__.py
+++ b/services/agents/app/core/crews/ml_models_searcher/__init__.py
@@ -1,3 +1,3 @@
-from .ml_models_searcher import run_ml_models_searcher, MLModelsSearcherOutput
+from .ml_models_searcher import run_ml_models_searcher, MLModelsSearcherOutput, AGENT_ROLE
 
-__all__ = ['run_ml_models_searcher', 'MLModelsSearcherOutput']
+__all__ = ['run_ml_models_searcher', 'MLModelsSearcherOutput', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/ml_models_searcher/ml_models_searcher.py
+++ b/services/agents/app/core/crews/ml_models_searcher/ml_models_searcher.py
@@ -1,15 +1,13 @@
 from pathlib import Path
 from typing import List
 from pydantic import BaseModel, Field
-from crewai import Agent, Crew, Task, CrewOutput
+from crewai import Agent, Crew, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 from crewai.tools import tool
 
 from .tools import get_tools
-from ..utils import track_agent, get_agent_role_from_config
-from app.services.metrics import add_agent_in_metrics
-from app.services.agent_history import agent_history_client
+from ..utils import get_agent_role_from_config, run_crew_with_tracking
 from app.core.memory import models_context
 from app.logs import get_logger
 from app.core.llm import llm
@@ -66,32 +64,31 @@ class MLModelsSearcherCrew:
             verbose=verbose
         )
 
-@track_agent(agent_role=AGENT_ROLE)
 def run_ml_models_searcher(
     model_ids: List[str],
     context: str,
     verbose: bool = False
 ) -> MLModelsSearcherOutput:
     """
-    Запускает агента-поисковика лучших практик.
-    
+    Запускает агента-поисковика по обученным моделям.
+
     Args:
-        discussion_id: ID дискуссии
-        model_ids: Конкретный запрос для поиска
+        model_ids: Список ID моделей для анализа
         context: Дополнительный контекст
         verbose: Логирование
     """
     crew = MLModelsSearcherCrew().crew(verbose=verbose)
 
-    crew_output = crew.kickoff(
+    crew_output = run_crew_with_tracking(
+        crew=crew,
+        agent_role=AGENT_ROLE,
         inputs={
-            "model_ids": ",".join(id for id in model_ids),
-            "context": context 
-        }
+            "model_ids": ",".join(model_ids),
+            "context": context,
+        },
     )
-    result: MLModelsSearcherOutput
 
-    if not isinstance(crew_output, CrewOutput):
+    if crew_output is None:
         return MLModelsSearcherOutput(
             text="В процессе работы была получена ошибка с типизацией",
             summary="",
@@ -99,27 +96,14 @@ def run_ml_models_searcher(
         )
 
     try:
-
-        task_output = crew_output.tasks_output[0]
-        result = task_output.pydantic # type: ignore[index]
-
+        result = crew_output.tasks_output[0].pydantic  # type: ignore[index]
     except Exception as e:
         logger.warning(f"Не удалось получить pydantic output: {e}. Используем fallback.")
-        raw_text = extract_result(crew_output)
         result = MLModelsSearcherOutput(
-            text=raw_text,
+            text=extract_result(crew_output),
             summary="",
             metrics_summary=[]
         )
-
-    # Сохраняем метрики и историю
-    add_agent_in_metrics(crew=crew)
-
-    agent_history_client.agent_succeed(
-        response_id=str(crew.id),
-        agent_role=AGENT_ROLE,
-        text=result.text  # сохраняем основной текст
-    )
 
     logger.info(f"ML Models Searcher завершён | Моделей разобрано: {len(model_ids)}")
     return result

--- a/services/agents/app/core/crews/praxis_searcher/__init__.py
+++ b/services/agents/app/core/crews/praxis_searcher/__init__.py
@@ -1,3 +1,3 @@
-from .praxis_searcher import run_praxis_searcher, PraxisSearchOutput
+from .praxis_searcher import run_praxis_searcher, PraxisSearchOutput, AGENT_ROLE
 
-__all__ = ['run_praxis_searcher', 'PraxisSearchOutput']
+__all__ = ['run_praxis_searcher', 'PraxisSearchOutput', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/praxis_searcher/praxis_searcher.py
+++ b/services/agents/app/core/crews/praxis_searcher/praxis_searcher.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 from typing import List, Optional
 from pydantic import BaseModel, Field
-from crewai import Agent, Crew, Task, CrewOutput
+from crewai import Agent, Crew, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 from crewai.tools import tool
 
-from ..utils import track_agent, get_agent_role_from_config
-from app.services.metrics import add_agent_in_metrics
-from app.services.agent_history import agent_history_client
+from ..utils import get_agent_role_from_config, run_crew_with_tracking
 from app.logs import get_logger
 from app.core.llm import llm
 from .tools import get_tools
@@ -68,7 +66,6 @@ class PraxisSearcherCrew:
             verbose=verbose
         )
 
-@track_agent(agent_role=AGENT_ROLE)
 def run_praxis_searcher(
     search_query: str,
     context: str = "",
@@ -84,15 +81,13 @@ def run_praxis_searcher(
     """
     crew = PraxisSearcherCrew().crew(verbose=verbose)
 
-    inputs = {
-        "search_query": search_query,
-        "context": context
-    }
+    crew_output = run_crew_with_tracking(
+        crew=crew,
+        agent_role=AGENT_ROLE,
+        inputs={"search_query": search_query, "context": context},
+    )
 
-    crew_output = crew.kickoff(inputs=inputs)
-    result: PraxisSearchOutput
-
-    if not isinstance(crew_output, CrewOutput):
+    if crew_output is None:
         return PraxisSearchOutput(
             text="В процессе работы была получена ошибка с типизацией",
             sources=[],
@@ -100,27 +95,14 @@ def run_praxis_searcher(
         )
 
     try:
-
-        task_output = crew_output.tasks_output[0]
-        result = task_output.pydantic # type: ignore[index]
-
+        result = crew_output.tasks_output[0].pydantic  # type: ignore[index]
     except Exception as e:
         logger.warning(f"Не удалось получить pydantic output: {e}. Используем fallback.")
-        raw_text = extract_result(crew_output)
         result = PraxisSearchOutput(
-            text=raw_text,
+            text=extract_result(crew_output),
             sources=[],
             summary="Не удалось структурировать вывод. Используйте сырой текст выше."
         )
-
-    # Сохраняем метрики и историю
-    add_agent_in_metrics(crew=crew)
-
-    agent_history_client.agent_succeed(
-        response_id=str(crew.id),
-        agent_role=AGENT_ROLE,
-        text=result.text
-    )
 
     return result
 

--- a/services/agents/app/core/crews/reporter/__init__.py
+++ b/services/agents/app/core/crews/reporter/__init__.py
@@ -1,3 +1,3 @@
-from .reporter import run_reporter
+from .reporter import run_reporter, AGENT_ROLE
 
-__all__ = ['run_reporter']
+__all__ = ['run_reporter', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/reporter/reporter.py
+++ b/services/agents/app/core/crews/reporter/reporter.py
@@ -1,15 +1,13 @@
 from pathlib import Path
 from typing import List
 from pydantic import BaseModel, Field
-from crewai import Agent, Crew, Process, Task, CrewOutput
+from crewai import Agent, Crew, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 
 from .tools import get_tools
-from ..utils import track_agent, get_agent_role_from_config
+from ..utils import get_agent_role_from_config, run_crew_with_tracking
 from app.core.memory import models_context, discussion_context
-from app.services.metrics import add_agent_in_metrics
-from app.services.agent_history import agent_history_client
 from app.logs import get_logger
 from app.core.llm import llm
 
@@ -69,65 +67,48 @@ class ReporterCrew:
             verbose=verbose
         )
 
-@track_agent(agent_role=AGENT_ROLE)
 def run_reporter(
         business_requirements: str,
         deployment_constraints: str,
         verbose: bool = False
     ) -> ReporterOut:
     """
-    Агент аналитик данных анализирует данные. И на выдаёт описание данных.
+    Агент репортер подводит итоги обучений.
 
     Args:
         business_requirements: бизнес требования
         deployment_constraints: технические требования
         verbose: логирование в консоли
-
-    * Автоматически записывает метрики использования агента, а так же
-    записывает в историю дискусии.
     """
     crew = ReporterCrew().crew(verbose=verbose)
 
-    crew_output = crew.kickoff(
+    crew_output = run_crew_with_tracking(
+        crew=crew,
+        agent_role=AGENT_ROLE,
         inputs={
             "models_id": models_context.get_models(),
             "discussion_id": discussion_context.get(),
             "business_requirements": business_requirements,
             "deployment_constraints": deployment_constraints,
-        }
+        },
     )
 
-    result: ReporterOut
-
-    if not isinstance(crew_output, CrewOutput):
+    if crew_output is None:
         return ReporterOut(
             result="Не получилось обработать результат ответа агента",
             description=""
         )
 
     try:
-
-        task_output = crew_output.tasks_output[0]
-        result = task_output.pydantic # type: ignore[index]
-
+        result = crew_output.tasks_output[0].pydantic  # type: ignore[index]
     except Exception as e:
         logger.warning(f"Не удалось получить pydantic output: {e}. Используем fallback.")
-        raw_text = extract_result(crew_output)
         result = ReporterOut(
             result="Не удалось обработать ответ агента в 'pydantic' схему",
-            description=f"{raw_text}"
+            description=extract_result(crew_output)
         )
 
-    # Сохраняем метрики и историю
-    add_agent_in_metrics(crew=crew)
-
-    agent_history_client.agent_start(
-        response_id=str(crew.id),
-        agent_role=AGENT_ROLE,
-        text=result.get_summary()  # сохраняем основной текст
-    )
-
-    logger.info(f"Аналитик датасетов отработал")
+    logger.info("Reporter отработал")
     return result
 
 

--- a/services/agents/app/core/crews/researcher/__init__.py
+++ b/services/agents/app/core/crews/researcher/__init__.py
@@ -1,3 +1,3 @@
-from .researcher import run_researcher, ResearcherOutput
+from .researcher import run_researcher, ResearcherOutput, AGENT_ROLE
 
-__all__ = ['run_researcher', 'ResearcherOutput']
+__all__ = ['run_researcher', 'ResearcherOutput', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/researcher/researcher.py
+++ b/services/agents/app/core/crews/researcher/researcher.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 from typing import List
 from pydantic import BaseModel, Field
-from crewai import Agent, Crew, Task, CrewOutput
+from crewai import Agent, Crew, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 
 from .tools import get_tools
-from ..utils import track_agent, get_agent_role_from_config
-from app.services.metrics import add_agent_in_metrics
-from app.services.agent_history import agent_history_client
+from ..utils import get_agent_role_from_config, run_crew_with_tracking
 from app.logs import get_logger
 from app.core.llm import llm
 
@@ -70,7 +68,6 @@ class ResearcherCrew:
             verbose=verbose
         )
 
-@track_agent(agent_role=AGENT_ROLE)
 def run_researcher(
     business_requirements: str,
     dataset_info: str,
@@ -79,7 +76,7 @@ def run_researcher(
 ) -> ResearcherOutput:
     """
     Запускает агента-поисковика лучших практик.
-    
+
     Args:
         business_requirements: Требования бизнеса
         dataset_info: Информация о датасете
@@ -91,17 +88,18 @@ def run_researcher(
     for denied_hypothesis in denied_hypotheses_info:
         denied_hypotheses_info_str += f"\nОтвергнутая гипотеза:\n{denied_hypothesis}"
 
-    inputs = {
-        "business_requirements": business_requirements,
-        "dataset_info": dataset_info,
-        "denied_hypotheses_info": denied_hypotheses_info_str
-    }
-
     logger.debug('Запуск ResearcherCrew')
-    crew_output = crew.kickoff(inputs=inputs)
-    result: ResearcherOutput
+    crew_output = run_crew_with_tracking(
+        crew=crew,
+        agent_role=AGENT_ROLE,
+        inputs={
+            "business_requirements": business_requirements,
+            "dataset_info": dataset_info,
+            "denied_hypotheses_info": denied_hypotheses_info_str,
+        },
+    )
 
-    if not isinstance(crew_output, CrewOutput):
+    if crew_output is None:
         return ResearcherOutput(
             analysis_summary="В процессе работы была получена ошибка с типизацией",
             hypotheses_1="",
@@ -110,30 +108,17 @@ def run_researcher(
         )
 
     try:
-
-        task_output = crew_output.tasks_output[0]
-        result = task_output.pydantic # type: ignore[index]
-
+        result = crew_output.tasks_output[0].pydantic  # type: ignore[index]
     except Exception as e:
         logger.warning(f"Не удалось получить pydantic output: {e}. Используем fallback.")
-        raw_text = extract_result(crew_output)
         result = ResearcherOutput(
-            analysis_summary=raw_text,
+            analysis_summary=extract_result(crew_output),
             hypotheses_1="",
             hypotheses_2="",
             hypotheses_3=""
         )
 
-    # Сохраняем метрики и историю
-    add_agent_in_metrics(crew=crew)
-
-    agent_history_client.agent_succeed(
-        response_id=str(crew.id),
-        agent_role=AGENT_ROLE,
-        text=result.get_full_info()
-    )
-
-    logger.info(f"Researcher завершён")
+    logger.info("Researcher завершён")
     return result
 
 def extract_result(crew_output):

--- a/services/agents/app/core/crews/utils/__init__.py
+++ b/services/agents/app/core/crews/utils/__init__.py
@@ -1,7 +1,9 @@
 from .track_agent import track_agent, get_agent_role_from_config
 from .track_tool import track_tool, get_tools_with_tracking
+from .run_crew import run_crew_with_tracking
 
 __all__ = [
-    'track_agent', 'track_tool', 
-    'get_tools_with_tracking', 'get_agent_role_from_config'
+    'track_agent', 'track_tool',
+    'get_tools_with_tracking', 'get_agent_role_from_config',
+    'run_crew_with_tracking',
 ]

--- a/services/agents/app/core/crews/utils/run_crew.py
+++ b/services/agents/app/core/crews/utils/run_crew.py
@@ -1,0 +1,58 @@
+import time
+from typing import Callable
+
+from crewai import Crew, CrewOutput
+
+from app.services.agent_history import agent_history_client
+from app.services.metrics import add_agent_in_metrics
+from app.core.memory import agent_response_context
+from app.logs import get_logger
+
+logger = get_logger(__name__)
+
+
+def run_crew_with_tracking(
+    crew: Crew,
+    agent_role: str,
+    inputs: dict,
+    get_result_text: Callable[[CrewOutput], str] = lambda o: o.raw if hasattr(o, "raw") else str(o),
+) -> CrewOutput | None:
+    """
+    Запускает crew.kickoff с полным жизненным циклом трекинга.
+    response_id = str(crew.id) — согласован с метриками.
+
+    Returns:
+        CrewOutput или None если crew.kickoff вернул не CrewOutput
+    """
+    response_id = str(crew.id)
+    agent_response_context.set(response_id)
+    start_time = time.time()
+
+    agent_history_client.agent_start(
+        response_id=response_id,
+        agent_role=agent_role,
+        text=f"Агент '{agent_role}' начал работу",
+    )
+
+    try:
+        crew_output = crew.kickoff(inputs=inputs)
+
+        if not isinstance(crew_output, CrewOutput):
+            return None
+
+        duration_ms = (time.time() - start_time) * 1000
+        add_agent_in_metrics(crew=crew)
+        agent_history_client.agent_succeed(
+            response_id=response_id,
+            agent_role=agent_role,
+            text=get_result_text(crew_output),
+            duration_ms=duration_ms,
+        )
+        return crew_output
+
+    except Exception as e:
+        agent_history_client.error(f"Агент '{agent_role}' завершился с ошибкой: {str(e)}")
+        raise
+
+    finally:
+        agent_response_context.clear()

--- a/services/agents/app/core/crews/utils/run_crew.py
+++ b/services/agents/app/core/crews/utils/run_crew.py
@@ -1,14 +1,31 @@
 import time
-from typing import Callable
+from typing import Callable, Optional
 
 from crewai import Crew, CrewOutput
 
 from app.services.agent_history import agent_history_client
 from app.services.metrics import add_agent_in_metrics
-from app.core.memory import agent_response_context
+from app.core.memory import agent_response_context, iteration_context
 from app.logs import get_logger
 
 logger = get_logger(__name__)
+
+
+def _extract_crew_meta(crew: Crew) -> tuple[Optional[str], Optional[str]]:
+    """Возвращает (model_name, task_name). Никогда не бросает исключений."""
+    model = None
+    task_name = None
+    try:
+        if crew.agents and crew.agents[0].llm:
+            model = getattr(crew.agents[0].llm, "model", None)
+    except Exception:
+        pass
+    try:
+        if crew.tasks:
+            task_name = crew.tasks[0].name
+    except Exception:
+        pass
+    return model, task_name
 
 
 def run_crew_with_tracking(
@@ -28,10 +45,16 @@ def run_crew_with_tracking(
     agent_response_context.set(response_id)
     start_time = time.time()
 
+    model, task_name = _extract_crew_meta(crew)
+    iteration = iteration_context.get()
+
     agent_history_client.agent_start(
         response_id=response_id,
         agent_role=agent_role,
         text=f"Агент '{agent_role}' начал работу",
+        model=model,
+        task_name=task_name,
+        iteration=iteration,
     )
 
     try:
@@ -47,6 +70,9 @@ def run_crew_with_tracking(
             agent_role=agent_role,
             text=get_result_text(crew_output),
             duration_ms=duration_ms,
+            model=model,
+            task_name=task_name,
+            iteration=iteration,
         )
         return crew_output
 

--- a/services/agents/app/core/memory/__init__.py
+++ b/services/agents/app/core/memory/__init__.py
@@ -41,18 +41,20 @@ class Discussion:
 
 class ModelsContext:
     def __init__(self):
-        self._models: ContextVar[List[str]] = ContextVar('models_context', default=[])
+        self._models: ContextVar[Optional[List[str]]] = ContextVar('models_context', default=None)
 
     def add_model(self, model_id: str) -> None:
         """Добавить ID модели"""
         models = self._models.get()
+        if models is None:
+            models = []
         models.append(model_id)
         self._models.set(models)
         logger.debug(f"ModelsContext: добавлен model_id={model_id}, всего: {len(models)}")
-    
+
     def get_models(self) -> List[str]:
         """Получить список всех ID моделей"""
-        return self._models.get()
+        return self._models.get() or []
     
     def clear(self) -> None:
         """Очистить контекст моделей"""

--- a/services/agents/app/core/memory/__init__.py
+++ b/services/agents/app/core/memory/__init__.py
@@ -95,6 +95,21 @@ class AgentResponseContext:
         return self._response_id.get() is not None
 
 
+class IterationContext:
+    def __init__(self):
+        self._iteration: ContextVar[Optional[int]] = ContextVar('iteration', default=None)
+
+    def set(self, iteration: int) -> None:
+        self._iteration.set(iteration)
+
+    def get(self) -> Optional[int]:
+        return self._iteration.get()
+
+    def clear(self) -> None:
+        self._iteration.set(None)
+
+
 models_context = ModelsContext()
 discussion_context = Discussion()
 agent_response_context = AgentResponseContext()
+iteration_context = IterationContext()

--- a/services/agents/app/core/pipeline/debug.py
+++ b/services/agents/app/core/pipeline/debug.py
@@ -70,7 +70,7 @@ def debugging(
             return TrainingOut(
                 is_completed_successfully=False,
                 error=f"Дебагер не может исправить: {training_res.error}"+
-                    "\n\nПояснения от дебагера: {ml_debuger_out.reason}"
+                    f"\n\nПояснения от дебагера: {ml_debuger_out.reason}"
             ), train_input.version_model
         
         logger.info("[ДЕБАГ] ✅ Агент-дебагер нашёл решение")        

--- a/services/agents/app/services/agent_history/client.py
+++ b/services/agents/app/services/agent_history/client.py
@@ -96,6 +96,9 @@ class AgentHistoryClient:
         text: str,
         status: str,
         duration_ms: Optional[float] = None,
+        model: Optional[str] = None,
+        task_name: Optional[str] = None,
+        iteration: Optional[int] = None,
     ) -> bool:
         """Добавление ответа агента в историю"""
         data: Dict[str, Any] = {
@@ -106,6 +109,12 @@ class AgentHistoryClient:
         }
         if duration_ms is not None:
             data["duration_ms"] = duration_ms
+        if model is not None:
+            data["model"] = model
+        if task_name is not None:
+            data["task_name"] = task_name
+        if iteration is not None:
+            data["iteration"] = iteration
         return self._make_discussion_request("responses", data)
 
     def agent_start(
@@ -113,8 +122,14 @@ class AgentHistoryClient:
         response_id: str,
         agent_role: str,
         text: str,
+        model: Optional[str] = None,
+        task_name: Optional[str] = None,
+        iteration: Optional[int] = None,
     ) -> bool:
-        return self._add_agent(response_id, agent_role, text, status="IN PROGRESS")
+        return self._add_agent(
+            response_id, agent_role, text, status="IN PROGRESS",
+            model=model, task_name=task_name, iteration=iteration,
+        )
 
     def agent_succeed(
         self,
@@ -122,8 +137,14 @@ class AgentHistoryClient:
         agent_role: str,
         text: str,
         duration_ms: Optional[float] = None,
+        model: Optional[str] = None,
+        task_name: Optional[str] = None,
+        iteration: Optional[int] = None,
     ) -> bool:
-        return self._add_agent(response_id, agent_role, text, status="SUCCEED", duration_ms=duration_ms)
+        return self._add_agent(
+            response_id, agent_role, text, status="SUCCEED",
+            duration_ms=duration_ms, model=model, task_name=task_name, iteration=iteration,
+        )
 
     def _add_tool(
         self,

--- a/services/agents/app/services/agent_history/client.py
+++ b/services/agents/app/services/agent_history/client.py
@@ -2,8 +2,8 @@ import requests
 from typing import Any, Dict, Optional
 
 from app.config import config_url
-from app.logs import get_logger
 from app.core.memory import discussion_context
+from app.logs import get_logger
 
 logger = get_logger(__name__)
 
@@ -14,9 +14,50 @@ class AgentHistoryClient:
     def __init__(self):
         self.base_url = config_url.AGENT_HISTORY['url']
 
+    def create_discussion(
+        self,
+        discussion_id: str,
+        pipeline: str,
+        agent_roles: list[str],
+    ) -> bool:
+        """Создать дискуссию в agent_history"""
+        url = f"{self.base_url}/discussions"
+        try:
+            response = requests.post(url, json={
+                "discussion_id": discussion_id,
+                "pipeline": pipeline,
+                "agent_roles": agent_roles,
+            })
+            if response.status_code == 201:
+                logger.debug(f"✅ Дискуссия создана discussion_id=`{discussion_id}`")
+                return True
+            logger.error(f"Ошибка создания дискуссии: {response.status_code} - {response.text}")
+            return False
+        except Exception as e:
+            logger.error(f"Непредвиденная ошибка при создании дискуссии: {e}")
+            return False
+
+    def update_discussion_meta(
+        self,
+        discussion_id: str,
+        status: str,
+    ) -> bool:
+        """Обновить метаданные дискуссии (например, статус)"""
+        url = f"{self.base_url}/discussions/{discussion_id}/meta"
+        try:
+            response = requests.patch(url, json={"status": status})
+            if response.status_code == 200:
+                logger.debug(f"✅ Статус дискуссии обновлён: {status}")
+                return True
+            logger.error(f"Ошибка обновления мета: {response.status_code} - {response.text}")
+            return False
+        except Exception as e:
+            logger.error(f"Непредвиденная ошибка при обновлении мета: {e}")
+            return False
+
     def _make_discussion_request(
-        self, 
-        endpoint: str, 
+        self,
+        endpoint: str,
         data: Dict[str, Any]
     ) -> bool:
         """
@@ -49,64 +90,40 @@ class AgentHistoryClient:
             return False
 
     def _add_agent(
-        self, 
+        self,
         response_id: str,
         agent_role: str,
         text: str,
-        status: str
+        status: str,
+        duration_ms: Optional[float] = None,
     ) -> bool:
-        """
-        Добавление ответа агента в историю
-        """
-        data = {
+        """Добавление ответа агента в историю"""
+        data: Dict[str, Any] = {
             "response_id": response_id,
             "status": status,
             "agent_role": agent_role,
-            "text": text
+            "text": text,
         }
+        if duration_ms is not None:
+            data["duration_ms"] = duration_ms
         return self._make_discussion_request("responses", data)
 
     def agent_start(
-        self, 
+        self,
         response_id: str,
         agent_role: str,
         text: str,
     ) -> bool:
-        """
-        Добавление агента при инциализации первого
-
-        Args:
-            response_id: Id ответа,
-            agent_role: Роль агента,
-            text: Текст от агента,
-        """
-        return self._add_agent(
-            response_id,
-            agent_role,
-            text,
-            status="IN PROGRESS"
-        )
+        return self._add_agent(response_id, agent_role, text, status="IN PROGRESS")
 
     def agent_succeed(
-        self, 
+        self,
         response_id: str,
         agent_role: str,
         text: str,
+        duration_ms: Optional[float] = None,
     ) -> bool:
-        """
-        Добавление результатов работы агента
-
-        Args:
-            response_id: Id ответа,
-            agent_role: Роль агента,
-            text: Текст от агента,
-        """
-        return self._add_agent(
-            response_id,
-            agent_role,
-            text,
-            status="SUCCEED"
-        )
+        return self._add_agent(response_id, agent_role, text, status="SUCCEED", duration_ms=duration_ms)
 
     def _add_tool(
         self,


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
-  **Централизация трекинга агентов**: убран дублирующий декоратор `@track_agent` из всех 8 crew-файлов. Вся логика трекинга вынесена в единую функцию `run_crew_with_tracking` (`app/core/crews/utils/run_crew.py`)
- **Единый `response_id`**: теперь `response_id` в `agent_history` и в `metrics` одинаковый: `str(crew.id)`. Ранее `@track_agent` генерировал случайный `uuid4()`, создавая расхождение между сервисами
- **Жизненный цикл дискуссий**: все эндпоинты (роутеры `analytics`, `ml_engin`, `researcher`, `searcher`, `full_pipeline`) теперь явно создают дискуссию с `pipeline` и `agent_roles` через `create_discussion`. Статус дискуссии обновляется в `completed`/`failed` по итогам пайплайна
- **Обогащение метаданных агентов**: в `AgentResponse` теперь заполняются поля `model` (имя LLM), `task_name` (название задачи из конфига CrewAI), `iteration` (номер итерации development-пайплайна через `IterationContext`)
- **Добавлен `IterationContext`**: новый `ContextVar` в `app/core/memory`, позволяет передавать номер текущей итерации обучения до любого crew без изменения сигнатур функций
- **Исправлены баги**: mutable default в `ContextVar` для `ModelsContext`, неправильный тип default для `max_iter` (`""` вместо `2`), отсутствующий `f` prefix в f-string в `debug.py`, отсутствие обработки `None` из `development_models` в роутере