### PR TITLE
Frontend/feat/start workflow

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,3 @@
 VITE_DMS=localhost:6500
 VITE_AGENT_HISTORY=localhost:6410
+VITE_AGENTS=localhost:6400

--- a/frontend/src/components/agents/DiscussionDetail.tsx
+++ b/frontend/src/components/agents/DiscussionDetail.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { agentHistoryService } from '../../services/agentHistoryService';
+import type { DiscussionMeta } from '../../types/agentHistory';
+import { useNotification } from '../../contexts/NotificationContext';
+import DiscussionInfo from './DiscussionInfo';
+import DiscussionView from './DiscussionView';
+
+interface Props {
+  discussionId: string;
+  onBack: () => void;
+}
+
+// Интервал опроса прогресса активной дискуссии.
+const POLL_INTERVAL_MS = 3000;
+
+// Детальный просмотр дискуссии. Сам грузит meta и, пока дискуссия активна,
+// периодически опрашивает её статус (а DiscussionView — ленту сообщений),
+// чтобы показывать прогресс пайплайна в реальном времени.
+const DiscussionDetail: React.FC<Props> = ({ discussionId, onBack }) => {
+  const { showNotification } = useNotification();
+  const [meta, setMeta] = useState<DiscussionMeta | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const poll = async () => {
+      try {
+        const data = await agentHistoryService.getDiscussionMeta(discussionId);
+        if (cancelled) return;
+        setMeta(data);
+        // Продолжаем опрос только пока дискуссия активна.
+        if (data.status === 'active') {
+          timer = setTimeout(poll, POLL_INTERVAL_MS);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        showNotification(
+          err instanceof Error ? err.message : 'Ошибка загрузки дискуссии',
+          'error',
+        );
+      }
+    };
+
+    poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [discussionId, showNotification]);
+
+  const isActive = meta?.status === 'active';
+
+  return (
+    <div className="discussion-detail">
+      <button className="button secondary small back-button" onClick={onBack}>
+        <i className="fas fa-arrow-left"></i> Назад к списку
+      </button>
+      <DiscussionInfo discussion={meta} discussionId={discussionId} />
+      <DiscussionView discussionId={discussionId} active={isActive} />
+    </div>
+  );
+};
+
+export default DiscussionDetail;

--- a/frontend/src/components/agents/DiscussionHistory.tsx
+++ b/frontend/src/components/agents/DiscussionHistory.tsx
@@ -5,8 +5,7 @@ import type { DiscussionMeta } from '../../types/agentHistory';
 import { useNotification } from '../../contexts/NotificationContext';
 import ConfirmModal from '../common/ConfirmModal';
 import DiscussionCard from './DiscussionCard';
-import DiscussionInfo from './DiscussionInfo';
-import DiscussionView from './DiscussionView';
+import DiscussionDetail from './DiscussionDetail';
 
 const DiscussionHistory: React.FC = () => {
   const { showNotification } = useNotification();
@@ -64,21 +63,9 @@ const DiscussionHistory: React.FC = () => {
     }
   };
 
-  const selected = selectedId
-    ? discussions.find(d => d.discussion_id === selectedId)
-    : null;
-
   // ── Детальный просмотр выбранной дискуссии ──────────────────────────────────
   if (selectedId) {
-    return (
-      <div className="discussion-detail">
-        <button className="button secondary small back-button" onClick={() => navigate(-1)}>
-          <i className="fas fa-arrow-left"></i> Назад к списку
-        </button>
-        <DiscussionInfo discussion={selected ?? null} discussionId={selectedId} />
-        <DiscussionView discussionId={selectedId} />
-      </div>
-    );
+    return <DiscussionDetail discussionId={selectedId} onBack={() => navigate(-1)} />;
   }
 
   // ── Список дискуссий ────────────────────────────────────────────────────────

--- a/frontend/src/components/agents/DiscussionView.tsx
+++ b/frontend/src/components/agents/DiscussionView.tsx
@@ -7,6 +7,8 @@ import MessageBubble from './MessageBubble';
 
 interface Props {
   discussionId: string;
+  // Если дискуссия активна — лента периодически обновляется (polling прогресса).
+  active?: boolean;
 }
 
 // Элемент единой ленты: ответ агента или системное сообщение.
@@ -21,19 +23,25 @@ const SYSTEM_ICONS: Record<SystemMessageType, string> = {
   ERROR: 'fa-circle-exclamation',
 };
 
-const DiscussionView: React.FC<Props> = ({ discussionId }) => {
+const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
   const { showNotification } = useNotification();
   const [feed, setFeed] = useState<FeedItem[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // Спиннер показываем только при первой загрузке, фоновые рефетчи — тихо.
+    let firstLoad = true;
+
     const fetchFeed = async () => {
       try {
-        setLoading(true);
+        if (firstLoad) setLoading(true);
         const [responses, systemMessages] = await Promise.all([
           agentHistoryService.getResponses(discussionId),
           agentHistoryService.getSystemMessages(discussionId),
         ]);
+        if (cancelled) return;
 
         const items: FeedItem[] = [
           ...responses.map((data): FeedItem => ({ kind: 'response', timestamp: data.timestamp, data })),
@@ -42,13 +50,21 @@ const DiscussionView: React.FC<Props> = ({ discussionId }) => {
         items.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
         setFeed(items);
       } catch (err) {
+        if (cancelled) return;
         showNotification(err instanceof Error ? err.message : 'Ошибка загрузки диалога', 'error');
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
+        firstLoad = false;
+        // Пока дискуссия активна — продолжаем опрашивать ленту.
+        if (!cancelled && active) timer = setTimeout(fetchFeed, 3000);
       }
     };
     fetchFeed();
-  }, [discussionId, showNotification]);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [discussionId, active, showNotification]);
 
   if (loading) {
     return <div className="loading">Загрузка диалога...</div>;

--- a/frontend/src/components/agents/RunPipelineForm.tsx
+++ b/frontend/src/components/agents/RunPipelineForm.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { datasetService } from '../../services/datasetService';
+import { agentsService } from '../../services/agentsService';
+import type { Dataset } from '../../types/dataset';
+import { useNotification } from '../../contexts/NotificationContext';
+
+interface Props {
+  // Вызывается после успешного старта пайплайна с id созданной дискуссии.
+  onStarted: (discussionId: string) => void;
+}
+
+// Разбить строку с тегами по запятой: trim, без пустых.
+const parseTags = (raw: string): string[] =>
+  raw.split(',').map(t => t.trim()).filter(Boolean);
+
+// Разбить многострочный текст по строкам: trim, без пустых.
+const parseLines = (raw: string): string[] =>
+  raw.split('\n').map(t => t.trim()).filter(Boolean);
+
+const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
+  const { showNotification } = useNotification();
+
+  // Датасеты грузим один раз — для резолва имя→id и подсказок.
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+
+  // Поля формы.
+  const [datasetName, setDatasetName] = useState('');
+  const [versionName, setVersionName] = useState('');
+  const [modelName, setModelName] = useState('');
+  const [businessRequirements, setBusinessRequirements] = useState('');
+  const [deploymentConstraints, setDeploymentConstraints] = useState('');
+  const [title, setTitle] = useState('');
+  const [tags, setTags] = useState('');
+  const [deniedHypotheses, setDeniedHypotheses] = useState('');
+  const [maxIter, setMaxIter] = useState(2);
+
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fetchDatasets = async () => {
+      try {
+        const data = await datasetService.getDatasets();
+        setDatasets(data);
+      } catch (err) {
+        showNotification(
+          err instanceof Error ? err.message : 'Ошибка загрузки датасетов',
+          'error',
+        );
+      }
+    };
+    fetchDatasets();
+  }, [showNotification]);
+
+  // Датасет, совпавший по имени с введённым (для подсказок версий).
+  const matchedDataset = useMemo(
+    () => datasets.find(d => d.name.trim() === datasetName.trim()) ?? null,
+    [datasets, datasetName],
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+
+    // Резолв имя→id датасета и версии.
+    const dataset = datasets.find(d => d.name.trim() === datasetName.trim());
+    if (!dataset) {
+      showNotification(`Датасет «${datasetName}» не найден`, 'error');
+      return;
+    }
+    const version = dataset.versions.find(v => v.name.trim() === versionName.trim());
+    if (!version) {
+      showNotification(`Версия «${versionName}» не найдена в датасете «${dataset.name}»`, 'error');
+      return;
+    }
+
+    // Валидация обязательных текстовых полей.
+    if (!modelName.trim()) {
+      showNotification('Укажите имя модели', 'error');
+      return;
+    }
+    if (!businessRequirements.trim()) {
+      showNotification('Укажите бизнес-требования', 'error');
+      return;
+    }
+    if (!deploymentConstraints.trim()) {
+      showNotification('Укажите ограничения прода', 'error');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await agentsService.startDevelopment({
+        dataset_id: dataset.id,
+        version_id: version.id,
+        model_name: modelName.trim(),
+        business_requirements: businessRequirements.trim(),
+        deployment_constraints: deploymentConstraints.trim(),
+        denied_hypotheses_info: parseLines(deniedHypotheses),
+        max_iter: maxIter,
+        title: title.trim() || undefined,
+        tags: parseTags(tags),
+      });
+      showNotification('Пайплайн запущен', 'success');
+      onStarted(result.discussion_id);
+    } catch (err) {
+      showNotification(
+        err instanceof Error ? err.message : 'Не удалось запустить пайплайн',
+        'error',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="run-pipeline-form" onSubmit={handleSubmit}>
+      <h2>Запуск пайплайна разработки</h2>
+
+      <div className="form-section">
+        <h3>Данные</h3>
+        <div className="form-grid">
+          <div className="form-field">
+            <label htmlFor="run-dataset">Имя датасета <span className="required-star">*</span></label>
+            <input
+              id="run-dataset"
+              type="text"
+              list="run-datasets-list"
+              placeholder="например: CIFAR-10"
+              value={datasetName}
+              onChange={(e) => { setDatasetName(e.target.value); setVersionName(''); }}
+              disabled={submitting}
+            />
+            <datalist id="run-datasets-list">
+              {datasets.map(d => <option key={d.id} value={d.name} />)}
+            </datalist>
+          </div>
+          <div className="form-field">
+            <label htmlFor="run-version">Имя версии <span className="required-star">*</span></label>
+            <input
+              id="run-version"
+              type="text"
+              list="run-versions-list"
+              placeholder="например: v1.0"
+              value={versionName}
+              onChange={(e) => setVersionName(e.target.value)}
+              disabled={submitting}
+            />
+            <datalist id="run-versions-list">
+              {matchedDataset?.versions.map(v => <option key={v.id} value={v.name} />)}
+            </datalist>
+          </div>
+        </div>
+      </div>
+
+      <div className="form-section">
+        <h3>Параметры модели</h3>
+        <div className="form-grid">
+          <div className="form-field">
+            <label htmlFor="run-model">Имя модели <span className="required-star">*</span></label>
+            <input
+              id="run-model"
+              type="text"
+              placeholder="например: resnet50"
+              value={modelName}
+              onChange={(e) => setModelName(e.target.value)}
+              disabled={submitting}
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="run-max-iter">Попыток обучения</label>
+            <input
+              id="run-max-iter"
+              type="number"
+              min={1}
+              value={maxIter}
+              onChange={(e) => setMaxIter(Math.max(1, Number(e.target.value) || 1))}
+              disabled={submitting}
+            />
+          </div>
+          <div className="form-field full-width">
+            <label htmlFor="run-business">Бизнес-требования <span className="required-star">*</span></label>
+            <textarea
+              id="run-business"
+              placeholder="Что нужно бизнесу от модели"
+              value={businessRequirements}
+              onChange={(e) => setBusinessRequirements(e.target.value)}
+              rows={3}
+              disabled={submitting}
+            />
+          </div>
+          <div className="form-field full-width">
+            <label htmlFor="run-deployment">Ограничения прода <span className="required-star">*</span></label>
+            <textarea
+              id="run-deployment"
+              placeholder="Технические ограничения, например: только CPU, ≤100 МБ"
+              value={deploymentConstraints}
+              onChange={(e) => setDeploymentConstraints(e.target.value)}
+              rows={3}
+              disabled={submitting}
+            />
+          </div>
+          <div className="form-field full-width">
+            <label htmlFor="run-denied">Запрещённые гипотезы и практики</label>
+            <textarea
+              id="run-denied"
+              placeholder="По одной на строку (необязательно)"
+              value={deniedHypotheses}
+              onChange={(e) => setDeniedHypotheses(e.target.value)}
+              rows={2}
+              disabled={submitting}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="form-section">
+        <h3>Оформление запуска</h3>
+        <div className="form-grid">
+          <div className="form-field">
+            <label htmlFor="run-title">Название запуска</label>
+            <input
+              id="run-title"
+              type="text"
+              placeholder="Необязательно — иначе сгенерируется автоматически"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              disabled={submitting}
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="run-tags">Теги</label>
+            <input
+              id="run-tags"
+              type="text"
+              placeholder="через запятую"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              disabled={submitting}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="run-pipeline-actions">
+        <button type="submit" className="button" disabled={submitting}>
+          {submitting ? (
+            <><i className="fas fa-spinner fa-spin"></i> Запуск...</>
+          ) : (
+            <><i className="fas fa-play"></i> Запустить</>
+          )}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default RunPipelineForm;

--- a/frontend/src/components/agents/RunPipelineForm.tsx
+++ b/frontend/src/components/agents/RunPipelineForm.tsx
@@ -9,13 +9,9 @@ interface Props {
   onStarted: (discussionId: string) => void;
 }
 
-// Разбить строку с тегами по запятой: trim, без пустых.
-const parseTags = (raw: string): string[] =>
-  raw.split(',').map(t => t.trim()).filter(Boolean);
-
-// Разбить многострочный текст по строкам: trim, без пустых.
-const parseLines = (raw: string): string[] =>
-  raw.split('\n').map(t => t.trim()).filter(Boolean);
+// Заглушка предустановленных тегов. Позже будем подтягивать жёстко заданные
+// теги из сервиса истории агентов вместо этого хардкода.
+const SUGGESTED_TAGS = ['эксперимент', 'baseline', 'продакшн-кандидат', 'быстрый прогон'];
 
 const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
   const { showNotification } = useNotification();
@@ -30,11 +26,37 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
   const [businessRequirements, setBusinessRequirements] = useState('');
   const [deploymentConstraints, setDeploymentConstraints] = useState('');
   const [title, setTitle] = useState('');
-  const [tags, setTags] = useState('');
-  const [deniedHypotheses, setDeniedHypotheses] = useState('');
+  // Теги добавляются по одному в список.
+  const [tagList, setTagList] = useState<string[]>([]);
+  const [tagDraft, setTagDraft] = useState('');
+  // Запрещённые гипотезы добавляются по одной в список.
+  const [deniedList, setDeniedList] = useState<string[]>([]);
+  const [deniedDraft, setDeniedDraft] = useState('');
   const [maxIter, setMaxIter] = useState(2);
 
   const [submitting, setSubmitting] = useState(false);
+
+  // Добавить тег (из черновика или переданный из предложенных), без дублей.
+  const addTag = (raw?: string) => {
+    const value = (raw ?? tagDraft).trim();
+    if (!value) return;
+    setTagList(prev => (prev.includes(value) ? prev : [...prev, value]));
+    setTagDraft('');
+  };
+  const removeTag = (index: number) => {
+    setTagList(prev => prev.filter((_, i) => i !== index));
+  };
+
+  // Добавить запрещённую гипотезу из черновика в список (без дублей).
+  const addDenied = () => {
+    const value = deniedDraft.trim();
+    if (!value) return;
+    setDeniedList(prev => (prev.includes(value) ? prev : [...prev, value]));
+    setDeniedDraft('');
+  };
+  const removeDenied = (index: number) => {
+    setDeniedList(prev => prev.filter((_, i) => i !== index));
+  };
 
   useEffect(() => {
     const fetchDatasets = async () => {
@@ -95,10 +117,10 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
         model_name: modelName.trim(),
         business_requirements: businessRequirements.trim(),
         deployment_constraints: deploymentConstraints.trim(),
-        denied_hypotheses_info: parseLines(deniedHypotheses),
+        denied_hypotheses_info: deniedList,
         max_iter: maxIter,
         title: title.trim() || undefined,
-        tags: parseTags(tags),
+        tags: tagList,
       });
       showNotification('Пайплайн запущен', 'success');
       onStarted(result.discussion_id);
@@ -117,7 +139,10 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
       <h2>Запуск пайплайна разработки</h2>
 
       <div className="form-section">
-        <h3>Данные</h3>
+        <div className="form-section-head">
+          <h3><i className="fas fa-database"></i> Данные и модель</h3>
+          <p className="form-section-hint">Что обучаем и на каких данных.</p>
+        </div>
         <div className="form-grid">
           <div className="form-field">
             <label htmlFor="run-dataset">Имя датасета <span className="required-star">*</span></label>
@@ -149,22 +174,17 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
               {matchedDataset?.versions.map(v => <option key={v.id} value={v.name} />)}
             </datalist>
           </div>
-        </div>
-      </div>
-
-      <div className="form-section">
-        <h3>Параметры модели</h3>
-        <div className="form-grid">
           <div className="form-field">
             <label htmlFor="run-model">Имя модели <span className="required-star">*</span></label>
             <input
               id="run-model"
               type="text"
-              placeholder="например: resnet50"
+              placeholder="придумайте сами, например: my-model"
               value={modelName}
               onChange={(e) => setModelName(e.target.value)}
               disabled={submitting}
             />
+            <span className="field-hint">Произвольное имя — под ним сохранится обученная модель.</span>
           </div>
           <div className="form-field">
             <label htmlFor="run-max-iter">Попыток обучения</label>
@@ -177,6 +197,15 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
               disabled={submitting}
             />
           </div>
+        </div>
+      </div>
+
+      <div className="form-section">
+        <div className="form-section-head">
+          <h3><i className="fas fa-circle-info"></i> Контекст для агентов</h3>
+          <p className="form-section-hint">Эту информацию агенты используют при подборе решения.</p>
+        </div>
+        <div className="form-grid">
           <div className="form-field full-width">
             <label htmlFor="run-business">Бизнес-требования <span className="required-star">*</span></label>
             <textarea
@@ -201,20 +230,55 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
           </div>
           <div className="form-field full-width">
             <label htmlFor="run-denied">Запрещённые гипотезы и практики</label>
-            <textarea
-              id="run-denied"
-              placeholder="По одной на строку (необязательно)"
-              value={deniedHypotheses}
-              onChange={(e) => setDeniedHypotheses(e.target.value)}
-              rows={2}
-              disabled={submitting}
-            />
+            <div className="denied-input-row">
+              <input
+                id="run-denied"
+                type="text"
+                placeholder="Например: не использовать аугментацию поворотом"
+                value={deniedDraft}
+                onChange={(e) => setDeniedDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { e.preventDefault(); addDenied(); }
+                }}
+                disabled={submitting}
+              />
+              <button
+                type="button"
+                className="button secondary small"
+                onClick={addDenied}
+                disabled={submitting || !deniedDraft.trim()}
+              >
+                <i className="fas fa-plus"></i> Добавить
+              </button>
+            </div>
+            {deniedList.length > 0 && (
+              <ul className="denied-list">
+                {deniedList.map((item, index) => (
+                  <li key={item} className="denied-item">
+                    <span className="denied-item-text">{item}</span>
+                    <button
+                      type="button"
+                      className="denied-item-remove"
+                      onClick={() => removeDenied(index)}
+                      disabled={submitting}
+                      aria-label="Удалить"
+                      title="Удалить"
+                    >
+                      <i className="fas fa-xmark"></i>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
       </div>
 
       <div className="form-section">
-        <h3>Оформление запуска</h3>
+        <div className="form-section-head">
+          <h3><i className="fas fa-tag"></i> Параметры запуска</h3>
+          <p className="form-section-hint">Как этот запуск будет назван в истории.</p>
+        </div>
         <div className="form-grid">
           <div className="form-field">
             <label htmlFor="run-title">Название запуска</label>
@@ -227,16 +291,64 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
               disabled={submitting}
             />
           </div>
-          <div className="form-field">
+          <div className="form-field full-width">
             <label htmlFor="run-tags">Теги</label>
-            <input
-              id="run-tags"
-              type="text"
-              placeholder="через запятую"
-              value={tags}
-              onChange={(e) => setTags(e.target.value)}
-              disabled={submitting}
-            />
+            <div className="denied-input-row">
+              <input
+                id="run-tags"
+                type="text"
+                placeholder="Например: эксперимент"
+                value={tagDraft}
+                onChange={(e) => setTagDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { e.preventDefault(); addTag(); }
+                }}
+                disabled={submitting}
+              />
+              <button
+                type="button"
+                className="button secondary small"
+                onClick={() => addTag()}
+                disabled={submitting || !tagDraft.trim()}
+              >
+                <i className="fas fa-plus"></i> Добавить
+              </button>
+            </div>
+            {SUGGESTED_TAGS.filter(t => !tagList.includes(t)).length > 0 && (
+              <div className="tag-suggestions">
+                <span className="tag-suggestions-label">Предложенные:</span>
+                {SUGGESTED_TAGS.filter(t => !tagList.includes(t)).map(t => (
+                  <button
+                    key={t}
+                    type="button"
+                    className="tag-suggestion"
+                    onClick={() => addTag(t)}
+                    disabled={submitting}
+                  >
+                    <i className="fas fa-plus"></i> {t}
+                  </button>
+                ))}
+              </div>
+            )}
+            {tagList.length > 0 && (
+              <ul className="tag-list">
+                {tagList.map((tag, index) => (
+                  <li key={tag} className="tag-chip">
+                    <span className="tag-chip-text">{tag}</span>
+                    <button
+                      type="button"
+                      className="tag-chip-remove"
+                      onClick={() => removeTag(index)}
+                      disabled={submitting}
+                      aria-label="Удалить тег"
+                      title="Удалить"
+                    >
+                      <i className="fas fa-xmark"></i>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/agents/index.ts
+++ b/frontend/src/components/agents/index.ts
@@ -2,4 +2,6 @@ export { default as DiscussionHistory } from './DiscussionHistory';
 export { default as DiscussionCard } from './DiscussionCard';
 export { default as DiscussionInfo } from './DiscussionInfo';
 export { default as DiscussionView } from './DiscussionView';
+export { default as DiscussionDetail } from './DiscussionDetail';
 export { default as MessageBubble } from './MessageBubble';
+export { default as RunPipelineForm } from './RunPipelineForm';

--- a/frontend/src/components/layout/Header.css
+++ b/frontend/src/components/layout/Header.css
@@ -54,7 +54,7 @@
 /* Навигация */
 .nav {
   display: flex;
-  gap: 2.5rem;
+  gap: 2rem;
 }
 
 .nav a {
@@ -62,42 +62,39 @@
   font-family: 'Inter', sans-serif;
   font-weight: 500;
   text-decoration: none !important;
-  font-size: 1rem;
-  padding: 0.5rem 0;
+  font-size: 0.95rem;
+  padding: 0.5rem 0.2rem;
   position: relative;
   transition: var(--transition);
-  border: none; /* убедимся, что нет подчёркивания */
+  border: none;
 }
 
 .nav a:hover {
-  color: var(--color-accent);
+  color: var(--color-text-primary);
 }
 
 /* Активная ссылка */
 .nav a.active {
-  color: var(--color-accent);
+  color: var(--color-accent-light);
   font-weight: 600;
 }
 
-/* Лёгкий фон при наведении (опционально) */
+/* Акцентная линия под активной ссылкой */
 .nav a::after {
   content: '';
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 100%;
-  height: 100%;
-  background: var(--color-accent-soft);
-  border-radius: 30px;
-  transform: translate(-50%, -50%) scale(0.8);
-  opacity: 0;
+  left: 0.2rem;
+  right: 0.2rem;
+  bottom: 0;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--color-accent);
+  transform: scaleX(0);
   transition: var(--transition);
-  z-index: -1;
 }
 
-.nav a:hover::after {
-  transform: translate(-50%, -50%) scale(1);
-  opacity: 1;
+.nav a.active::after {
+  transform: scaleX(1);
 }
 
 /* Адаптивность */
@@ -108,7 +105,6 @@
     gap: 0.8rem;
   }
   .nav {
-    gap: 1.5rem;
     flex-wrap: wrap;
     justify-content: center;
   }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -11,8 +11,8 @@ const Header: React.FC = () => {
       <nav className="nav">
         <NavLink to="/" className={({ isActive }) => isActive ? 'active' : ''}>Главная</NavLink>
         <NavLink to="/datasets" className={({ isActive }) => isActive ? 'active' : ''}>Датасеты</NavLink>
-        <NavLink to="/models" className={({ isActive }) => isActive ? 'active' : ''}>Модели</NavLink>
         <NavLink to="/agents" className={({ isActive }) => isActive ? 'active' : ''}>Агенты</NavLink>
+        <NavLink to="/models" className={({ isActive }) => isActive ? 'active' : ''}>Модели</NavLink>
       </nav>
     </header>
   );

--- a/frontend/src/pages/Agents.css
+++ b/frontend/src/pages/Agents.css
@@ -85,12 +85,32 @@
 }
 
 .run-pipeline-form .form-section {
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-bg-primary);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 3px solid var(--color-accent);
+  border-radius: 12px;
+}
+
+.run-pipeline-form .form-section-head {
+  margin-bottom: 1.25rem;
 }
 
 .run-pipeline-form .form-section h3 {
-  margin: 0 0 1rem;
+  margin: 0;
   font-size: 1.1rem;
+  color: var(--color-text-primary);
+}
+
+.run-pipeline-form .form-section h3 i {
+  color: var(--color-accent-light);
+  margin-right: 0.5rem;
+}
+
+.run-pipeline-form .form-section-hint {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
   color: var(--color-text-secondary);
 }
 
@@ -123,7 +143,7 @@
 .run-pipeline-form textarea {
   width: 100%;
   padding: 0.8rem;
-  background: var(--color-bg-primary);
+  background: var(--color-bg-secondary);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 8px;
   color: var(--color-text-primary);
@@ -140,6 +160,139 @@
 
 .run-pipeline-form textarea {
   resize: vertical;
+}
+
+.run-pipeline-form .field-hint {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  opacity: 0.8;
+}
+
+/* Поле добавления запрещённых гипотез */
+.denied-input-row {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.denied-input-row input {
+  flex: 1;
+}
+
+.denied-input-row .button {
+  white-space: nowrap;
+}
+
+.denied-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.denied-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.8rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+}
+
+.denied-item-text {
+  font-size: 0.9rem;
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+
+.denied-item-remove {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0.2rem 0.4rem;
+  border-radius: 6px;
+  transition: var(--transition);
+}
+
+.denied-item-remove:hover:not(:disabled) {
+  color: var(--color-accent-light);
+  background: var(--color-accent-soft);
+}
+
+/* Предложенные теги (заглушка) */
+.tag-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tag-suggestions-label {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.tag-suggestion {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px dashed var(--color-accent);
+  color: var(--color-accent-light);
+  border-radius: 40px;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.tag-suggestion:hover:not(:disabled) {
+  background: var(--color-accent-soft);
+}
+
+/* Добавленные теги */
+.tag-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.4rem 0.3rem 0.8rem;
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent);
+  border-radius: 40px;
+  font-size: 0.85rem;
+  color: var(--color-text-primary);
+}
+
+.tag-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  border-radius: 50%;
+  transition: var(--transition);
+}
+
+.tag-chip-remove:hover:not(:disabled) {
+  color: var(--color-accent-light);
 }
 
 .run-pipeline-actions {

--- a/frontend/src/pages/Agents.css
+++ b/frontend/src/pages/Agents.css
@@ -73,20 +73,84 @@
   margin-right: 0.4rem;
 }
 
-/* ── Заготовка вкладки «Запуск» ──────────────────────────────────────────────── */
-.agents-run-placeholder {
-  text-align: center;
-  padding: 4rem 2rem;
+/* ── Форма вкладки «Запуск» ──────────────────────────────────────────────────── */
+.run-pipeline-form {
   background: var(--color-bg-secondary);
   border-radius: 16px;
-  border: 1px dashed rgba(255, 255, 255, 0.1);
+  padding: 2rem;
+}
+
+.run-pipeline-form h2 {
+  margin: 0 0 1.5rem;
+}
+
+.run-pipeline-form .form-section {
+  margin-bottom: 2rem;
+}
+
+.run-pipeline-form .form-section h3 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
   color: var(--color-text-secondary);
 }
 
-.agents-run-placeholder i {
-  font-size: 2.5rem;
-  color: var(--color-accent);
-  margin-bottom: 1rem;
+.run-pipeline-form .form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+.run-pipeline-form .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.run-pipeline-form .form-field.full-width {
+  grid-column: 1 / -1;
+}
+
+.run-pipeline-form label {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.run-pipeline-form .required-star {
+  color: var(--color-accent-light);
+}
+
+.run-pipeline-form input,
+.run-pipeline-form textarea {
+  width: 100%;
+  padding: 0.8rem;
+  background: var(--color-bg-primary);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: var(--color-text-primary);
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: var(--transition);
+}
+
+.run-pipeline-form input:focus,
+.run-pipeline-form textarea:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.run-pipeline-form textarea {
+  resize: vertical;
+}
+
+.run-pipeline-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+  .run-pipeline-form .form-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ── Утилиты ─────────────────────────────────────────────────────────────────── */

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,11 +1,19 @@
 import React, { useState } from 'react';
-import { DiscussionHistory } from '../components/agents';
+import { useSearchParams } from 'react-router-dom';
+import { DiscussionHistory, RunPipelineForm } from '../components/agents';
 import './Agents.css';
 
 type AgentsTab = 'run' | 'history';
 
 const Agents: React.FC = () => {
   const [activeTab, setActiveTab] = useState<AgentsTab>('history');
+  const [, setSearchParams] = useSearchParams();
+
+  // После старта пайплайна — переключаемся на историю и открываем дискуссию.
+  const handleStarted = (discussionId: string) => {
+    setActiveTab('history');
+    setSearchParams({ discussion: discussionId });
+  };
 
   return (
     <div className="agents-page">
@@ -35,11 +43,7 @@ const Agents: React.FC = () => {
       {/* Содержимое вкладки */}
       <div className="agents-content">
         {activeTab === 'run' ? (
-          <div className="agents-run-placeholder">
-            <i className="fas fa-flask"></i>
-            <h3>Запуск пайплайнов</h3>
-            <p>Здесь появится возможность запускать пайплайны обучения с агентами.</p>
-          </div>
+          <RunPipelineForm onStarted={handleStarted} />
         ) : (
           <DiscussionHistory />
         )}

--- a/frontend/src/services/agentsService.ts
+++ b/frontend/src/services/agentsService.ts
@@ -1,0 +1,64 @@
+// Сервис для запуска пайплайнов агентов (сервис agents, порт 6400).
+
+// Базовый URL сервиса агентов берётся из переменной окружения VITE_AGENTS,
+// если её нет – localhost:6400.
+const AGENTS_URL = `http://${import.meta.env.VITE_AGENTS ?? 'localhost:6400'}`;
+
+/**
+ * Универсальная обработка HTTP-ответа.
+ * @throws Error с текстом из тела ответа (FastAPI: detail/message) или статусом.
+ */
+async function handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let errorMsg = `HTTP error ${response.status}`;
+    try {
+      const errorData = await response.json();
+      errorMsg = errorData.detail || errorData.message || errorMsg;
+    } catch {
+      // Тело не JSON — оставляем стандартное сообщение.
+    }
+    throw new Error(errorMsg);
+  }
+
+  const text = await response.text();
+  if (!text) return true as T;
+  return JSON.parse(text);
+}
+
+/** Параметры запуска пайплайна development. */
+export interface StartDevelopmentPayload {
+  dataset_id: string;
+  version_id: string;
+  model_name: string;
+  deployment_constraints: string;
+  business_requirements: string;
+  denied_hypotheses_info?: string[];
+  max_iter?: number;
+  title?: string;
+  tags?: string[];
+}
+
+/** Ответ на запуск: id созданной дискуссии и её статус. */
+export interface StartDevelopmentResult {
+  discussion_id: string;
+  status: string;
+}
+
+/**
+ * Сервис запуска пайплайнов агентов.
+ */
+export const agentsService = {
+  /**
+   * Запустить полный пайплайн development асинхронно.
+   * Дискуссия создаётся сразу, пайплайн выполняется в фоне.
+   * POST /development/start
+   */
+  async startDevelopment(payload: StartDevelopmentPayload): Promise<StartDevelopmentResult> {
+    const response = await fetch(`${AGENTS_URL}/development/start`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return handleResponse<StartDevelopmentResult>(response);
+  },
+};


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
- Добавлена форма запуска пайплайна `development` на вкладке «Запуск» страницы агентов
- Датасет и версия указываются **по имени** (name→id на фронте, подсказки через datalist)
- Запрещённые гипотезы и теги добавляются по одному в список; для тегов — заглушка предложенных (позже подтянем из сервиса истории)
- После старта - переход к созданной дискуссии с live-polling прогресса агентов и статуса
- Форма визуально разбита на три смысловых блока: «Данные и модель», «Контекст для агентов», «Параметры запуска»
- Новый сервис `agentsService` (`POST /development/start`) + переменная окружения `VITE_AGENTS`
- В шапке поменяны местами пункты «Агенты» и «Модели», навигация переведена на минималистичный стиль с подчёркиванием активного пункта