### PR TITLE
fix: widen ml_models dataset UUID columns and guard model creation fa…

### DIFF
--- a/db/postgres/ml_models/init/01-create-table-ml_models.sql
+++ b/db/postgres/ml_models/init/01-create-table-ml_models.sql
@@ -25,9 +25,9 @@ CREATE TABLE IF NOT EXISTS ml_models (
     classes JSONB NOT NULL DEFAULT '[]'::jsonb,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    -- Датасет для которого создана модель
-    dataset_id VARCHAR(20) NOT NULL, 
-    dataset_version_id VARCHAR(20) NOT NULL, 
+    -- Датасет для которого создана модель (UUID, 36 символов)
+    dataset_id VARCHAR(36) NOT NULL,
+    dataset_version_id VARCHAR(36) NOT NULL,
 
     -- Framework для работы с моделью
     framework VARCHAR(50),

--- a/services/agents/app/core/pipeline/train.py
+++ b/services/agents/app/core/pipeline/train.py
@@ -55,6 +55,17 @@ def training(
         train_params=ml_model.configuration,
         classes=get_dataset_info_classes(training_input.dataset_id)
     )
+
+    # При ошибке create_model возвращает не id, а {"ERROR": ...}. Не отправляем
+    # обучение с битым model_id — сразу сообщаем о провале.
+    if not isinstance(model_id, str):
+        error = model_id.get("ERROR") if isinstance(model_id, dict) else str(model_id)
+        logger.error(f"🟥 Не удалось создать ML модель: {error}")
+        return TrainingOut(
+            is_completed_successfully=False,
+            error=f"Не удалось создать ML модель: {error}"
+        )
+
     logger.info("✅ ML модель создана")
 
     logger.info("Создание задачи на обучение...")


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
- Колонки `dataset_id`/`dataset_version_id` в таблице `ml_models` расширены `VARCHAR(20)` → `VARCHAR(36)` UUID датасета (36 символов) больше не обрезается, `POST /models` не падает с 500
- В `train.py` добавлена проверка результата `create_model`: при ошибке создания модели обучение не уходит в tasker с битым `model_id`, а сразу возвращается осмысленная ошибка (убран ложный «успех» и каскад в 422)
