### PR TITLE
Ml models/refactor/all

### DIFF
--- a/db/postgres/ml_models/init/01-create-table-ml_models.sql
+++ b/db/postgres/ml_models/init/01-create-table-ml_models.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS ml_models (
     model_type VARCHAR(100) NOT NULL,
     status_id INTEGER NOT NULL DEFAULT 1,
     description TEXT,
-    metrics_result TEXT DEFAULT 'No info',
+    metrics_report TEXT DEFAULT 'No info',
     classes JSONB NOT NULL DEFAULT '[]'::jsonb,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
 

--- a/services/ml_models/app/api/deps.py
+++ b/services/ml_models/app/api/deps.py
@@ -1,5 +1,8 @@
+from fastapi import HTTPException, status
+
 from app.core.train_models_tasks import MlModelsManager
 from app.core.files import FilesManager
+from app.core.utils import valid_uuid
 
 ml_models_manager = MlModelsManager()
 files_manager = FilesManager()
@@ -9,3 +12,21 @@ async def get_ml_models_manager() -> MlModelsManager:
 
 async def get_files_manager() -> FilesManager:
     return files_manager
+
+def validate_model_id(model_id: str) -> str:
+    """Зависимость: валидирует UUID модели из пути, иначе 404."""
+    if not valid_uuid(model_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Модель с ID {model_id} не найдена"
+        )
+    return model_id
+
+def validate_file_id(file_id: str) -> str:
+    """Зависимость: валидирует UUID файла из пути, иначе 404."""
+    if not valid_uuid(file_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Файл с ID {file_id} не найден"
+        )
+    return file_id

--- a/services/ml_models/app/api/routers/files.py
+++ b/services/ml_models/app/api/routers/files.py
@@ -3,8 +3,14 @@ from fastapi.responses import FileResponse
 
 from app.logs import get_logger
 from app.api.schemas import Files, File, FileDeletes
-from app.api.deps import get_files_manager, FilesManager
-from app.core.utils import valid_uuid
+from app.api.deps import (
+    get_files_manager,
+    FilesManager,
+    get_ml_models_manager,
+    MlModelsManager,
+    validate_model_id,
+    validate_file_id,
+)
 
 routers = APIRouter(
     prefix='/models',
@@ -16,6 +22,8 @@ logger = get_logger(__name__)
 @routers.get(
     "/{model_id}/files",
     summary="Получение информации о файлах модели",
+    description="Возвращает список файлов, связанных с указанной моделью",
+    response_description="Список файлов модели",
     responses={
         200: {"description": "Информация о файлах модели успешно получена"},
         204: {"description": "Модель не имеет файлов"},
@@ -24,31 +32,28 @@ logger = get_logger(__name__)
     }
 )
 async def get_files(
-    model_id: str,
-    manager: FilesManager = Depends(get_files_manager)
+    model_id: str = Depends(validate_model_id),
+    manager: FilesManager = Depends(get_files_manager),
+    models_manager: MlModelsManager = Depends(get_ml_models_manager),
 ):
-    try:
-        valid_uuid(model_id, True)
-        files = manager.get_info_files(model_id)
-        if files:
-            return Files(
-                files=[
-                    File(**file)
-                    for file in files
-                ]
-            )
-        else:
-            return Response(status_code=status.HTTP_204_NO_CONTENT)
-    except ValueError as e:
-        logger.error(f"Получен не валидный model_id('{model_id}')")
+    # Модель должна существовать — иначе 404 (а не «нет файлов»)
+    if models_manager.get_model(model_id) is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Модель с ID {model_id} не найдена"
         )
 
+    files = manager.get_info_files(model_id)
+    if files:
+        return Files(files=[File(**file) for file in files])
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
 @routers.post(
     "/{model_id}/files",
     summary="Загрузить файл модели",
+    description="Загружает и сохраняет файл, связанный с указанной моделью",
+    response_description="Пустой ответ при успешной загрузке",
     responses={
         200: {"description": "Файл успешно загружен"},
         404: {"description": "Модель не найдена"},
@@ -57,28 +62,38 @@ async def get_files(
     }
 )
 async def add_file(
-    model_id: str,
     files: UploadFile,
-    manager: FilesManager = Depends(get_files_manager)
+    model_id: str = Depends(validate_model_id),
+    manager: FilesManager = Depends(get_files_manager),
+    models_manager: MlModelsManager = Depends(get_ml_models_manager)
 ):
-    try:
-        valid_uuid(model_id, True)
-        manager.add_file(model_id, files)
-    except ValueError as e:
-        logger.error(f"Получен не валидный model_id('{model_id}')")
+    # Модель должна существовать — иначе 404 (а не 500 + директория-мусор)
+    if models_manager.get_model(model_id) is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Модель с ID {model_id} не найдена"
         )
+
+    try:
+        manager.add_file(model_id, files)
     except FileExistsError:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Файл уже существует"
         )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
+    return {"model_id": model_id, "filename": files.filename, "status": "ok"}
 
 @routers.delete(
     "/{model_id}/files",
     summary="Удаление файлов модели",
+    description="Удаляет указанные файлы модели, либо все файлы модели, если идентификаторы не переданы",
+    response_description="Пустой ответ при успешном удалении",
     responses={
         200: {"description": "Операция удалёния выполнена"},
         204: {"description": "Нет файлов для удаления"},
@@ -87,34 +102,34 @@ async def add_file(
     }
 )
 async def del_file(
-    model_id: str,
     files: FileDeletes,
-    manager: FilesManager = Depends(get_files_manager)
+    model_id: str = Depends(validate_model_id),
+    manager: FilesManager = Depends(get_files_manager),
+    models_manager: MlModelsManager = Depends(get_ml_models_manager)
 ):
-    try:
-        valid_uuid(model_id, True)
-
-        if files.ids is None:
-            result = manager.drop(model_id)
-        else:
-            result = manager.drop(model_id, files.ids)
-
-        if result == 0:
-            return Response(
-                status_code=status.HTTP_204_NO_CONTENT,
-                content="Нет файлов для удаления"
-            )
-
-    except ValueError as e:
-        logger.error(f"Получен не валидный model_id('{model_id}')")
+    # Модель должна существовать — иначе 404 (а не 204 + директория-мусор)
+    if models_manager.get_model(model_id) is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Модель с ID {model_id} не найдена"
         )
 
+    if files.ids is None:
+        result = manager.drop(model_id)
+    else:
+        result = manager.drop(model_id, files.ids)
+
+    if result == 0:
+        return Response(
+            status_code=status.HTTP_204_NO_CONTENT,
+            content="Нет файлов для удаления"
+        )
+
 @routers.get(
     "/files/{file_id}/download",
     summary="Скачать конкретный файл по ID",
+    description="Возвращает содержимое файла модели для скачивания по его идентификатору",
+    response_description="Содержимое файла",
     responses={
         200: {"description": "Файл успешно скачан"},
         404: {"description": "Файл не найден"},
@@ -122,17 +137,15 @@ async def del_file(
     }
 )
 async def download_file(
-    file_id: str,
+    file_id: str = Depends(validate_file_id),
     manager: FilesManager = Depends(get_files_manager)
 ):
     """
     Скачать конкретный файл по его ID.
     """
     try:
-        valid_uuid(file_id, True)
-        
         file_path, filename = manager.get_file_path(file_id)
-        
+
         return FileResponse(
             path=str(file_path),
             filename=filename,

--- a/services/ml_models/app/api/routers/info.py
+++ b/services/ml_models/app/api/routers/info.py
@@ -17,9 +17,10 @@ routers = APIRouter(
     "/health",
     summary="Проверка работоспособности сервиса",
     description="""
-Проверяет работу сервиса и зависимостей. 
+Проверяет работу сервиса и зависимостей.
 Выводит полную информацию о работоспособности сервиса
 """,
+    response_description="Информация о состоянии сервиса и его зависимостей",
     response_model=HealthResponse,
     responses={
         200: {"description": "Выдаёт информацию о состояниях"},
@@ -33,6 +34,8 @@ async def health():
 @routers.get(
     "/models/status",
     summary="Получение информации о статусах моделей",
+    description="Возвращает справочник всех возможных статусов моделей с их описаниями",
+    response_description="Список статусов моделей",
     response_model=MLModelsStatusesResponse,
     responses={
         200: {"description": "Выдаёт информацию о состояниях"},

--- a/services/ml_models/app/api/routers/ml_models.py
+++ b/services/ml_models/app/api/routers/ml_models.py
@@ -3,21 +3,25 @@ from typing import Optional
 from psycopg2 import OperationalError, InterfaceError
 from fastapi import APIRouter, Depends, HTTPException, status, Response, Query
 
-from app.logs import get_logger
 from app.api.schemas import *
-from app.api.deps import get_ml_models_manager, MlModelsManager
-from app.core.utils import valid_uuid
+from app.api.deps import (
+    get_ml_models_manager,
+    MlModelsManager,
+    get_files_manager,
+    FilesManager,
+    validate_model_id,
+)
 
 routers = APIRouter(
     prefix='/models',
     tags=['models']
 )
 
-logger = get_logger(__name__)
-
 @routers.get(
     "",
     summary="Получить информацию о всех моделях",
+    description="Возвращает список моделей (свежие сверху) с опциональной фильтрацией по датасету и статусу",
+    response_description="Список метаданных моделей",
     response_model=MLModels,
     responses={
         200: {"description": "Список моделей (возможно пустой)"},
@@ -27,26 +31,38 @@ logger = get_logger(__name__)
 async def get_models(
     dataset_id: Optional[str] = Query(None, description="Фильтр по ID датасета"),
     model_status: Optional[str] = Query(None, alias="status", description="Фильтр по статусу модели"),
+    name: Optional[str] = Query(None, description="Фильтр по имени модели (все версии модели)"),
+    limit: Optional[int] = Query(None, ge=1, description="Размер страницы (без параметра — все модели)"),
+    offset: int = Query(0, ge=0, description="Смещение для пагинации"),
     manager: MlModelsManager = Depends(get_ml_models_manager)
 ):
     """
     Получить полную информацию о моделях (свежие сверху).
 
-    Опционально фильтрует по датасету и/или статусу. Всегда возвращает 200 с
-    JSON-списком; при отсутствии моделей список пустой.
+    Опционально фильтрует по датасету, статусу и/или имени (все версии модели).
+    Пагинация необязательна: без `limit` возвращаются все модели. Всегда
+    возвращает 200 с JSON-списком и общим количеством `total` (с учётом фильтров).
     """
 
-    # Получение моделей
-    models = manager.get_model(dataset_id=dataset_id, status=model_status)
+    # Получение моделей и общего количества с учётом фильтров
+    models = manager.get_model(
+        dataset_id=dataset_id,
+        status=model_status,
+        name=name,
+        limit=limit,
+        offset=offset
+    )
+    total = manager.count_model(dataset_id=dataset_id, status=model_status, name=name)
 
-    if models is None:
-        return MLModels(models=[])
+    items = [MLModel(**model) for model in models] if models else []
 
-    return MLModels(models=[MLModel(**model) for model in models])
+    return MLModels(models=items, total=total, limit=limit, offset=offset)
 
 @routers.post(
     "",
-    summary="Создание модели",
+    summary="Создать модель",
+    description="Создаёт новую ML модель с её параметрами обучения и привязкой к датасету",
+    response_description="Идентификатор созданной модели",
     status_code=201,
     responses={
         201: {"description": "Модель успешно создана"},
@@ -70,9 +86,28 @@ async def create_model(
             detail=f"Ошибка в запросе: {e}"
         )
 
+@routers.get(
+    "/statistics",
+    summary="Получить статистику по моделям",
+    description="Возвращает общее количество моделей и распределение по статусам",
+    response_description="Общее количество и счётчики моделей по статусам",
+    response_model=MLModelsStatistics,
+    responses={
+        200: {"description": "Статистика успешно собрана"},
+        503: {"description": "Ошибка подключения к БД"}
+    }
+)
+async def get_models_statistics(
+    manager: MlModelsManager = Depends(get_ml_models_manager)
+):
+    """Статистика моделей: всего и по статусам (для дашборда)"""
+    return manager.get_statistics()
+
 @routers.delete(
     "/{model_id}",
-    summary="Удаление модели",
+    summary="Удалить модель",
+    description="Удаляет указанную модель по её идентификатору вместе со связанными данными",
+    response_description="Пустой ответ при успешном удалении",
     status_code=status.HTTP_200_OK,
     responses={
         204: {"description": "Модель успешно удалена"},
@@ -80,28 +115,28 @@ async def create_model(
     }
 )
 async def delete_task(
-    model_id: str,
-    manager: MlModelsManager = Depends(get_ml_models_manager)
+    model_id: str = Depends(validate_model_id),
+    manager: MlModelsManager = Depends(get_ml_models_manager),
+    files_manager: FilesManager = Depends(get_files_manager)
 ):
-    try:
-        deleted = manager.delete(model_id)
+    deleted = manager.delete(model_id)
 
-        if not deleted:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Модель с ID {model_id} не найдена"
-            )
-                
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
-    except ValueError as e:
+    if not deleted:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Некорректный формат введённых данных: {e}"
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Модель с ID {model_id} не найдена"
         )
+
+    # Запись модели удалена (FK CASCADE убрал метаданные файлов) — чистим диск
+    files_manager.drop_model_dir(model_id)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 @routers.get(
     "/{model_id}",
     summary="Получить информацию о модели",
+    description="Возвращает полную информацию об указанной модели по её идентификатору",
+    response_description="Метаданные модели",
     response_model=MLModel,
     responses={
         200: {"description": "Модель успешно найдена"},
@@ -109,19 +144,10 @@ async def delete_task(
     }
 )
 async def get_model_by_id(
-    model_id: str,
+    model_id: str = Depends(validate_model_id),
     manager: MlModelsManager = Depends(get_ml_models_manager)
 ):
     """Получить полную информацию о модели по её ID"""
-    
-    try:
-        valid_uuid(model_id, True)
-    except ValueError as e:
-        logger.error(f"Получен не валидный model_id('{model_id}')")
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Модель с ID {model_id} не найдена"
-        )
 
     # Получение модели
     models = manager.get_model(model_id)
@@ -139,6 +165,8 @@ async def get_model_by_id(
 @routers.patch(
     "/{model_id}",
     summary="Частичное обновление модели",
+    description="Обновляет переданные поля указанной модели; неуказанные поля остаются прежними",
+    response_description="Пустой ответ при успешном обновлении",
     responses={
         200: {"description": "Модель успешно обновлена"},
         400: {"description": "Некорректные данные запроса"},
@@ -146,23 +174,14 @@ async def get_model_by_id(
     }
 )
 async def update_model(
-    model_id: str,
     update_data: MLModelUpdate,
+    model_id: str = Depends(validate_model_id),
     manager: MlModelsManager = Depends(get_ml_models_manager)
 ):
     """
     Частичное обновление модели.
     Можно обновить любое из полей, передав только нужные.
     """
-
-    try:
-        valid_uuid(model_id, True)
-    except ValueError as e:
-        logger.error(f"Получен не валидный model_id = '{model_id}'")
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Модель с ID {model_id} не найдена"
-        )
 
     # Получаем словарь без None значений
     update_dict = update_data.model_dump(exclude_none=True)
@@ -173,15 +192,8 @@ async def update_model(
             detail="Нет данных для обновления"
         )
 
-    # Проверка существования модели до обновления
-    if manager.get_model(model_id) is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Модель с ID {model_id} не найдена"
-        )
-
+    # Один запрос: UPDATE ... RETURNING вернёт False, если модели нет → 404
     try:
-        # Выполняем обновление
         updated_model = manager.update_model(model_id, update_dict)
     except ValueError as e:
         raise HTTPException(

--- a/services/ml_models/app/api/routers/ml_models.py
+++ b/services/ml_models/app/api/routers/ml_models.py
@@ -1,5 +1,7 @@
+from typing import Optional
+
 from psycopg2 import OperationalError, InterfaceError
-from fastapi import APIRouter, Depends, HTTPException, status, Response
+from fastapi import APIRouter, Depends, HTTPException, status, Response, Query
 
 from app.logs import get_logger
 from app.api.schemas import *
@@ -18,26 +20,29 @@ logger = get_logger(__name__)
     summary="Получить информацию о всех моделях",
     response_model=MLModels,
     responses={
-        200: {"description": "Модели успешно найдены"},
-        204: {"description": "Нет моделей в базе данных"},
+        200: {"description": "Список моделей (возможно пустой)"},
         503: {"description": "Ошибка подключения к БД"}
     }
 )
 async def get_models(
+    dataset_id: Optional[str] = Query(None, description="Фильтр по ID датасета"),
+    model_status: Optional[str] = Query(None, alias="status", description="Фильтр по статусу модели"),
     manager: MlModelsManager = Depends(get_ml_models_manager)
 ):
-    """Получить полную информацию о моделях"""
+    """
+    Получить полную информацию о моделях (свежие сверху).
+
+    Опционально фильтрует по датасету и/или статусу. Всегда возвращает 200 с
+    JSON-списком; при отсутствии моделей список пустой.
+    """
 
     # Получение моделей
-    models = manager.get_model()
+    models = manager.get_model(dataset_id=dataset_id, status=model_status)
 
     if models is None:
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
+        return MLModels(models=[])
 
-    models = [MLModel(**model) for model in models]
-    model = MLModels(models=models)
-
-    return model
+    return MLModels(models=[MLModel(**model) for model in models])
 
 @routers.post(
     "",
@@ -159,27 +164,35 @@ async def update_model(
             detail=f"Модель с ID {model_id} не найдена"
         )
 
-    try:
-        # Получаем словарь без None значений
-        update_dict = update_data.model_dump(exclude_none=True)
-        
-        if not update_dict:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Нет данных для обновления"
-            )
+    # Получаем словарь без None значений
+    update_dict = update_data.model_dump(exclude_none=True)
 
+    if not update_dict:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Нет данных для обновления"
+        )
+
+    # Проверка существования модели до обновления
+    if manager.get_model(model_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Модель с ID {model_id} не найдена"
+        )
+
+    try:
         # Выполняем обновление
         updated_model = manager.update_model(model_id, update_dict)
-        
-        if updated_model:
-            return Response(
-                status_code=200
-            )
-        else:
-            raise
     except ValueError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(e)
-            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
+    if not updated_model:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Модель с ID {model_id} не найдена"
+        )
+
+    return Response(status_code=200)

--- a/services/ml_models/app/api/schemas/ml_models.py
+++ b/services/ml_models/app/api/schemas/ml_models.py
@@ -2,25 +2,28 @@ from pydantic import BaseModel, Field
 from datetime import datetime
 from typing import Optional, List, Dict, Any
 
-class MLModelsStatistics(BaseModel):
-    """Статситика по моделям"""
-    total: int = Field(..., description="Общее поличество моделей")
-    by_status: List[MLModelsCountByStatus] = Field(..., description="Распределение моделей по статусам")
-
-class MLModelsCountByStatus(BaseModel):
-    """Информация о количестве моделей с """
-    status: MLModelStatus = Field(..., description="Информация о статусе")
-    count: int = Field(..., description="Количество моделей в данном статусе")
-
 class MLModelStatus(BaseModel):
     """Информация о статусe модели"""
     id: int = Field(..., description="ID статуса")
     status: str = Field(..., description="Статус модели")
     description: Optional[str] = Field(None, description="Описание статуса")
 
+class MLModelsCountByStatus(BaseModel):
+    """Количество моделей в конкретном статусе"""
+    status: MLModelStatus = Field(..., description="Информация о статусе")
+    count: int = Field(..., description="Количество моделей в данном статусе")
+
+class MLModelsStatistics(BaseModel):
+    """Статистика по моделям"""
+    total: int = Field(..., description="Общее количество моделей")
+    by_status: List[MLModelsCountByStatus] = Field(..., description="Распределение моделей по статусам")
+
 class MLModels(BaseModel):
-    """ML модели"""
+    """ML модели с метаданными пагинации"""
     models: List[MLModel] = Field(..., description="Список ML моделей")
+    total: int = Field(0, description="Общее количество моделей с учётом фильтров")
+    limit: Optional[int] = Field(None, description="Размер страницы из запроса (None - пагинация не применялась)")
+    offset: int = Field(0, description="Смещение из запроса")
 
 class MLModel(BaseModel):
     """Полная схема ML модели"""
@@ -30,7 +33,7 @@ class MLModel(BaseModel):
     model_type: str
     status: str = Field(..., description="Статус модели")
     description: Optional[str] = Field(None, description="Описание модели")
-    metrics_result: str = Field(..., description="Описание метрик модели")
+    metrics_report: str = Field(..., description="Описание метрик модели")
     classes: List[str] = Field(..., description="Список классов")
     train_params: Dict[str, Any] = Field(..., description="Параметры обучения модели")
     created_at: datetime = Field(..., description="Создание модели")
@@ -45,11 +48,11 @@ class MLModel(BaseModel):
 
 class MLModelCreate(BaseModel):
     """Схема для создания ML модели"""
-    name: str
-    version: int
-    model_type: str
+    name: str = Field(..., min_length=1, description="Имя модели")
+    version: int = Field(..., ge=1, description="Версия модели (>= 1)")
+    model_type: str = Field(..., min_length=1, description="Тип модели")
     description: Optional[str] = None
-    classes: List[str]
+    classes: List[str] = Field(..., min_length=1, description="Список классов (непустой)")
     train_params: Dict[str, Any]
     dataset_id: str
     dataset_version_id: str
@@ -60,7 +63,7 @@ class MLModelUpdate(BaseModel):
     """Схема для обновления ML модели"""
     status: Optional[str] = None
     description: Optional[str] = None
-    metrics_result: Optional[str] = None
+    metrics_report: Optional[str] = None
     train_params: Optional[Dict[str, Any]] = None
     framework: Optional[str] = None
     framework_version: Optional[str] = None

--- a/services/ml_models/app/core/files.py
+++ b/services/ml_models/app/core/files.py
@@ -23,25 +23,35 @@ class FilesManager:
     ):
         """Сохранение файла"""
         try:
+            # Санитизация имени: только basename, без обхода директорий
+            safe_name = Path(file.filename or "").name
+            if not safe_name or safe_name in (".", ".."):
+                raise ValueError(f"Некорректное имя файла: {file.filename!r}")
+
             # переходим в папку по id модели и загружаем новые файлы
             model_dir = self._get_model_dir(model_id)
 
-            file_path = model_dir / str(file.filename)
+            file_path = model_dir / safe_name
             if file_path.exists():
                 raise FileExistsError("Файл уже сущестует")
-            
+
             # Сохраняем новые файлы
             with open(file_path, "wb") as buffer:
                 shutil.copyfileobj(file.file, buffer)
-            
+
+            # В БД храним путь относительно storage_dir (устойчив к переезду);
+            # размер считаем из абсолютного пути
+            rel_path = file_path.relative_to(self.storage_dir)
+            file_size = file_path.stat().st_size
             self._add_info_file(
-                model_id, 
-                str(file.filename), 
-                file_path
+                model_id,
+                safe_name,
+                str(rel_path),
+                file_size
             )
 
-            logger.info(f"Сохранён файл: {file.filename} для модели '{model_id}'")
-        except FileExistsError as e:
+            logger.info(f"Сохранён файл: {safe_name} для модели '{model_id}'")
+        except (FileExistsError, ValueError) as e:
             logger.error(f"Ошибка при сохранении нового файла '{file.filename}' для '{model_id}': {e}")
             raise e
         except Exception as e:
@@ -92,12 +102,12 @@ class FilesManager:
             file_ids: Список ID файлов для удаления (если не указывать, удаляет все файлы
         """
         model_dir = self._get_model_dir(model_id)
-        
+
         if id_files:
-            
+
             pl = ', '.join(['%s::uuid' for _ in id_files])
             query = f"""
-                SELECT file_path
+                SELECT filename
                 FROM ml_model_files
                 WHERE model_id = %s AND id IN ({pl})
             """
@@ -105,7 +115,7 @@ class FilesManager:
                 files = db.fetch_all(query, (model_id, *id_files))
         else:
             query = """
-                SELECT file_path
+                SELECT filename
                 FROM ml_model_files
                 WHERE model_id = %s
             """
@@ -113,7 +123,8 @@ class FilesManager:
                 files = db.fetch_all(query, (model_id,))
 
         for file_row in files:
-            file_path = Path(file_row[0])
+            # путь реконструируем из storage_dir/model_id/filename
+            file_path = model_dir / file_row[0]
             if file_path.exists():
                 file_path.unlink()
                 logger.info(f"Удалён файл: {file_path}")
@@ -173,6 +184,18 @@ class FilesManager:
                 logger.info(f"Удалено {deleted_count} записей о файлах для модели {model_id}")
                 return deleted_count
 
+    def drop_model_dir(self, model_id: str) -> None:
+        """
+        Полностью удалить директорию модели с диска.
+
+        Вызывается при удалении модели: FK CASCADE убирает записи о файлах из БД,
+        а физические файлы и директорию нужно удалить отдельно.
+        """
+        model_dir = self.storage_dir / str(model_id)
+        if model_dir.exists():
+            shutil.rmtree(model_dir, ignore_errors=True)
+            logger.info(f"Удалена директория файлов модели {model_id}")
+
     def _get_model_dir(self, model_id: str) -> Path:
         """Получить путь к папке модели"""
         model_dir = self.storage_dir / model_id
@@ -180,19 +203,18 @@ class FilesManager:
         return model_dir
     
     def _add_info_file(
-        self, 
+        self,
         model_id: str,
         filename: str,
-        file_path: Path
+        file_path: str,
+        file_size: int
     ):
-        """Добавляем в БД информацию о файле"""
+        """Добавляем в БД информацию о файле (file_path — относительно storage_dir)"""
         query = """
             INSERT INTO ml_model_files (model_id, filename, file_path, file_size)
             VALUES (%s, %s, %s, %s)
             RETURNING id
         """
-
-        file_size = file_path.stat().st_size
 
         with self.db as db:
             result = db.fetch_one(
@@ -220,21 +242,22 @@ class FilesManager:
         """Получить путь к файлу по его ID и его имя"""
 
         query = """
-            SELECT file_path, filename
+            SELECT model_id, filename
             FROM ml_model_files
             WHERE id = %s
         """
-        
+
         with self.db as db:
             result = db.fetch_one(query, (file_id,))
-            
+
             if not result:
                 raise ValueError(f"Файл с ID {file_id} не найден")
-            
-            file_path_str, filename = result
-            file_path = Path(file_path_str)
-            
+
+            model_id, filename = result
+            # путь реконструируем из storage_dir/model_id/filename
+            file_path = self.storage_dir / str(model_id) / filename
+
             if not file_path.exists():
                 raise ValueError(f"Физический файл не найден: {filename}")
-            
+
             return file_path, filename

--- a/services/ml_models/app/core/postresql.py
+++ b/services/ml_models/app/core/postresql.py
@@ -1,5 +1,8 @@
+import threading
+
 import psycopg2
 from psycopg2 import OperationalError
+from psycopg2.pool import ThreadedConnectionPool
 
 from app.logs import get_logger
 
@@ -7,64 +10,79 @@ logger = get_logger(__name__)
 
 
 class PostgresManager:
-    """Базовый класс для работы с PostgreSQL"""
-    
-    def __init__(self, url: str):
+    """
+    Базовый класс для работы с PostgreSQL через пул соединений.
+
+    Пул общий для всех экземпляров с одним URL (class-level). Состояние
+    соединения хранится в thread-local, поэтому конкурентные запросы (sync-роуты
+    FastAPI бегут в threadpool) не делят один курсор. Интерфейс прежний:
+    `with self.db as db: db.fetch_all(...)`.
+    """
+
+    _pool: ThreadedConnectionPool | None = None
+    _pool_lock = threading.Lock()
+
+    def __init__(self, url: str, minconn: int = 1, maxconn: int = 10):
         self.url = url
-    
-    def connect(self):
-        """Подключение к БД"""
-        try:
-            self.conn = psycopg2.connect(self.url)
-            self.cursor = self.conn.cursor()
-            logger.info("✅ Подключено к PostgreSQL")
-        except OperationalError as e:
-            logger.error(f"Ошибка подключения: {e}")
-            raise
-    
-    def disconnect(self):
-        """Отключение от БД"""
-        if self.cursor:
-            self.cursor.close()
-        if self.conn:
-            self.conn.close()
-    
+        self._local = threading.local()
+
+        if PostgresManager._pool is None:
+            with PostgresManager._pool_lock:
+                if PostgresManager._pool is None:
+                    try:
+                        PostgresManager._pool = ThreadedConnectionPool(
+                            minconn, maxconn, dsn=url
+                        )
+                        logger.info("✅ Создан пул соединений PostgreSQL")
+                    except OperationalError as e:
+                        logger.error(f"Ошибка создания пула соединений: {e}")
+                        raise
+
     def execute(
-            self, 
-            query: str, 
+            self,
+            query: str,
             params: tuple | None = None
     ):
         """Выполнить запрос"""
         try:
-            self.cursor.execute(query, params)
-            self.conn.commit()
+            self._local.cursor.execute(query, params)
+            self._local.conn.commit()
         except Exception as e:
-            self.conn.rollback()
+            self._local.conn.rollback()
             logger.error(f"Ошибка выполнение запроса:\nQuery:\n{query}\n\nParams:\n{params}\n\nError:\n{e}")
             raise
-    
+
     def fetch_one(
-            self, 
-            query: str, 
+            self,
+            query: str,
             params: tuple | None = None
     ):
         """Выполнить запрос и вернуть одну строку"""
         self.execute(query, params)
-        return self.cursor.fetchone()
-    
+        return self._local.cursor.fetchone()
+
     def fetch_all(
-            self, 
-            query: str, 
+            self,
+            query: str,
             params: tuple | None = None
     ):
         """Выполнить запрос и вернуть все строки"""
         self.execute(query, params)
-        return self.cursor.fetchall()
-    
+        return self._local.cursor.fetchall()
+
     def __enter__(self):
-        self.connect()
+        conn = PostgresManager._pool.getconn()
+        self._local.conn = conn
+        self._local.cursor = conn.cursor()
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.disconnect()
+        cursor = getattr(self._local, "cursor", None)
+        conn = getattr(self._local, "conn", None)
+        if cursor is not None:
+            cursor.close()
+        if conn is not None:
+            PostgresManager._pool.putconn(conn)
+        self._local.cursor = None
+        self._local.conn = None
         return False

--- a/services/ml_models/app/core/train_models_tasks.py
+++ b/services/ml_models/app/core/train_models_tasks.py
@@ -46,11 +46,71 @@ class MlModelsManager:
         """Выводит количество имеющихся моделей"""
         query = f"""
             SELECT COUNT(id)
-            FROM {self._models_table} 
+            FROM {self._models_table}
         """
         with self.db as db:
             result = db.fetch_one(query)
             return result[0] if result else 0
+
+    def count_model(
+        self,
+        dataset_id: str | None = None,
+        status: str | None = None,
+        name: str | None = None
+    ) -> int:
+        """Количество моделей с учётом тех же фильтров, что и get_model (для пагинации)"""
+        query = f"""
+            SELECT COUNT(m.id)
+            FROM {self._models_table} m
+            LEFT JOIN {self._statuses_models_table} s ON m.status_id = s.id
+        """
+
+        conditions = []
+        params: list = []
+        if dataset_id:
+            conditions.append("m.dataset_id = %s")
+            params.append(dataset_id)
+        if status:
+            conditions.append("s.status = %s")
+            params.append(status)
+        if name:
+            conditions.append("m.name = %s")
+            params.append(name)
+
+        if conditions:
+            query += "WHERE " + " AND ".join(conditions) + "\n"
+
+        with self.db as db:
+            result = db.fetch_one(query, tuple(params) if params else None)
+            return result[0] if result else 0
+
+    def get_statistics(self) -> Dict[str, Any]:
+        """
+        Статистика по моделям: общее количество и распределение по статусам.
+
+        Один запрос с группировкой по статусам (LEFT JOIN, чтобы статусы без
+        моделей тоже попадали с count=0).
+        """
+        query = f"""
+            SELECT s.id, s.status, s.description, COUNT(m.id)
+            FROM {self._statuses_models_table} s
+            LEFT JOIN {self._models_table} m ON m.status_id = s.id
+            GROUP BY s.id, s.status, s.description
+            ORDER BY s.id
+        """
+        with self.db as db:
+            rows = db.fetch_all(query)
+
+        by_status = [
+            {
+                "status": {"id": row[0], "status": row[1], "description": row[2]},
+                "count": row[3],
+            }
+            for row in rows
+        ]
+        total = sum(item["count"] for item in by_status)
+
+        return {"total": total, "by_status": by_status}
 
     def create(
             self, 
@@ -149,10 +209,6 @@ class MlModelsManager:
             if v is not None
         }
 
-        # Проверка существования модели
-        if self.get_model(str(model_id)) is None:
-            raise ValueError("")
-
         # Обработка статуса
         if data.get("status"):
             statuses = self.get_statuses_info()
@@ -212,13 +268,18 @@ class MlModelsManager:
         self,
         model_id: str | None = None,
         dataset_id: str | None = None,
-        status: str | None = None
+        status: str | None = None,
+        name: str | None = None,
+        limit: int | None = None,
+        offset: int = 0
     ) -> List[Dict[str, Any]] | None:
         """
         Получить полную информацию о моделях.
 
         Без фильтров возвращает все модели (свежие сверху). Опционально
-        фильтрует по model_id, dataset_id и/или статусу модели.
+        фильтрует по model_id, dataset_id, статусу и/или имени модели (name —
+        для получения всех версий модели). Если задан limit — применяется
+        пагинация (LIMIT/OFFSET).
         """
 
         query = f"""
@@ -229,7 +290,7 @@ class MlModelsManager:
                 m.model_type,
                 s.status as status,
                 m.description,
-                m.metrics_result,
+                m.metrics_report,
                 m.classes,
                 m.train_params,
                 m.created_at,
@@ -252,11 +313,19 @@ class MlModelsManager:
         if status:
             conditions.append("s.status = %s")
             params.append(status)
+        if name:
+            conditions.append("m.name = %s")
+            params.append(name)
 
         if conditions:
             query += "WHERE " + " AND ".join(conditions) + "\n"
 
         query += "ORDER BY m.created_at DESC\n"
+
+        if limit is not None:
+            query += "LIMIT %s OFFSET %s\n"
+            params.append(limit)
+            params.append(offset)
 
         with self.db as db:
             rows = db.fetch_all(query, tuple(params) if params else None)
@@ -280,7 +349,7 @@ class MlModelsManager:
             'model_type': row[3],
             'status': row[4],
             'description': row[5],
-            'metrics_result': row[6],
+            'metrics_report': row[6],
             'classes': row[7],
             'train_params': row[8],
             'created_at': row[9],

--- a/services/ml_models/app/core/train_models_tasks.py
+++ b/services/ml_models/app/core/train_models_tasks.py
@@ -209,13 +209,20 @@ class MlModelsManager:
                 raise RuntimeError(f"Не удалось обновить модель: {e}")
 
     def get_model(
-        self, 
-        model_id: str | None = None
+        self,
+        model_id: str | None = None,
+        dataset_id: str | None = None,
+        status: str | None = None
     ) -> List[Dict[str, Any]] | None:
-        """Получить полную информацию о модели по ID"""
-        
+        """
+        Получить полную информацию о моделях.
+
+        Без фильтров возвращает все модели (свежие сверху). Опционально
+        фильтрует по model_id, dataset_id и/или статусу модели.
+        """
+
         query = f"""
-            SELECT 
+            SELECT
                 m.id,
                 m.name,
                 m.version,
@@ -233,22 +240,36 @@ class MlModelsManager:
             FROM {self._models_table} m
             LEFT JOIN {self._statuses_models_table} s ON m.status_id = s.id
         """
-        
+
+        conditions = []
+        params: list = []
         if model_id:
-            query += "WHERE m.id = %s\n"
-        
+            conditions.append("m.id = %s")
+            params.append(model_id)
+        if dataset_id:
+            conditions.append("m.dataset_id = %s")
+            params.append(dataset_id)
+        if status:
+            conditions.append("s.status = %s")
+            params.append(status)
+
+        if conditions:
+            query += "WHERE " + " AND ".join(conditions) + "\n"
+
+        query += "ORDER BY m.created_at DESC\n"
+
         with self.db as db:
-            rows = db.fetch_all(query, (model_id,))
-            
+            rows = db.fetch_all(query, tuple(params) if params else None)
+
             if len(rows) == 0:
                 return None
-                    
-            models = [
-                self._row_full_info_model_in_dict(row) 
-                for row in rows
-            ] 
 
-            return models 
+            models = [
+                self._row_full_info_model_in_dict(row)
+                for row in rows
+            ]
+
+            return models
     
     def _row_full_info_model_in_dict(self, row: tuple):
         """Преобразовать всю строчку из соединённой таблицы  """

--- a/services/ml_models/main.py
+++ b/services/ml_models/main.py
@@ -24,13 +24,15 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Настройка обработчиков ошибок БД (503) и неизвестных ошибок (500).
+# Должна выполняться на уровне модуля: при reload uvicorn импортирует "main:app"
+# в воркере, где __name__ != "__main__".
+setup_exception_handlers(app)
+
 if __name__ == "__main__":
     # Проверка состояния требуемых БД
     # НЕ БЛОКИРУЕТ ЗАПУСК ЕСЛИ ТРЕБУЕМЫЕ БД НЕ РАБОТАЮТ
     check_health_all()
-
-    # Настройка выкидывания ошибок с бд и ошибки 500
-    setup_exception_handlers(app)
 
     uvicorn.run(
         "main:app",


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
- Добавлен эндпоинт `GET /models/statistics` (всего моделей + распределение по статусам) и пагинация `GET /models` (`limit`/`offset`/`total`)
- Добавлены фильтры списка моделей по `dataset_id`, `status` и `name` (все версии модели); `GET /models` всегда возвращает 200 + JSON-список (вместо 204), свежие сверху
- `PostgresManager` переведён на пул соединений (`ThreadedConnectionPool`) с потокобезопасной изоляцией через thread-local
- Хранилище файлов: при удалении модели чистятся файлы с диска, имена файлов санитизируются (защита от path traversal), путь хранится относительно `storage_dir`
- Файловые ручки `add_file`/`del_file` проверяют существование модели → 404 без создания директории-мусора
- Усилена валидация `MLModelCreate` (`version >= 1`, непустые `name`/`model_type`/`classes`) → 422 вместо ошибки БД
- Рефактор: валидация UUID вынесена в зависимость `Depends`, `PATCH` выполняется одним запросом, активированы обработчики ошибок 503/500
- Всем эндпоинтам добавлены описания (`summary`/`description`/`response_description`) в стиле сервиса датасетов
- Поле `metrics_result` переименовано в `metrics_report` (схемы, БД-колонка, запросы)
