### PR TITLE
Metrics/refactor/all

### DIFF
--- a/services/agents/app/core/crews/utils/run_crew.py
+++ b/services/agents/app/core/crews/utils/run_crew.py
@@ -5,7 +5,7 @@ from crewai import Crew, CrewOutput
 
 from app.services.agent_history import agent_history_client
 from app.services.metrics import add_agent_in_metrics
-from app.core.memory import agent_response_context, iteration_context
+from app.core.memory import agent_response_context, iteration_context, discussion_context
 from app.logs import get_logger
 
 logger = get_logger(__name__)
@@ -79,7 +79,8 @@ def run_crew_with_tracking(
             return None
 
         duration_ms = (time.time() - start_time) * 1000
-        add_agent_in_metrics(crew=crew)
+        discussion_id = discussion_context.get() if discussion_context.is_set() else None
+        add_agent_in_metrics(crew=crew, discussion_id=discussion_id)
         agent_history_client.agent_succeed(
             response_id=response_id,
             agent_role=agent_role,

--- a/services/agents/app/services/metrics/client.py
+++ b/services/agents/app/services/metrics/client.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from crewai import Crew
 from crewai.types.usage_metrics import UsageMetrics
 
@@ -11,13 +11,19 @@ logger = get_logger(__name__)
 METRICS_URL = config_url.METRICS['url']
 
 def add_agent_in_metrics(
-        crew: Crew
+        crew: Crew,
+        discussion_id: Optional[str] = None
 ) -> bool:
     """
     Добавление метрик(потраченные токены)
+
+    Args:
+        crew: crew, чьи метрики использования сохраняем
+        discussion_id: дискуссия, к которой относится запуск (для агрегации)
     """
     agent_info = {}
     agent_info["response_id"] = str(crew.id)
+    agent_info["discussion_id"] = discussion_id
     agent_info["metrics"] = _token_metrics_to_dict(crew.usage_metrics)
 
     _post(agent_info)

--- a/services/metrics/app/api/routers/agent.py
+++ b/services/metrics/app/api/routers/agent.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, Depends
 
-from app.api.schemas import AgentResponse
+from app.api.schemas import AgentResponse, AgentDiscussionMetrics
 from app.api.deps import get_agent_metrics_manager, AgentsResponseManager
 from app.logs import get_logger
 
@@ -17,9 +17,28 @@ async def add_agent_response(
     Добавление нового ответа агента
     """
     try:
-        manager.add_response(response)
-        return True
-        
+        added = manager.add_response(response)
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    if not added:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Метрики ответа {response.response_id} уже существуют"
+        )
+    return {"response_id": response.response_id, "added": True}
+
+@router.get("/discussions/{discussion_id}", response_model=AgentDiscussionMetrics)
+async def get_discussion_metrics(
+    discussion_id: str,
+    manager: AgentsResponseManager = Depends(get_agent_metrics_manager)
+):
+    """
+    Метрики всех агентов дискуссии и суммарная сводка (токены и т.п.)
+    """
+    try:
+        return manager.get_discussion_metrics(discussion_id)
     except Exception as e:
         logger.error(f"Error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -34,11 +53,13 @@ async def get_agent_response(
     """
     try:
         response = manager.get_response_by_id(response_id)
-        
-        return response
     except Exception as e:
         logger.error(f"Error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+    if response is None:
+        raise HTTPException(status_code=404, detail=f"Метрики ответа {response_id} не найдены")
+    return response
 
 @router.delete("/{response_id}")
 async def delete_agent_response(
@@ -49,9 +70,11 @@ async def delete_agent_response(
     Удаление ответа агента
     """
     try:
-        manager.delete_response(response_id)
-        
-        return True
+        deleted = manager.delete_response(response_id)
     except Exception as e:
         logger.error(f"Error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Метрики ответа {response_id} не найдены")
+    return {"response_id": response_id, "deleted": True}

--- a/services/metrics/app/api/routers/agent.py
+++ b/services/metrics/app/api/routers/agent.py
@@ -8,14 +8,16 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
-@router.post("/add")
+@router.post(
+    "/add",
+    summary="Добавить метрики ответа агента",
+    description="Сохраняет метрики использования (токены и т.п.) одного ответа агента",
+    response_description="Идентификатор ответа и признак добавления",
+)
 async def add_agent_response(
     response: AgentResponse,
     manager: AgentsResponseManager = Depends(get_agent_metrics_manager)
 ):
-    """
-    Добавление нового ответа агента
-    """
     try:
         added = manager.add_response(response)
     except Exception as e:
@@ -29,28 +31,34 @@ async def add_agent_response(
         )
     return {"response_id": response.response_id, "added": True}
 
-@router.get("/discussions/{discussion_id}", response_model=AgentDiscussionMetrics)
+@router.get(
+    "/discussions/{discussion_id}",
+    response_model=AgentDiscussionMetrics,
+    summary="Получить метрики дискуссии",
+    description="Возвращает метрики всех ответов агентов дискуссии и суммарную сводку по токенам",
+    response_description="Метрики ответов дискуссии и их сводка",
+)
 async def get_discussion_metrics(
     discussion_id: str,
     manager: AgentsResponseManager = Depends(get_agent_metrics_manager)
 ):
-    """
-    Метрики всех агентов дискуссии и суммарная сводка (токены и т.п.)
-    """
     try:
         return manager.get_discussion_metrics(discussion_id)
     except Exception as e:
         logger.error(f"Error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/{response_id}", response_model=AgentResponse)
+@router.get(
+    "/{response_id}",
+    response_model=AgentResponse,
+    summary="Получить метрики ответа агента",
+    description="Возвращает метрики указанного ответа агента по его идентификатору",
+    response_description="Метрики ответа агента",
+)
 async def get_agent_response(
     response_id: str,
     manager: AgentsResponseManager = Depends(get_agent_metrics_manager)
 ):
-    """
-    Получение ответа агента по ID
-    """
     try:
         response = manager.get_response_by_id(response_id)
     except Exception as e:
@@ -61,14 +69,16 @@ async def get_agent_response(
         raise HTTPException(status_code=404, detail=f"Метрики ответа {response_id} не найдены")
     return response
 
-@router.delete("/{response_id}")
+@router.delete(
+    "/{response_id}",
+    summary="Удалить метрики ответа агента",
+    description="Удаляет сохранённые метрики указанного ответа агента из системы",
+    response_description="Идентификатор ответа и признак удаления",
+)
 async def delete_agent_response(
     response_id: str,
     manager: AgentsResponseManager = Depends(get_agent_metrics_manager)
 ):
-    """
-    Удаление ответа агента
-    """
     try:
         deleted = manager.delete_response(response_id)
     except Exception as e:

--- a/services/metrics/app/api/routers/model.py
+++ b/services/metrics/app/api/routers/model.py
@@ -1,6 +1,8 @@
+from typing import List
+
 from fastapi import APIRouter, HTTPException, Depends
 
-from app.api.schemas import ModelMetricAdd, ModelMetricAdds, ModelMetrics
+from app.api.schemas import ModelMetricAdd, ModelMetricAdds, ModelMetrics, ModelMetricsBatchRequest
 from app.api.deps import get_cv_training_metrics_manager, CVMetricManager
 from app.logs import get_logger
 
@@ -28,6 +30,17 @@ async def add_metrics(
         raise HTTPException(status_code=500, detail="Ошибка добавления метрик")
     return {"status": "ok"}
 
+@router.post("/batch", response_model=List[ModelMetrics])
+async def get_models_metrics(
+    body: ModelMetricsBatchRequest,
+    manager: CVMetricManager = Depends(get_cv_training_metrics_manager)
+):
+    """
+    Метрики сразу нескольких моделей за один запрос (для списков и сравнения).
+    Модели без метрик в ответ не попадают.
+    """
+    return manager.get_models_metrics(body.model_ids)
+
 @router.get("/{model_id}", response_model=ModelMetrics)
 async def get_task_metrics(
     model_id: str,
@@ -52,5 +65,7 @@ async def task_delete(
     model_id: str,
     manager: CVMetricManager = Depends(get_cv_training_metrics_manager)
 ):
-    res = manager.model_metrics_exists(model_id)
-    return {"is_delet": res}
+    deleted = manager.delete_metric(model_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Метрики модели {model_id} не найдены")
+    return {"model_id": model_id, "deleted": True}

--- a/services/metrics/app/api/routers/model.py
+++ b/services/metrics/app/api/routers/model.py
@@ -10,7 +10,12 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/models", tags=["metrics"])
 
-@router.post("/add")
+@router.post(
+    "/add",
+    summary="Добавить метрику модели",
+    description="Добавляет значения одной метрики модели; при отсутствии модели создаёт запись",
+    response_description="Статус операции",
+)
 async def add_metric(
     metric: ModelMetricAdd,
     manager: CVMetricManager = Depends(get_cv_training_metrics_manager)
@@ -20,7 +25,12 @@ async def add_metric(
         raise HTTPException(status_code=500, detail="Ошибка добавления метрики")
     return {"status": "ok"}
 
-@router.post("/adds")
+@router.post(
+    "/adds",
+    summary="Добавить несколько метрик модели",
+    description="Добавляет значения сразу нескольких метрик модели за один запрос (используется при обучении)",
+    response_description="Статус операции",
+)
 async def add_metrics(
     metric: ModelMetricAdds,
     manager: CVMetricManager = Depends(get_cv_training_metrics_manager)
@@ -30,18 +40,26 @@ async def add_metrics(
         raise HTTPException(status_code=500, detail="Ошибка добавления метрик")
     return {"status": "ok"}
 
-@router.post("/batch", response_model=List[ModelMetrics])
+@router.post(
+    "/batch",
+    response_model=List[ModelMetrics],
+    summary="Получить метрики нескольких моделей",
+    description="Возвращает метрики сразу нескольких моделей за один запрос; модели без метрик в ответ не попадают",
+    response_description="Список метрик по каждой найденной модели",
+)
 async def get_models_metrics(
     body: ModelMetricsBatchRequest,
     manager: CVMetricManager = Depends(get_cv_training_metrics_manager)
 ):
-    """
-    Метрики сразу нескольких моделей за один запрос (для списков и сравнения).
-    Модели без метрик в ответ не попадают.
-    """
     return manager.get_models_metrics(body.model_ids)
 
-@router.get("/{model_id}", response_model=ModelMetrics)
+@router.get(
+    "/{model_id}",
+    response_model=ModelMetrics,
+    summary="Получить метрики модели",
+    description="Возвращает все метрики указанной модели с их значениями по эпохам",
+    response_description="Метрики модели",
+)
 async def get_task_metrics(
     model_id: str,
     manager: CVMetricManager = Depends(get_cv_training_metrics_manager)
@@ -51,7 +69,12 @@ async def get_task_metrics(
         raise HTTPException(status_code=404, detail=f"Модель {model_id} не найдена")
     return metrics
 
-@router.get("/{model_id}/exists")
+@router.get(
+    "/{model_id}/exists",
+    summary="Проверить наличие метрик модели",
+    description="Проверяет, есть ли в системе сохранённые метрики для указанной модели",
+    response_description="Флаг наличия метрик модели",
+)
 async def task_exists(
     model_id: str,
     manager: CVMetricManager = Depends(get_cv_training_metrics_manager)
@@ -60,7 +83,12 @@ async def task_exists(
     return {"model_id": model_id, "exists": exists}
 
 
-@router.delete("/{model_id}")
+@router.delete(
+    "/{model_id}",
+    summary="Удалить метрики модели",
+    description="Удаляет все сохранённые метрики указанной модели из системы",
+    response_description="Идентификатор модели и признак удаления",
+)
 async def task_delete(
     model_id: str,
     manager: CVMetricManager = Depends(get_cv_training_metrics_manager)

--- a/services/metrics/app/api/schemas/agent.py
+++ b/services/metrics/app/api/schemas/agent.py
@@ -1,6 +1,13 @@
 from pydantic import BaseModel, Field
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
 
 class AgentResponse(BaseModel):
     response_id: str = Field(..., description="ID ответа")
+    discussion_id: Optional[str] = Field(None, description="ID дискуссии, к которой относится ответ")
     metrics: Dict[str, Any] = Field(..., description="Метрики использования агента")
+
+class AgentDiscussionMetrics(BaseModel):
+    """Метрики всех агентов дискуссии и их сводка"""
+    discussion_id: str = Field(..., description="ID дискуссии")
+    responses: List[AgentResponse] = Field(default_factory=list, description="Метрики каждого ответа агента")
+    summary: Dict[str, Any] = Field(default_factory=dict, description="Суммарные метрики по дискуссии")

--- a/services/metrics/app/api/schemas/model.py
+++ b/services/metrics/app/api/schemas/model.py
@@ -25,3 +25,7 @@ class SearchMetric(BaseModel):
     """Запрос на поиск требуемой метрики"""
     model_id: str = Field(..., description="ID модели")
     name: str = Field(..., description="Название метрики")
+
+class ModelMetricsBatchRequest(BaseModel):
+    """Запрос метрик сразу нескольких моделей"""
+    model_ids: List[str] = Field(default_factory=list, description="Список ID моделей")

--- a/services/metrics/app/core/agent.py
+++ b/services/metrics/app/core/agent.py
@@ -1,8 +1,8 @@
-from typing import Optional
+from typing import List, Optional
 from pymongo.errors import PyMongoError
 
 from .mongo import ManagerBase
-from app.api.schemas import AgentResponse
+from app.api.schemas import AgentResponse, AgentDiscussionMetrics
 from app.logs import get_logger
 
 logger = get_logger(__name__)
@@ -47,14 +47,42 @@ class AgentsResponseManager(ManagerBase):
             if doc:
                 doc.pop('_id', None)
                 return AgentResponse(**doc)
-            raise ValueError(f"Не найдены метрики ответа(id:'{response_id}')")
-            
+
+            logger.warning(f"Не найдены метрики ответа(id:'{response_id}')")
+            return None
+
         except PyMongoError as e:
             logger.error(f"Ошибка получения ответа(id:'{response_id}'): {e}")
             return None
 
+    def get_discussion_metrics(
+            self,
+            discussion_id: str
+    ) -> AgentDiscussionMetrics:
+        """Метрики всех агентов дискуссии и суммарная сводка по числовым полям"""
+        responses: List[AgentResponse] = []
+        try:
+            for doc in self.collection.find({'discussion_id': discussion_id}):
+                doc.pop('_id', None)
+                responses.append(AgentResponse(**doc))
+        except PyMongoError as e:
+            logger.error(f"Ошибка получения метрик дискуссии(id:'{discussion_id}'): {e}")
+
+        summary: dict = {"responses_count": len(responses)}
+        for response in responses:
+            for key, value in response.metrics.items():
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    continue
+                summary[key] = summary.get(key, 0) + value
+
+        return AgentDiscussionMetrics(
+            discussion_id=discussion_id,
+            responses=responses,
+            summary=summary,
+        )
+
     def delete_response(
-            self, 
+            self,
             response_id: str
     ) -> bool:
         """Удаление ответа"""

--- a/services/metrics/app/core/model.py
+++ b/services/metrics/app/core/model.py
@@ -27,7 +27,7 @@ class CVMetricManager(ManagerBase):
                     },
                     {
                         '$push': {
-                            f'metrics.$.values': metric.metric.values,
+                            f'metrics.$.values': {'$each': metric.metric.values}
                         }
                     }
                 )
@@ -36,7 +36,7 @@ class CVMetricManager(ManagerBase):
                 if result.matched_count == 0:
                     new_metric = {
                         'metric': metric.metric.name,
-                        'values': [metric.metric.values],
+                        'values': metric.metric.values,
                     }
                     self.collection.update_one(
                         {'model_id': metric.model_id},
@@ -51,7 +51,7 @@ class CVMetricManager(ManagerBase):
                     'model_id': metric.model_id,
                     'metrics': [{
                         'metric': metric.metric.name,
-                        'values': [metric.metric.values],
+                        'values': metric.metric.values,
                     }]
                 }
                 self.collection.insert_one(new_task)
@@ -145,6 +145,27 @@ class CVMetricManager(ManagerBase):
         except PyMongoError as e:
             logger.error(f"Ошибка получения метрик модели(id={model_id}): {e}")
             return None
+
+    def get_models_metrics(
+        self,
+        model_ids: list
+    ) -> list:
+        """Получение метрик сразу нескольких моделей одним запросом"""
+        try:
+            docs = self.collection.find({'model_id': {'$in': model_ids}})
+            return [
+                ModelMetrics(
+                    model_id=doc['model_id'],
+                    metrics=[
+                        ModelMetricData(name=m['metric'], values=m['values'])
+                        for m in doc['metrics']
+                    ],
+                )
+                for doc in docs
+            ]
+        except PyMongoError as e:
+            logger.error(f"Ошибка получения метрик моделей: {e}")
+            return []
 
     def model_metrics_exists(
             self,


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
- Исправлены баги сервиса метрик: `DELETE /models/{id}` теперь реально удаляет (раньше лишь проверял существование), `POST /models/add` пишет значения без двойной вложенности, `GET /agents/{id}` отдаёт 404 вместо 500, `DELETE /agents/{id}` возвращает честный результат, повторный `POST /agents/add` отвечает 409
- Добавлен `POST /models/batch`, метрики нескольких моделей за один запрос (списки и сравнение без N+1)
- Добавлен `GET /agents/discussions/{discussion_id}`, метрики всех агентов дискуссии и суммарная сводка по токенам
- В метрики агента теперь пишется `discussion_id` (проброшен из `discussion_context` сервиса агентов), что и делает возможной агрегацию по дискуссии
- Всем ручкам сервиса метрик добавлены описания (`summary`/`description`/`response_description`) в стилистике сервиса датасетов