### PR TITLE
Agents/refactor/change start pipeline

### DIFF
--- a/services/agents/app/api/routers/analytic.py
+++ b/services/agents/app/api/routers/analytic.py
@@ -84,3 +84,5 @@ def reporter(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
+    finally:
+        models_context.clear()

--- a/services/agents/app/api/routers/analytic.py
+++ b/services/agents/app/api/routers/analytic.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Query, HTTPException
 from app.core.crews.metrics_analyst import run_metrics_analyst, AGENT_ROLE as METRICS_ANALYST_ROLE
 from app.core.crews.dataset_analyst import run_dataset_analyst, AGENT_ROLE as DATASET_ANALYST_ROLE
 from app.core.crews.reporter import run_reporter, AGENT_ROLE as REPORTER_ROLE
-from app.core.memory import discussion_context, models_context
-from app.services.agent_history import agent_history_client
+from app.core.memory import models_context
+from app.services.agent_history import track_discussion
 
 routers = APIRouter(
     prefix='/analytics',
@@ -22,24 +22,18 @@ def analyze_datasets(
     dataset_version_id: str = Query(..., description="ID версии датасета"),
 ):
     try:
-
-        discussion_context.set(discussion_id)
-        agent_history_client.create_discussion(discussion_id, pipeline="dataset_analyst", agent_roles=[DATASET_ANALYST_ROLE])
-
-        result = run_dataset_analyst(
-            dataset_id=dataset_id,
-            dataset_version_id=dataset_version_id,
-            verbose=True
-        )
-        
+        with track_discussion(discussion_id, "dataset_analyst", "Анализ датасета", [DATASET_ANALYST_ROLE]):
+            result = run_dataset_analyst(
+                dataset_id=dataset_id,
+                dataset_version_id=dataset_version_id,
+                verbose=True
+            )
         return result
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
-    finally:
-        discussion_context.clear()
 
 
 @routers.get(
@@ -52,24 +46,18 @@ def analyze_ml_metric(
     model_id: str = Query(..., description="ID модели")
 ):
     try:
-        
-        discussion_context.set(discussion_id)
-        agent_history_client.create_discussion(discussion_id, pipeline="metrics_analyst", agent_roles=[METRICS_ANALYST_ROLE])
-
-        result = run_metrics_analyst(
-            business_goal=business_goal,
-            model_id=model_id,
-            verbose=True
-        )
-        
+        with track_discussion(discussion_id, "metrics_analyst", "Анализ метрик", [METRICS_ANALYST_ROLE]):
+            result = run_metrics_analyst(
+                business_goal=business_goal,
+                model_id=model_id,
+                verbose=True
+            )
         return result
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
-    finally:
-        discussion_context.clear()
 
 @routers.get(
         "/reporter",
@@ -82,23 +70,17 @@ def reporter(
     deployment_constraints: str = Query(..., description="Возможности прода")
 ):
     try:
-        
-        discussion_context.set(discussion_id)
-        agent_history_client.create_discussion(discussion_id, pipeline="reporter", agent_roles=[REPORTER_ROLE])
-        for model_id in models_id:
-            models_context.add_model(model_id)
-
-        result = run_reporter(
-            business_requirements=business_requirements,
-            deployment_constraints=deployment_constraints,
-            verbose=True
-        )
-        
+        with track_discussion(discussion_id, "reporter", "Итоговый отчёт", [REPORTER_ROLE]):
+            for model_id in models_id:
+                models_context.add_model(model_id)
+            result = run_reporter(
+                business_requirements=business_requirements,
+                deployment_constraints=deployment_constraints,
+                verbose=True
+            )
         return result
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
-    finally:
-        discussion_context.clear()

--- a/services/agents/app/api/routers/full_pipeline.py
+++ b/services/agents/app/api/routers/full_pipeline.py
@@ -3,8 +3,8 @@ from typing import List
 from fastapi import APIRouter, Query, HTTPException
 
 from app.core import development_models
-from app.core.memory import discussion_context, models_context
-from app.services.agent_history import agent_history_client
+from app.core.memory import models_context
+from app.services.agent_history import track_discussion
 from app.core.crews.dataset_analyst import AGENT_ROLE as DATASET_ANALYST_ROLE
 from app.core.crews.researcher import AGENT_ROLE as RESEARCHER_ROLE
 from app.core.crews.ml_engeneer import AGENT_ROLE as ML_ENGINEER_ROLE
@@ -36,27 +36,20 @@ def development(
     denied_hypotheses_info: List[str] = Query(default_factory=list, description="Гипотезы и практики, которые нужно избегать"),
     max_iter: int = Query(2, description="Количество попыток обучения")
 ):
+    discussion_id = str(uuid4())
     try:
-        discussion_id = str(uuid4())
-        discussion_context.set(discussion_id)
-
-        agent_history_client.create_discussion(
-            discussion_id=discussion_id,
-            pipeline="development",
-            agent_roles=_DEVELOPMENT_AGENT_ROLES,
-        )
-
-        result = development_models(
-            dataset_id=dataset_id,
-            dataset_version_id=version_id,
-            model_name=model_name,
-            deployment_constraints=deployment_constraints,
-            business_requirements=business_requirements,
-            denied_hypotheses_info=denied_hypotheses_info,
-            max_iter=max_iter,
-        )
-        if result is None:
-            raise HTTPException(status_code=422, detail="Пайплайн завершился без результата")
+        with track_discussion(discussion_id, "development", "Разработка модели", _DEVELOPMENT_AGENT_ROLES):
+            result = development_models(
+                dataset_id=dataset_id,
+                dataset_version_id=version_id,
+                model_name=model_name,
+                deployment_constraints=deployment_constraints,
+                business_requirements=business_requirements,
+                denied_hypotheses_info=denied_hypotheses_info,
+                max_iter=max_iter,
+            )
+            if result is None:
+                raise HTTPException(status_code=422, detail="Пайплайн завершился без результата")
         return result
 
     except HTTPException:
@@ -67,5 +60,4 @@ def development(
             detail=f"Ошибка при выполнении: {str(e)}"
         )
     finally:
-        discussion_context.clear()
         models_context.clear()

--- a/services/agents/app/api/routers/full_pipeline.py
+++ b/services/agents/app/api/routers/full_pipeline.py
@@ -1,15 +1,19 @@
 from uuid import uuid4
-from typing import List
-from fastapi import APIRouter, Query, HTTPException
+from typing import List, Optional
+from fastapi import APIRouter, Query, HTTPException, BackgroundTasks
+from pydantic import BaseModel, Field
 
 from app.core import development_models
-from app.core.memory import models_context
-from app.services.agent_history import track_discussion
+from app.core.memory import models_context, discussion_context
+from app.services.agent_history import track_discussion, agent_history_client
 from app.core.crews.dataset_analyst import AGENT_ROLE as DATASET_ANALYST_ROLE
 from app.core.crews.researcher import AGENT_ROLE as RESEARCHER_ROLE
 from app.core.crews.ml_engeneer import AGENT_ROLE as ML_ENGINEER_ROLE
 from app.core.crews.ml_debuger import AGENT_ROLE as ML_DEBUGER_ROLE
 from app.core.crews.reporter import AGENT_ROLE as REPORTER_ROLE
+from app.logs import get_logger
+
+logger = get_logger(__name__)
 
 routers = APIRouter(
     tags=['pipeline']
@@ -22,6 +26,47 @@ _DEVELOPMENT_AGENT_ROLES = [
     ML_DEBUGER_ROLE,
     REPORTER_ROLE,
 ]
+
+
+class DevelopmentRequest(BaseModel):
+    dataset_id: str = Field(..., description="ID датасета для анализа")
+    version_id: str = Field(..., description="ID версии датасета")
+    model_name: str = Field(..., description="Имя модели")
+    deployment_constraints: str = Field(..., description="Технические возможности прода")
+    business_requirements: str = Field(..., description="Описание бизнес требований")
+    denied_hypotheses_info: List[str] = Field(default_factory=list, description="Гипотезы и практики, которые нужно избегать")
+    max_iter: int = Field(2, description="Количество попыток обучения")
+    title: Optional[str] = Field(None, description="Название запуска (опционально)")
+    tags: List[str] = Field(default_factory=list, description="Теги запуска (опционально)")
+
+
+class StartResponse(BaseModel):
+    discussion_id: str = Field(..., description="ID созданной дискуссии для отслеживания прогресса")
+    status: str = Field(..., description="Статус запуска")
+
+
+def _run_development_background(discussion_id: str, req: DevelopmentRequest) -> None:
+    """Фоновое выполнение пайплайна development с финализацией статуса дискуссии."""
+    discussion_context.set(discussion_id)
+    try:
+        result = development_models(
+            dataset_id=req.dataset_id,
+            dataset_version_id=req.version_id,
+            model_name=req.model_name,
+            deployment_constraints=req.deployment_constraints,
+            business_requirements=req.business_requirements,
+            denied_hypotheses_info=req.denied_hypotheses_info,
+            max_iter=req.max_iter,
+        )
+        agent_history_client.update_discussion_meta(
+            discussion_id, "completed" if result is not None else "failed"
+        )
+    except Exception as e:
+        logger.error(f"Пайплайн development упал (discussion_id={discussion_id}): {e}")
+        agent_history_client.update_discussion_meta(discussion_id, "failed")
+    finally:
+        discussion_context.clear()
+        models_context.clear()
 
 @routers.get(
         "/development",
@@ -61,3 +106,30 @@ def development(
         )
     finally:
         models_context.clear()
+
+
+@routers.post(
+    "/development/start",
+    status_code=202,
+    response_model=StartResponse,
+    description="Асинхронный запуск полного пайплайна. Возвращает discussion_id сразу, "
+                "пайплайн выполняется в фоне. Прогресс отслеживается через agent_history."
+)
+def start_development(req: DevelopmentRequest, background_tasks: BackgroundTasks):
+    discussion_id = str(uuid4())
+    title = req.title or f"Разработка модели «{req.model_name}»"
+    # Авто-теги из параметров + пользовательские, без дублей, с сохранением порядка.
+    tags = list(dict.fromkeys([*req.tags, req.model_name, req.dataset_id]))
+
+    # Создаём дискуссию СИНХРОННО, чтобы фронт сразу мог её открыть (active),
+    # уже с осмысленными метаданными.
+    agent_history_client.create_discussion(
+        discussion_id=discussion_id,
+        pipeline="development",
+        agent_roles=_DEVELOPMENT_AGENT_ROLES,
+        title=title,
+        tags=tags,
+    )
+
+    background_tasks.add_task(_run_development_background, discussion_id, req)
+    return StartResponse(discussion_id=discussion_id, status="started")

--- a/services/agents/app/api/routers/ml_engin.py
+++ b/services/agents/app/api/routers/ml_engin.py
@@ -12,7 +12,7 @@ routers = APIRouter(
         "/ml_engineer",
         description="Рассуждения агентов ML-инженеров"
 )
-def run_etp(
+def run_ml_engineer(
     discussion_id: str = Query(description="ID дискуссии"),
     business_requirements: str = Query(description="Бизнес требования к модели"),
     deployment_constraints: str = Query(description="Технические требования к модели"),
@@ -39,7 +39,7 @@ def run_etp(
         "/ml_debug",
         description="Агент исправляет ошибку в конфиге запуска обучения мл моделей"
 )
-def run_ed(
+def run_ml_debugger(
     discussion_id: str = Query(description="ID дискуссии"),
     error: str = Query(description="Ошибка полученная при обучении"),
     config: str = Query(description="Конфигурации обучения")

--- a/services/agents/app/api/routers/ml_engin.py
+++ b/services/agents/app/api/routers/ml_engin.py
@@ -2,8 +2,7 @@ from fastapi import APIRouter, Query, HTTPException
 
 from app.core.crews.ml_engeneer import run_ml_engineering, AGENT_ROLE as ML_ENGINEER_ROLE
 from app.core.crews.ml_debuger import run_ml_debug, AGENT_ROLE as ML_DEBUGER_ROLE
-from app.core.memory import discussion_context
-from app.services.agent_history import agent_history_client
+from app.services.agent_history import track_discussion
 
 routers = APIRouter(
     tags=['engineering']
@@ -21,26 +20,20 @@ def run_etp(
     researcher_proposals: str = Query(description="Рекомендации от исследователя")
 ):
     try:
-        
-        discussion_context.set(discussion_id)
-        agent_history_client.create_discussion(discussion_id, pipeline="ml_engineer", agent_roles=[ML_ENGINEER_ROLE])
-
-        result = run_ml_engineering(
-            dataset_info=dataset_info,
-            business_requirements=business_requirements,
-            deployment_constraints=deployment_constraints,
-            researcher_proposals=researcher_proposals,
-            verbose=True
-        )
-
+        with track_discussion(discussion_id, "ml_engineer", "Подбор конфигурации обучения", [ML_ENGINEER_ROLE]):
+            result = run_ml_engineering(
+                dataset_info=dataset_info,
+                business_requirements=business_requirements,
+                deployment_constraints=deployment_constraints,
+                researcher_proposals=researcher_proposals,
+                verbose=True
+            )
         return result
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
-    finally:
-        discussion_context.clear()
 
 @routers.get(
         "/ml_debug",
@@ -52,21 +45,15 @@ def run_ed(
     config: str = Query(description="Конфигурации обучения")
 ):
     try:
-    
-        discussion_context.set(discussion_id)
-        agent_history_client.create_discussion(discussion_id, pipeline="ml_debuger", agent_roles=[ML_DEBUGER_ROLE])
-
-        result = run_ml_debug(
-            error=error,
-            config=config,
-            verbose=True
-        )
-
+        with track_discussion(discussion_id, "ml_debuger", "Отладка обучения", [ML_DEBUGER_ROLE]):
+            result = run_ml_debug(
+                error=error,
+                config=config,
+                verbose=True
+            )
         return result
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
-    finally:
-        discussion_context.clear()

--- a/services/agents/app/api/routers/researcher.py
+++ b/services/agents/app/api/routers/researcher.py
@@ -2,8 +2,7 @@ from typing import List
 from fastapi import APIRouter, Query, HTTPException
 
 from app.core.crews.researcher import run_researcher, ResearcherOutput, AGENT_ROLE as RESEARCHER_ROLE
-from app.core.memory import discussion_context
-from app.services.agent_history import agent_history_client
+from app.services.agent_history import track_discussion
 
 routers = APIRouter(
     prefix='/research',
@@ -22,22 +21,16 @@ def praxis_in_internet(
     denied_hypotheses_info: List[str] = Query(description="Гипотезы отклонённые ML инженером с обоснованием"),
 ):
     try:
-
-        discussion_context.set(discussion_id)
-        agent_history_client.create_discussion(discussion_id, pipeline="researcher", agent_roles=[RESEARCHER_ROLE])
-
-        result = run_researcher(
-            business_requirements=business_requirements,
-            dataset_info=dataset_info,
-            denied_hypotheses_info=denied_hypotheses_info,
-            verbose=True
-        )
-        
+        with track_discussion(discussion_id, "researcher", "Генерация гипотез", [RESEARCHER_ROLE]):
+            result = run_researcher(
+                business_requirements=business_requirements,
+                dataset_info=dataset_info,
+                denied_hypotheses_info=denied_hypotheses_info,
+                verbose=True
+            )
         return result
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
-    finally:
-        discussion_context.clear()

--- a/services/agents/app/api/routers/researcher.py
+++ b/services/agents/app/api/routers/researcher.py
@@ -14,11 +14,11 @@ routers = APIRouter(
     description="Создание гипотез",
     response_model=ResearcherOutput
 )
-def praxis_in_internet(
+def create_hypotheses(
     discussion_id: str = Query(..., description="ID диалога"),
     business_requirements: str = Query(..., description="Требования бизнеса"),
     dataset_info: str = Query(..., description="Информация о датасете"),
-    denied_hypotheses_info: List[str] = Query(description="Гипотезы отклонённые ML инженером с обоснованием"),
+    denied_hypotheses_info: List[str] = Query(default_factory=list, description="Гипотезы отклонённые ML инженером с обоснованием"),
 ):
     try:
         with track_discussion(discussion_id, "researcher", "Генерация гипотез", [RESEARCHER_ROLE]):

--- a/services/agents/app/api/routers/searcher.py
+++ b/services/agents/app/api/routers/searcher.py
@@ -3,8 +3,7 @@ from fastapi import APIRouter, Query, HTTPException
 
 from app.core.crews.praxis_searcher import run_praxis_searcher, PraxisSearchOutput, AGENT_ROLE as PRAXIS_SEARCHER_ROLE
 from app.core.crews.ml_models_searcher import run_ml_models_searcher, MLModelsSearcherOutput, AGENT_ROLE as ML_MODELS_SEARCHER_ROLE
-from app.core.memory import discussion_context
-from app.services.agent_history import agent_history_client
+from app.services.agent_history import track_discussion
 
 routers = APIRouter(
     prefix='/searcher',
@@ -22,24 +21,18 @@ def praxis_in_internet(
     context: str = Query(..., description="Контекст поиска"),
 ):
     try:
-
-        discussion_context.set(discussion_id)
-        agent_history_client.create_discussion(discussion_id, pipeline="praxis_searcher", agent_roles=[PRAXIS_SEARCHER_ROLE])
-
-        result = run_praxis_searcher(
-            search_query=search_query,
-            context=context,
-            verbose=True
-        )
-        
+        with track_discussion(discussion_id, "praxis_searcher", "Поиск практик", [PRAXIS_SEARCHER_ROLE]):
+            result = run_praxis_searcher(
+                search_query=search_query,
+                context=context,
+                verbose=True
+            )
         return result
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
-    finally:
-        discussion_context.clear()
 
 @routers.get(
     "/info_ml_models",
@@ -52,21 +45,15 @@ def get_info_ml_models(
     context: str = Query(..., description="Контекст"),
 ):
     try:
-
-        discussion_context.set(discussion_id)
-        agent_history_client.create_discussion(discussion_id, pipeline="ml_models_searcher", agent_roles=[ML_MODELS_SEARCHER_ROLE])
-
-        result = run_ml_models_searcher(
-            model_ids=model_ids,
-            context=context,
-            verbose=True
-        )
-        
+        with track_discussion(discussion_id, "ml_models_searcher", "Поиск ML моделей", [ML_MODELS_SEARCHER_ROLE]):
+            result = run_ml_models_searcher(
+                model_ids=model_ids,
+                context=context,
+                verbose=True
+            )
         return result
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=f"Ошибка при выполнении: {str(e)}"
         )
-    finally:
-        discussion_context.clear()

--- a/services/agents/app/core/__init__.py
+++ b/services/agents/app/core/__init__.py
@@ -3,8 +3,7 @@ from typing import List
 from app.logs import get_logger
 from app.core.crews.dataset_analyst import run_dataset_analyst
 from app.core.crews.reporter import run_reporter
-from app.core.memory import discussion_context, iteration_context
-from app.services.agent_history import agent_history_client
+from app.core.memory import iteration_context
 from .pipeline import (
     train_and_debug, reasoning,
     TrainingInput
@@ -44,7 +43,6 @@ def development_models(
     )
     if not dataset_analyst_out.readiness_assessment:
         logger.info("🟥 Анализ датасета показал, что данные не готовы к обучению")
-        agent_history_client.update_discussion_meta(discussion_context.get(), status="failed")
         return None
 
     logger.info("✅ Анализ датасета")
@@ -73,7 +71,6 @@ def development_models(
         if not ml_engin_out.decision:
             logger.info("🟥 МЛ инженер и исследователь не смогли придти к общему мнению.")
             logger.warning("🟥 Обучение остановлено")
-            agent_history_client.update_discussion_meta(discussion_context.get(), status="failed")
             return None
         logger.info("✅ Конец рассуждений.")
 
@@ -124,6 +121,5 @@ def development_models(
     )
 
     iteration_context.clear()
-    agent_history_client.update_discussion_meta(discussion_context.get(), status="completed")
     return result
 

--- a/services/agents/app/core/crews/utils/run_crew.py
+++ b/services/agents/app/core/crews/utils/run_crew.py
@@ -77,7 +77,16 @@ def run_crew_with_tracking(
         return crew_output
 
     except Exception as e:
-        agent_history_client.error(f"Агент '{agent_role}' завершился с ошибкой: {str(e)}")
+        duration_ms = (time.time() - start_time) * 1000
+        agent_history_client.agent_error(
+            response_id=response_id,
+            agent_role=agent_role,
+            text=f"Агент '{agent_role}' завершился с ошибкой: {str(e)}",
+            duration_ms=duration_ms,
+            model=model,
+            task_name=task_name,
+            iteration=iteration,
+        )
         raise
 
     finally:

--- a/services/agents/app/core/crews/utils/track_agent.py
+++ b/services/agents/app/core/crews/utils/track_agent.py
@@ -51,7 +51,11 @@ def track_agent(agent_role: str):
 
             except Exception as e:
                 error_msg = f"Агент '{agent_role}' завершился с ошибкой: {str(e)}"
-                agent_history_client.error(error_msg)
+                agent_history_client.agent_error(
+                    response_id=response_id,
+                    agent_role=agent_role,
+                    text=error_msg,
+                )
                 logger.error(f"❌ {error_msg}")
                 raise
 

--- a/services/agents/app/core/crews/utils/track_tool.py
+++ b/services/agents/app/core/crews/utils/track_tool.py
@@ -30,7 +30,7 @@ def track_tool(agent_role: str, tool: BaseTool) -> BaseTool:
         try:
             result = original_run(*args, **kwargs)
             duration_ms = (time.time() - start_time) * 1000
-            agent_history_client.tool_succed(
+            agent_history_client.tool_succeeded(
                 id=id_tool,
                 agent_role=agent_role,
                 name=tool.name,

--- a/services/agents/app/services/agent_history/__init__.py
+++ b/services/agents/app/services/agent_history/__init__.py
@@ -1,7 +1,9 @@
 from .tools import GetAgentHistoryTool
 from .client import agent_history_client
+from .lifecycle import track_discussion
 
 __all__ = [
     'agent_history_client',
-    'GetAgentHistoryTool'
+    'GetAgentHistoryTool',
+    'track_discussion',
 ]

--- a/services/agents/app/services/agent_history/client.py
+++ b/services/agents/app/services/agent_history/client.py
@@ -19,15 +19,19 @@ class AgentHistoryClient:
         discussion_id: str,
         pipeline: str,
         agent_roles: list[str],
+        title: Optional[str] = None,
     ) -> bool:
         """Создать дискуссию в agent_history"""
         url = f"{self.base_url}/discussions"
+        data: Dict[str, Any] = {
+            "discussion_id": discussion_id,
+            "pipeline": pipeline,
+            "agent_roles": agent_roles,
+        }
+        if title is not None:
+            data["title"] = title
         try:
-            response = requests.post(url, json={
-                "discussion_id": discussion_id,
-                "pipeline": pipeline,
-                "agent_roles": agent_roles,
-            })
+            response = requests.post(url, json=data)
             if response.status_code == 201:
                 logger.debug(f"✅ Дискуссия создана discussion_id=`{discussion_id}`")
                 return True

--- a/services/agents/app/services/agent_history/client.py
+++ b/services/agents/app/services/agent_history/client.py
@@ -146,6 +146,22 @@ class AgentHistoryClient:
             duration_ms=duration_ms, model=model, task_name=task_name, iteration=iteration,
         )
 
+    def agent_error(
+        self,
+        response_id: str,
+        agent_role: str,
+        text: str,
+        duration_ms: Optional[float] = None,
+        model: Optional[str] = None,
+        task_name: Optional[str] = None,
+        iteration: Optional[int] = None,
+    ) -> bool:
+        """Отметить ответ агента как завершившийся с ошибкой (перезаписывает IN PROGRESS)."""
+        return self._add_agent(
+            response_id, agent_role, text, status="ERROR",
+            duration_ms=duration_ms, model=model, task_name=task_name, iteration=iteration,
+        )
+
     def _add_tool(
         self,
         id: str,

--- a/services/agents/app/services/agent_history/client.py
+++ b/services/agents/app/services/agent_history/client.py
@@ -205,7 +205,7 @@ class AgentHistoryClient:
             response_id=response_id,
         )
 
-    def tool_succed(
+    def tool_succeeded(
         self,
         id: str,
         agent_role: str,

--- a/services/agents/app/services/agent_history/client.py
+++ b/services/agents/app/services/agent_history/client.py
@@ -20,6 +20,7 @@ class AgentHistoryClient:
         pipeline: str,
         agent_roles: list[str],
         title: Optional[str] = None,
+        tags: Optional[list[str]] = None,
     ) -> bool:
         """Создать дискуссию в agent_history"""
         url = f"{self.base_url}/discussions"
@@ -30,6 +31,8 @@ class AgentHistoryClient:
         }
         if title is not None:
             data["title"] = title
+        if tags is not None:
+            data["tags"] = tags
         try:
             response = requests.post(url, json=data)
             if response.status_code == 201:

--- a/services/agents/app/services/agent_history/lifecycle.py
+++ b/services/agents/app/services/agent_history/lifecycle.py
@@ -1,0 +1,39 @@
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+from app.core.memory import discussion_context
+from app.logs import get_logger
+from .client import agent_history_client
+
+logger = get_logger(__name__)
+
+
+@contextmanager
+def track_discussion(
+    discussion_id: str,
+    pipeline: str,
+    title: Optional[str],
+    agent_roles: list[str],
+) -> Iterator[None]:
+    """
+    Жизненный цикл дискуссии в истории агентов.
+
+    Создаёт дискуссию, выставляет discussion_id в контекст и гарантированно
+    финализирует статус: `completed` при штатном завершении блока, `failed` при
+    исключении. Ошибки самого agent_history не роняют пайплайн (клиент их глотает).
+    """
+    discussion_context.set(discussion_id)
+    try:
+        agent_history_client.create_discussion(
+            discussion_id=discussion_id,
+            pipeline=pipeline,
+            agent_roles=agent_roles,
+            title=title,
+        )
+        yield
+        agent_history_client.update_discussion_meta(discussion_id, "completed")
+    except Exception:
+        agent_history_client.update_discussion_meta(discussion_id, "failed")
+        raise
+    finally:
+        discussion_context.clear()


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
- Добавлен асинхронный запуск пайплайна `development` - `POST /development/start` сразу создаёт дискуссию с метаданными (title из формы или автозаголовок, теги = пользовательские + model_name/dataset_id), запускает пайплайн в фоне и мгновенно возвращает `discussion_id` (202)
- Введён контекст-менеджер `track_discussion` — дискуссия гарантированно финализирует статус (`completed`/`failed`), раньше простые пайплайны навсегда оставались `active`
- Упавший агент теперь записывается как `AgentResponse` со статусом `ERROR` (раньше зависал `IN PROGRESS`)
- Дискуссии создаются с заголовком (`title`) и тегами (`tags`)
- Поддержка `tags` в `create_discussion` клиента истории
- Чистка endpoints: `create_hypotheses` вместо `praxis_in_internet`, осмысленные `run_ml_engineer`/`run_ml_debugger`, `denied_hypotheses_info` сделан опциональным
- Исправлена утечка `models_context` в `reporter` (очистка между запросами)
- Исправлена опечатка `tool_succed` → `tool_succeeded`
