### PR TITLE
Frontend/feat/ml models

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import Footer from './components/layout/Footer';
 
 import Home from './pages/Home';
 import Datasets from './pages/Datasets';
+import DatasetDetail from './pages/DatasetDetail';
 import Models from './pages/Models';
 import ModelDetail from './pages/ModelDetail';
 import Agents from './pages/Agents';
@@ -35,6 +36,7 @@ function App() {
               */}
               <Route path="/" element={<Home />} />
               <Route path="/datasets" element={<Datasets />} />
+              <Route path="/datasets/:id" element={<DatasetDetail />} />
               <Route path="/models" element={<Models />} />
               <Route path="/models/:id" element={<ModelDetail />} />
               <Route path="/agents" element={<Agents />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,7 @@ function App() {
       <BrowserRouter>
         <div className="app-wrapper">
           <Header />
-          <main className="main-content">
+          <main id="main-content" className="main-content">
             <Routes>
               {/*
                 Route определяет соответствие между путём URL и компонентом,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import DatasetDetail from './pages/DatasetDetail';
 import Models from './pages/Models';
 import ModelDetail from './pages/ModelDetail';
 import Agents from './pages/Agents';
+import AgentDiscussion from './pages/AgentDiscussion';
 
 import './styles/App.css';
 
@@ -40,6 +41,7 @@ function App() {
               <Route path="/models" element={<Models />} />
               <Route path="/models/:id" element={<ModelDetail />} />
               <Route path="/agents" element={<Agents />} />
+              <Route path="/agents/discussion/:discussionId" element={<AgentDiscussion />} />
             </Routes>
           </main>
           <Footer />

--- a/frontend/src/components/FileUploader.css
+++ b/frontend/src/components/FileUploader.css
@@ -34,6 +34,7 @@
 .upload-icon {
   font-size: 2.5rem;
   margin-bottom: 0.5rem;
+  color: var(--color-accent);
 }
 
 .browse-link {
@@ -68,6 +69,7 @@
 
 .file-icon {
   font-size: 2rem;
+  color: var(--color-accent);
 }
 
 .file-details {

--- a/frontend/src/components/FileUploader.tsx
+++ b/frontend/src/components/FileUploader.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import './FileUploader.css';
 import { formatBytes } from '../utils/format';
+import { ICONS } from '../constants/icons';
 
 interface FileUploaderProps {
   onFileSelect: (file: File | null) => void;
@@ -63,18 +64,18 @@ const FileUploader: React.FC<FileUploaderProps> = ({
   const getFileIcon = (fileName: string) => {
     const ext = fileName.split('.').pop()?.toLowerCase();
     if (ext === 'zip' || ext === 'rar' || ext === '7z' || ext === 'tar' || ext === 'gz') {
-      return '📦';
+      return ICONS.fileArchive;
     }
     if (ext === 'jpg' || ext === 'jpeg' || ext === 'png' || ext === 'gif' || ext === 'svg') {
-      return '🖼️';
+      return ICONS.fileImage;
     }
     if (ext === 'csv' || ext === 'xlsx' || ext === 'xls') {
-      return '📊';
+      return ICONS.fileTable;
     }
     if (ext === 'txt' || ext === 'md') {
-      return '📄';
+      return ICONS.fileText;
     }
-    return '📁';
+    return ICONS.file;
   };
 
   return (
@@ -96,7 +97,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({
             style={{ display: 'none' }}
           />
           <div className="drop-zone-content">
-            <span className="upload-icon">📤</span>
+            <span className="upload-icon"><i className={`fas ${ICONS.upload}`}></i></span>
             <p>Перетащите файл сюда или <span className="browse-link">выберите</span></p>
             <p className="file-hint">Поддерживаются: {accept.split(',').join(', ')}</p>
           </div>
@@ -104,14 +105,14 @@ const FileUploader: React.FC<FileUploaderProps> = ({
       ) : (
         <div className="file-preview">
           <div className="file-info">
-            <span className="file-icon">{getFileIcon(currentFile.name)}</span>
+            <span className="file-icon"><i className={`fas ${getFileIcon(currentFile.name)}`}></i></span>
             <div className="file-details">
               <p className="file-name">{currentFile.name}</p>
               <p className="file-size">{formatBytes(currentFile.size)}</p>
             </div>
           </div>
           <button className="remove-file" onClick={handleRemove} title="Удалить файл">
-            <i className="fas fa-times"></i>
+            <i className={`fas ${ICONS.close}`}></i>
           </button>
         </div>
       )}

--- a/frontend/src/components/agents/DiscussionCard.tsx
+++ b/frontend/src/components/agents/DiscussionCard.tsx
@@ -3,6 +3,7 @@ import type { DiscussionMeta } from '../../types/agentHistory';
 import { DISCUSSION_STATUS_LABELS, getDiscussionTitle, getDiscussionAgents } from '../../types/agentHistory';
 import { formatDateTime } from '../../utils/format';
 import { useCopyToClipboard } from '../../hooks';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   discussion: DiscussionMeta;
@@ -43,7 +44,7 @@ const DiscussionCard: React.FC<Props> = ({ discussion, onSelect, onDelete }) => 
         <div className="discussion-title-group">
           {discussion.pipeline && (
             <span className="discussion-badge">
-              <i className="fas fa-diagram-project"></i> {discussion.pipeline}
+              <i className={`fas ${ICONS.pipeline}`}></i> {discussion.pipeline}
             </span>
           )}
           <h2>{title}</h2>
@@ -52,8 +53,8 @@ const DiscussionCard: React.FC<Props> = ({ discussion, onSelect, onDelete }) => 
             title="Нажмите, чтобы скопировать ID"
             onClick={handleCopyId}
           >
-            <i className="fas fa-hashtag"></i>{discussion.discussion_id}
-            <i className="fas fa-copy discussion-id-copy-icon"></i>
+            <i className={`fas ${ICONS.id}`}></i>{discussion.discussion_id}
+            <i className={`fas ${ICONS.copy} discussion-id-copy-icon`}></i>
           </span>
         </div>
         <div className="discussion-card-actions">
@@ -66,27 +67,27 @@ const DiscussionCard: React.FC<Props> = ({ discussion, onSelect, onDelete }) => 
             aria-label="Удалить диалог"
             onClick={handleDelete}
           >
-            <i className="fas fa-trash"></i>
+            <i className={`fas ${ICONS.delete}`}></i>
           </button>
         </div>
       </div>
 
       <div className="discussion-meta">
         {agentsCount > 0 && (
-          <span><i className="fas fa-users"></i> Агентов: {agentsCount}</span>
+          <span><i className={`fas ${ICONS.agentsGroup}`}></i> Агентов: {agentsCount}</span>
         )}
         {discussion.responses_count != null && (
-          <span><i className="fas fa-comments"></i> Ответов: {discussion.responses_count}</span>
+          <span><i className={`fas ${ICONS.discussion}`}></i> Ответов: {discussion.responses_count}</span>
         )}
         {discussion.tool_calls_count != null && discussion.tool_calls_count > 0 && (
-          <span><i className="fas fa-wrench"></i> Вызовов: {discussion.tool_calls_count}</span>
+          <span><i className={`fas ${ICONS.tools}`}></i> Вызовов: {discussion.tool_calls_count}</span>
         )}
       </div>
 
       <div className="discussion-meta discussion-meta--dates">
-        <span title="Время старта"><i className="fas fa-calendar-alt"></i> Время старта: {formatDateTime(discussion.created_at)}</span>
+        <span title="Время старта"><i className={`fas ${ICONS.dateCreated}`}></i> Время старта: {formatDateTime(discussion.created_at)}</span>
         {discussion.finished_at && (
-          <span title="Время завершения"><i className="fas fa-flag-checkered"></i> Время завершения: {formatDateTime(discussion.finished_at)}</span>
+          <span title="Время завершения"><i className={`fas ${ICONS.dateFinished}`}></i> Время завершения: {formatDateTime(discussion.finished_at)}</span>
         )}
       </div>
 

--- a/frontend/src/components/agents/DiscussionCard.tsx
+++ b/frontend/src/components/agents/DiscussionCard.tsx
@@ -1,10 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { DiscussionMeta } from '../../types/agentHistory';
 import { DISCUSSION_STATUS_LABELS, getDiscussionTitle, getDiscussionAgents } from '../../types/agentHistory';
 import { formatDateTime } from '../../utils/format';
 import { useCopyToClipboard } from '../../hooks';
-import { CollapseChevron } from '../common/Collapse';
-import { DISCUSSION_AGENTS_LIMIT } from '../../constants';
 
 interface Props {
   discussion: DiscussionMeta;
@@ -14,152 +12,91 @@ interface Props {
 
 const DiscussionCard: React.FC<Props> = ({ discussion, onSelect, onDelete }) => {
   const title = getDiscussionTitle(discussion);
-  const [agentsExpanded, setAgentsExpanded] = useState(false);
-  const [collapsed, setCollapsed] = useState(true);
   const copyToClipboard = useCopyToClipboard();
+  const open = () => onSelect(discussion.discussion_id);
+  const agentsCount = getDiscussionAgents(discussion).length;
 
   const handleCopyId = (e: React.MouseEvent) => {
     e.stopPropagation();
     copyToClipboard(discussion.discussion_id);
   };
 
-  // Список агентов берём из агрегата; если его нет — из заявленных ролей meta.
-  const agents = getDiscussionAgents(discussion);
-  const visibleAgents = agentsExpanded ? agents : agents.slice(0, DISCUSSION_AGENTS_LIMIT);
-  const hiddenCount = agents.length - visibleAgents.length;
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete(discussion.discussion_id);
+  };
 
   return (
-    <div className={`card discussion-card${collapsed ? ' discussion-card--collapsed' : ''}`}>
-      <div className="discussion-card-header" onClick={() => setCollapsed(c => !c)} aria-expanded={!collapsed}>
+    <div
+      className="card card--hoverable discussion-card"
+      onClick={open}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          open();
+        }
+      }}
+    >
+      <div className="discussion-card-header">
         <div className="discussion-title-group">
-          <CollapseChevron open={!collapsed} />
-          <div className="discussion-title-inner">
-            <h2
-              className="discussion-card-title"
-              onClick={(e) => { e.stopPropagation(); onSelect(discussion.discussion_id); }}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  onSelect(discussion.discussion_id);
-                }
-              }}
-            >{title}</h2>
-            <span
-              className="discussion-id discussion-id--copyable"
-              title="Нажмите, чтобы скопировать ID"
-              onClick={handleCopyId}
-            >
-              <i className="fas fa-hashtag"></i>{discussion.discussion_id}
-              <i className="fas fa-copy discussion-id-copy-icon"></i>
+          {discussion.pipeline && (
+            <span className="discussion-badge">
+              <i className="fas fa-diagram-project"></i> {discussion.pipeline}
             </span>
-            {collapsed && (
-              <div className="discussion-card-summary">
-                {discussion.pipeline && (
-                  <span><i className="fas fa-diagram-project"></i> {discussion.pipeline}</span>
-                )}
-                <span><i className="fas fa-calendar-alt"></i> {formatDateTime(discussion.created_at)}</span>
-                {discussion.finished_at && (
-                  <span><i className="fas fa-flag-checkered"></i> {formatDateTime(discussion.finished_at)}</span>
-                )}
-              </div>
-            )}
-          </div>
+          )}
+          <h2>{title}</h2>
+          <span
+            className="discussion-id"
+            title="Нажмите, чтобы скопировать ID"
+            onClick={handleCopyId}
+          >
+            <i className="fas fa-hashtag"></i>{discussion.discussion_id}
+            <i className="fas fa-copy discussion-id-copy-icon"></i>
+          </span>
         </div>
         <div className="discussion-card-actions">
           <span className={`status-badge status-${discussion.status}`}>
             {DISCUSSION_STATUS_LABELS[discussion.status]}
           </span>
           <button
-            className="icon-button"
+            className="icon-button icon-button--danger"
             title="Удалить диалог"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete(discussion.discussion_id);
-            }}
+            aria-label="Удалить диалог"
+            onClick={handleDelete}
           >
             <i className="fas fa-trash"></i>
           </button>
         </div>
       </div>
 
-      {!collapsed && (
-        <>
-          <div className="discussion-meta">
-            {discussion.pipeline && (
-              <span><i className="fas fa-diagram-project"></i> {discussion.pipeline}</span>
-            )}
-            <span><i className="fas fa-calendar-alt"></i> {formatDateTime(discussion.created_at)}</span>
-            {discussion.finished_at && (
-              <span><i className="fas fa-flag-checkered"></i> {formatDateTime(discussion.finished_at)}</span>
-            )}
-          </div>
-          {(discussion.responses_count != null || (discussion.tool_calls_count != null && discussion.tool_calls_count > 0)) && (
-            <div className="discussion-meta">
-              {discussion.responses_count != null && (
-                <span><i className="fas fa-comments"></i> {discussion.responses_count} ответов</span>
-              )}
-              {discussion.tool_calls_count != null && discussion.tool_calls_count > 0 && (
-                <span><i className="fas fa-wrench"></i> {discussion.tool_calls_count} вызовов</span>
-              )}
-            </div>
-          )}
+      <div className="discussion-meta">
+        {agentsCount > 0 && (
+          <span><i className="fas fa-users"></i> Агентов: {agentsCount}</span>
+        )}
+        {discussion.responses_count != null && (
+          <span><i className="fas fa-comments"></i> Ответов: {discussion.responses_count}</span>
+        )}
+        {discussion.tool_calls_count != null && discussion.tool_calls_count > 0 && (
+          <span><i className="fas fa-wrench"></i> Вызовов: {discussion.tool_calls_count}</span>
+        )}
+      </div>
 
-          {agents.length > 0 && (
-            <div className="discussion-agents-section">
-              <h4 className="discussion-section-title">
-                <i className="fas fa-users"></i> Агенты ({agents.length})
-              </h4>
-              <div className="discussion-agents">
-                {visibleAgents.map(agent => (
-                  <div key={agent.role} className="agent-card">
-                    <span className="agent-card-avatar">
-                      <i className="fas fa-robot"></i>
-                    </span>
-                    <div className="agent-card-body">
-                      <span className="agent-card-role" title={agent.role}>{agent.role}</span>
-                      {agent.models.length > 0 && (
-                        <div className="agent-card-models">
-                          {agent.models.map(model => (
-                            <span key={model} className="agent-model-badge" title={model}>
-                              <i className="fas fa-brain"></i>
-                              <span className="agent-model-text">{model}</span>
-                            </span>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                ))}
-                {hiddenCount > 0 && (
-                  <button
-                    className="agents-more"
-                    onClick={(e) => { e.stopPropagation(); setAgentsExpanded(true); }}
-                  >
-                    +{hiddenCount} ещё
-                  </button>
-                )}
-                {agentsExpanded && agents.length > DISCUSSION_AGENTS_LIMIT && (
-                  <button
-                    className="agents-more"
-                    onClick={(e) => { e.stopPropagation(); setAgentsExpanded(false); }}
-                  >
-                    свернуть
-                  </button>
-                )}
-              </div>
-            </div>
-          )}
+      <div className="discussion-meta discussion-meta--dates">
+        <span title="Время старта"><i className="fas fa-calendar-alt"></i> Время старта: {formatDateTime(discussion.created_at)}</span>
+        {discussion.finished_at && (
+          <span title="Время завершения"><i className="fas fa-flag-checkered"></i> Время завершения: {formatDateTime(discussion.finished_at)}</span>
+        )}
+      </div>
 
-          {discussion.tags.length > 0 && (
-            <div className="discussion-tags">
-              {discussion.tags.map(tag => (
-                <span key={tag} className="tag">{tag}</span>
-              ))}
-            </div>
-          )}
-        </>
+      {discussion.tags.length > 0 && (
+        <div className="discussion-tags">
+          <span className="discussion-tags-label">Теги:</span>
+          {discussion.tags.map(tag => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/agents/DiscussionDetail.tsx
+++ b/frontend/src/components/agents/DiscussionDetail.tsx
@@ -33,7 +33,7 @@ const DiscussionDetail: React.FC<Props> = ({ discussionId, onBack }) => {
 
   return (
     <div className="discussion-detail">
-      <button className="button secondary small back-button" onClick={onBack}>
+      <button className="detail-back-link" onClick={onBack}>
         <i className="fas fa-arrow-left"></i> Назад к списку
       </button>
       <DiscussionInfo discussion={meta ?? null} discussionId={discussionId} />

--- a/frontend/src/components/agents/DiscussionDetail.tsx
+++ b/frontend/src/components/agents/DiscussionDetail.tsx
@@ -5,6 +5,7 @@ import { usePolling } from '../../hooks';
 import { POLL_INTERVAL_DISCUSSION_MS } from '../../constants';
 import DiscussionInfo from './DiscussionInfo';
 import DiscussionView from './DiscussionView';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   discussionId: string;
@@ -34,7 +35,7 @@ const DiscussionDetail: React.FC<Props> = ({ discussionId, onBack }) => {
   return (
     <div className="discussion-detail">
       <button className="detail-back-link" onClick={onBack}>
-        <i className="fas fa-arrow-left"></i> Назад к списку
+        <i className={`fas ${ICONS.back}`}></i> Назад к списку
       </button>
       <DiscussionInfo discussion={meta ?? null} discussionId={discussionId} />
       <DiscussionView discussionId={discussionId} active={isActive} />

--- a/frontend/src/components/agents/DiscussionHistory.tsx
+++ b/frontend/src/components/agents/DiscussionHistory.tsx
@@ -1,28 +1,23 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { agentHistoryService } from '../../services/agentHistoryService';
 import type { DiscussionMeta } from '../../types/agentHistory';
 import { useNotification } from '../../contexts/NotificationContext';
 import ConfirmModal from '../common/ConfirmModal';
 import DiscussionCard from './DiscussionCard';
-import DiscussionDetail from './DiscussionDetail';
 
 const DiscussionHistory: React.FC = () => {
   const { showNotification } = useNotification();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
-  // Выбранная дискуссия хранится в URL (?discussion=<id>), чтобы работала
-  // нативная кнопка «Назад» браузера.
-  const selectedId = searchParams.get('discussion');
 
   const [discussions, setDiscussions] = useState<DiscussionMeta[]>([]);
   const [loading, setLoading] = useState(false);
   // Дискуссия, ожидающая подтверждения удаления.
   const [pendingDelete, setPendingDelete] = useState<DiscussionMeta | null>(null);
 
-  // Открыть дискуссию — добавляем запись в историю браузера.
+  // Открыть дискуссию — переход на отдельную страницу детального просмотра.
   const openDiscussion = (discussionId: string) => {
-    setSearchParams({ discussion: discussionId });
+    navigate(`/agents/discussion/${discussionId}`);
   };
 
   useEffect(() => {
@@ -55,18 +50,11 @@ const DiscussionHistory: React.FC = () => {
     try {
       await agentHistoryService.deleteDiscussion(discussionId);
       setDiscussions(prev => prev.filter(d => d.discussion_id !== discussionId));
-      // Если удаляем открытую дискуссию — убираем её из URL без новой записи в истории.
-      if (selectedId === discussionId) setSearchParams({}, { replace: true });
       showNotification('Диалог удалён', 'success');
     } catch (err) {
       showNotification(err instanceof Error ? err.message : 'Ошибка удаления диалога', 'error');
     }
   };
-
-  // ── Детальный просмотр выбранной дискуссии ──────────────────────────────────
-  if (selectedId) {
-    return <DiscussionDetail discussionId={selectedId} onBack={() => navigate(-1)} />;
-  }
 
   // ── Список дискуссий ────────────────────────────────────────────────────────
   if (loading && discussions.length === 0) {

--- a/frontend/src/components/agents/DiscussionInfo.tsx
+++ b/frontend/src/components/agents/DiscussionInfo.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { DiscussionMeta } from '../../types/agentHistory';
 import { DISCUSSION_STATUS_LABELS, getDiscussionTitle, getDiscussionAgents } from '../../types/agentHistory';
 import { formatDateTime } from '../../utils/format';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   discussion: DiscussionMeta | null;
@@ -19,7 +20,7 @@ const DiscussionInfo: React.FC<Props> = ({ discussion, discussionId }) => {
           <div className="discussion-title-inner">
             <h2 className="discussion-detail-title">{title}</h2>
             <span className="discussion-id" title={discussionId}>
-              <i className="fas fa-hashtag"></i>{discussionId}
+              <i className={`fas ${ICONS.id}`}></i>{discussionId}
             </span>
           </div>
         </div>
@@ -38,14 +39,14 @@ const DiscussionInfo: React.FC<Props> = ({ discussion, discussionId }) => {
             <div className="discussion-stats">
               {discussion.responses_count != null && (
                 <div className="stat-chip">
-                  <i className="fas fa-comments"></i>
+                  <i className={`fas ${ICONS.discussion}`}></i>
                   <span className="stat-chip-value">{discussion.responses_count}</span>
                   <span className="stat-chip-label">ответов</span>
                 </div>
               )}
               {discussion.tool_calls_count != null && discussion.tool_calls_count > 0 && (
                 <div className="stat-chip">
-                  <i className="fas fa-wrench"></i>
+                  <i className={`fas ${ICONS.tools}`}></i>
                   <span className="stat-chip-value">{discussion.tool_calls_count}</span>
                   <span className="stat-chip-label">вызовов</span>
                 </div>
@@ -55,24 +56,24 @@ const DiscussionInfo: React.FC<Props> = ({ discussion, discussionId }) => {
 
           <div className="discussion-info-meta">
             {discussion.pipeline && (
-              <span><i className="fas fa-diagram-project"></i> {discussion.pipeline}</span>
+              <span><i className={`fas ${ICONS.pipeline}`}></i> {discussion.pipeline}</span>
             )}
-            <span><i className="fas fa-calendar-alt"></i> Создано: {formatDateTime(discussion.created_at)}</span>
+            <span><i className={`fas ${ICONS.dateCreated}`}></i> Создано: {formatDateTime(discussion.created_at)}</span>
             {discussion.finished_at && (
-              <span><i className="fas fa-flag-checkered"></i> Завершено: {formatDateTime(discussion.finished_at)}</span>
+              <span><i className={`fas ${ICONS.dateFinished}`}></i> Завершено: {formatDateTime(discussion.finished_at)}</span>
             )}
           </div>
 
           {agents.length > 0 && (
             <div className="discussion-agents-section">
               <h4 className="discussion-section-title">
-                <i className="fas fa-users"></i> Агенты ({agents.length})
+                <i className={`fas ${ICONS.agentsGroup}`}></i> Агенты ({agents.length})
               </h4>
               <div className="discussion-agents">
                 {agents.map(agent => (
                   <div key={agent.role} className="agent-card">
                     <span className="agent-card-avatar">
-                      <i className="fas fa-robot"></i>
+                      <i className={`fas ${ICONS.agent}`}></i>
                     </span>
                     <div className="agent-card-body">
                       <span className="agent-card-role" title={agent.role}>{agent.role}</span>
@@ -80,7 +81,7 @@ const DiscussionInfo: React.FC<Props> = ({ discussion, discussionId }) => {
                         <div className="agent-card-models">
                           {agent.models.map(model => (
                             <span key={model} className="agent-model-badge" title={model}>
-                              <i className="fas fa-brain"></i>
+                              <i className={`fas ${ICONS.agentModel}`}></i>
                               <span className="agent-model-text">{model}</span>
                             </span>
                           ))}

--- a/frontend/src/components/agents/DiscussionInfo.tsx
+++ b/frontend/src/components/agents/DiscussionInfo.tsx
@@ -25,6 +25,7 @@ const DiscussionInfo: React.FC<Props> = ({ discussion, discussionId }) => {
         </div>
         {discussion && (
           <span className={`status-badge status-${discussion.status}`}>
+            <span className={`status-dot ${discussion.status === 'active' ? 'status-dot--pulse' : ''}`} aria-hidden="true" />
             {DISCUSSION_STATUS_LABELS[discussion.status]}
           </span>
         )}
@@ -32,6 +33,26 @@ const DiscussionInfo: React.FC<Props> = ({ discussion, discussionId }) => {
 
       {discussion && (
         <>
+          {(discussion.responses_count != null ||
+            (discussion.tool_calls_count != null && discussion.tool_calls_count > 0)) && (
+            <div className="discussion-stats">
+              {discussion.responses_count != null && (
+                <div className="stat-chip">
+                  <i className="fas fa-comments"></i>
+                  <span className="stat-chip-value">{discussion.responses_count}</span>
+                  <span className="stat-chip-label">ответов</span>
+                </div>
+              )}
+              {discussion.tool_calls_count != null && discussion.tool_calls_count > 0 && (
+                <div className="stat-chip">
+                  <i className="fas fa-wrench"></i>
+                  <span className="stat-chip-value">{discussion.tool_calls_count}</span>
+                  <span className="stat-chip-label">вызовов</span>
+                </div>
+              )}
+            </div>
+          )}
+
           <div className="discussion-info-meta">
             {discussion.pipeline && (
               <span><i className="fas fa-diagram-project"></i> {discussion.pipeline}</span>
@@ -39,12 +60,6 @@ const DiscussionInfo: React.FC<Props> = ({ discussion, discussionId }) => {
             <span><i className="fas fa-calendar-alt"></i> Создано: {formatDateTime(discussion.created_at)}</span>
             {discussion.finished_at && (
               <span><i className="fas fa-flag-checkered"></i> Завершено: {formatDateTime(discussion.finished_at)}</span>
-            )}
-            {discussion.responses_count != null && (
-              <span><i className="fas fa-comments"></i> {discussion.responses_count} ответов</span>
-            )}
-            {discussion.tool_calls_count != null && discussion.tool_calls_count > 0 && (
-              <span><i className="fas fa-wrench"></i> {discussion.tool_calls_count} вызовов</span>
             )}
           </div>
 

--- a/frontend/src/components/agents/DiscussionView.tsx
+++ b/frontend/src/components/agents/DiscussionView.tsx
@@ -47,7 +47,9 @@ const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
       continueWhile: () => active,
       onError: err =>
         showNotification(err instanceof Error ? err.message : 'Ошибка загрузки диалога', 'error'),
-      deps: [discussionId],
+      // active в deps: когда статус дискуссии становится active (meta догрузилась),
+      // цикл опроса перезапускается, иначе он умер бы после первого запроса.
+      deps: [discussionId, active],
     },
   );
 
@@ -57,7 +59,7 @@ const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
     return <div className="loading-state">Загрузка диалога...</div>;
   }
 
-  if (feed.length === 0) {
+  if (feed.length === 0 && !active) {
     return <p className="empty-state">В этой дискуссии пока нет сообщений.</p>;
   }
 
@@ -76,6 +78,13 @@ const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
             <span className="system-message-time">{formatDateTime(item.data.timestamp)}</span>
           </div>
         ),
+      )}
+
+      {active && (
+        <div className="discussion-running" role="status" aria-live="polite">
+          <i className="fas fa-spinner fa-spin"></i>
+          <span>Дискуссия в процессе...</span>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/agents/DiscussionView.tsx
+++ b/frontend/src/components/agents/DiscussionView.tsx
@@ -6,6 +6,7 @@ import { usePolling } from '../../hooks';
 import { POLL_INTERVAL_DISCUSSION_MS } from '../../constants';
 import { formatDateTime, statusClass } from '../../utils/format';
 import MessageBubble from './MessageBubble';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   discussionId: string;
@@ -20,9 +21,9 @@ type FeedItem =
 
 // Иконка системного сообщения по типу.
 const SYSTEM_ICONS: Record<SystemMessageType, string> = {
-  INFO: 'fa-circle-info',
-  WARNING: 'fa-triangle-exclamation',
-  ERROR: 'fa-circle-exclamation',
+  INFO: ICONS.info,
+  WARNING: ICONS.warning,
+  ERROR: ICONS.error,
 };
 
 const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
@@ -78,7 +79,7 @@ const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
   if (feed.length === 0 && !active) {
     return (
       <p className="empty-state">
-        <i className="fas fa-comment-slash"></i> В этой дискуссии пока нет сообщений.
+        <i className={`fas ${ICONS.noMessages}`}></i> В этой дискуссии пока нет сообщений.
       </p>
     );
   }
@@ -89,7 +90,7 @@ const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
         item.kind === 'response' ? (
           <div key={item.data.response_id} className="timeline-row timeline-row--response">
             <span className={`timeline-node ${statusClass(item.data.status)}`} aria-hidden="true">
-              <i className="fas fa-robot"></i>
+              <i className={`fas ${ICONS.agent}`}></i>
             </span>
             <div className="timeline-content">
               <MessageBubble discussionId={discussionId} response={item.data} />
@@ -117,11 +118,11 @@ const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
         <div className="timeline-row timeline-row--active" role="status" aria-live="polite">
           <span className="timeline-node timeline-node--active" aria-hidden="true">
             <span className="timeline-node-pulse"></span>
-            <i className="fas fa-robot"></i>
+            <i className={`fas ${ICONS.agent}`}></i>
           </span>
           <div className="timeline-content">
             <div className="discussion-running">
-              <i className="fas fa-spinner fa-spin"></i>
+              <i className={`fas ${ICONS.loading} fa-spin`}></i>
               <span>Агенты работают...</span>
             </div>
           </div>

--- a/frontend/src/components/agents/DiscussionView.tsx
+++ b/frontend/src/components/agents/DiscussionView.tsx
@@ -4,7 +4,7 @@ import type { AgentResponse, SystemMessage, SystemMessageType } from '../../type
 import { useNotification } from '../../contexts/NotificationContext';
 import { usePolling } from '../../hooks';
 import { POLL_INTERVAL_DISCUSSION_MS } from '../../constants';
-import { formatDateTime } from '../../utils/format';
+import { formatDateTime, statusClass } from '../../utils/format';
 import MessageBubble from './MessageBubble';
 
 interface Props {
@@ -56,34 +56,75 @@ const DiscussionView: React.FC<Props> = ({ discussionId, active = false }) => {
   const feed = data ?? [];
 
   if (loading && feed.length === 0) {
-    return <div className="loading-state">Загрузка диалога...</div>;
+    // Скелетоны вместо текстовой заглушки — лента ощущается живой ещё до прихода данных.
+    return (
+      <div className="discussion-timeline" aria-busy="true">
+        {[0, 1, 2].map(i => (
+          <div key={i} className="timeline-row">
+            <span className="timeline-node timeline-node--skeleton skeleton" />
+            <div className="timeline-content">
+              <div className="message-skeleton">
+                <div className="skeleton skeleton-line skeleton-line--head" />
+                <div className="skeleton skeleton-line" />
+                <div className="skeleton skeleton-line skeleton-line--short" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
   }
 
   if (feed.length === 0 && !active) {
-    return <p className="empty-state">В этой дискуссии пока нет сообщений.</p>;
+    return (
+      <p className="empty-state">
+        <i className="fas fa-comment-slash"></i> В этой дискуссии пока нет сообщений.
+      </p>
+    );
   }
 
   return (
-    <div className="discussion-feed">
+    <div className="discussion-timeline">
       {feed.map(item =>
         item.kind === 'response' ? (
-          <MessageBubble key={item.data.response_id} discussionId={discussionId} response={item.data} />
+          <div key={item.data.response_id} className="timeline-row timeline-row--response">
+            <span className={`timeline-node ${statusClass(item.data.status)}`} aria-hidden="true">
+              <i className="fas fa-robot"></i>
+            </span>
+            <div className="timeline-content">
+              <MessageBubble discussionId={discussionId} response={item.data} />
+            </div>
+          </div>
         ) : (
           <div
             key={`sys-${item.data.timestamp}-${item.data.type_}-${item.data.message.slice(0, 32)}`}
-            className={`system-message msg-${item.data.type_.toLowerCase()}`}
+            className={`timeline-row timeline-row--system msg-${item.data.type_.toLowerCase()}`}
           >
-            <i className={`fas ${SYSTEM_ICONS[item.data.type_]}`}></i>
-            <span className="system-message-text">{item.data.message}</span>
-            <span className="system-message-time">{formatDateTime(item.data.timestamp)}</span>
+            <span className="timeline-node timeline-node--system" aria-hidden="true">
+              <i className={`fas ${SYSTEM_ICONS[item.data.type_]}`}></i>
+            </span>
+            <div className="timeline-content">
+              <div className="system-message">
+                <span className="system-message-text">{item.data.message}</span>
+                <span className="system-message-time">{formatDateTime(item.data.timestamp)}</span>
+              </div>
+            </div>
           </div>
         ),
       )}
 
       {active && (
-        <div className="discussion-running" role="status" aria-live="polite">
-          <i className="fas fa-spinner fa-spin"></i>
-          <span>Дискуссия в процессе...</span>
+        <div className="timeline-row timeline-row--active" role="status" aria-live="polite">
+          <span className="timeline-node timeline-node--active" aria-hidden="true">
+            <span className="timeline-node-pulse"></span>
+            <i className="fas fa-robot"></i>
+          </span>
+          <div className="timeline-content">
+            <div className="discussion-running">
+              <i className="fas fa-spinner fa-spin"></i>
+              <span>Агенты работают...</span>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/agents/MessageBubble.tsx
+++ b/frontend/src/components/agents/MessageBubble.tsx
@@ -19,15 +19,33 @@ const STATUS_LABELS: Record<AgentStatus, string> = {
   ERROR: 'Ошибка',
 };
 
+// Превью текста ответа для свёрнутой карточки: грубая зачистка markdown до плоской строки.
+const toPreview = (text: string, max = 140): string => {
+  const flat = text
+    .replace(/```[\s\S]*?```/g, ' ')           // блоки кода
+    .replace(/[#>*_`~-]+/g, ' ')               // markdown-разметка
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')   // ссылки → текст
+    .replace(/\s+/g, ' ')
+    .trim();
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+};
+
 // Отображение одного вызова инструмента: шапка-список + раскрываемые подробности.
-const ToolItem: React.FC<{ tool: Tool }> = ({ tool }) => {
+// maxDuration — наибольшая длительность среди инструментов ответа (для ширины latency-bar).
+const ToolItem: React.FC<{ tool: Tool; maxDuration: number }> = ({ tool, maxDuration }) => {
   const [expanded, setExpanded] = useState(false);
 
   const hasDetails =
     Boolean(tool.message) || tool.input_args != null || tool.output != null || Boolean(tool.error_traceback);
 
+  // Относительная ширина бара длительности (видно «тяжёлые» вызовы).
+  const barWidth =
+    tool.duration_ms != null && maxDuration > 0
+      ? `${Math.max(4, (tool.duration_ms / maxDuration) * 100)}%`
+      : null;
+
   return (
-    <div className={`tool-item ${expanded ? 'expanded' : ''}`}>
+    <div className={`tool-item ${statusClass(tool.status)} ${expanded ? 'expanded' : ''}`}>
       <div
         className={`tool-header ${hasDetails ? 'clickable' : ''}`}
         {...(hasDetails ? getDisclosureProps(expanded, () => setExpanded(prev => !prev)) : {})}
@@ -37,7 +55,16 @@ const ToolItem: React.FC<{ tool: Tool }> = ({ tool }) => {
           <i className="fas fa-wrench"></i> {tool.name}
         </span>
         <div className="tool-header-right">
-          {tool.duration_ms != null && <span className="tool-duration"><i className="fas fa-clock"></i> {formatDuration(tool.duration_ms)}</span>}
+          {tool.duration_ms != null && (
+            <span className="tool-duration">
+              {barWidth && (
+                <span className="tool-latency-bar" aria-hidden="true">
+                  <span className="tool-latency-bar-fill" style={{ width: barWidth }} />
+                </span>
+              )}
+              <i className="fas fa-clock"></i> {formatDuration(tool.duration_ms)}
+            </span>
+          )}
           <span className={`status-badge ${statusClass(tool.status)}`}>{STATUS_LABELS[tool.status]}</span>
         </div>
       </div>
@@ -96,12 +123,19 @@ const MessageBubble: React.FC<Props> = ({ discussionId, response }) => {
       >
         <span className="message-header-left">
           <CollapseChevron open={!collapsed} />
-          <span className="message-role"><i className="fas fa-robot"></i> {response.agent_role}</span>
+          <span className="message-role">{response.agent_role}</span>
         </span>
         <div className="message-header-right">
+          {response.duration_ms != null && (
+            <span className="message-header-duration"><i className="fas fa-clock"></i> {formatDuration(response.duration_ms)}</span>
+          )}
           <span className={`status-badge ${statusClass(response.status)}`}>{STATUS_LABELS[response.status]}</span>
         </div>
       </div>
+
+      {collapsed && response.text.trim() && (
+        <p className="message-preview">{toPreview(response.text)}</p>
+      )}
 
       {!collapsed && (
         <>
@@ -129,7 +163,14 @@ const MessageBubble: React.FC<Props> = ({ discussionId, response }) => {
           {Array.isArray(tools) && (
             tools.length === 0
               ? <p className="tools-status">Инструменты не вызывались</p>
-              : <div className="tools-list">{tools.map(tool => <ToolItem key={tool.id} tool={tool} />)}</div>
+              : (() => {
+                  const maxDuration = Math.max(0, ...tools.map(t => t.duration_ms ?? 0));
+                  return (
+                    <div className="tools-list">
+                      {tools.map(tool => <ToolItem key={tool.id} tool={tool} maxDuration={maxDuration} />)}
+                    </div>
+                  );
+                })()
           )}
         </>
       )}

--- a/frontend/src/components/agents/MessageBubble.tsx
+++ b/frontend/src/components/agents/MessageBubble.tsx
@@ -6,6 +6,7 @@ import { agentHistoryService } from '../../services/agentHistoryService';
 import type { AgentResponse, AgentStatus, Tool } from '../../types/agentHistory';
 import { formatDateTime, formatDuration, statusClass } from '../../utils/format';
 import { CollapseChevron, getDisclosureProps } from '../common/Collapse';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   discussionId: string;
@@ -52,7 +53,7 @@ const ToolItem: React.FC<{ tool: Tool; maxDuration: number }> = ({ tool, maxDura
       >
         <span className="tool-name">
           {hasDetails && <CollapseChevron open={expanded} />}
-          <i className="fas fa-wrench"></i> {tool.name}
+          <i className={`fas ${ICONS.tools}`}></i> {tool.name}
         </span>
         <div className="tool-header-right">
           {tool.duration_ms != null && (
@@ -62,7 +63,7 @@ const ToolItem: React.FC<{ tool: Tool; maxDuration: number }> = ({ tool, maxDura
                   <span className="tool-latency-bar-fill" style={{ width: barWidth }} />
                 </span>
               )}
-              <i className="fas fa-clock"></i> {formatDuration(tool.duration_ms)}
+              <i className={`fas ${ICONS.duration}`}></i> {formatDuration(tool.duration_ms)}
             </span>
           )}
           <span className={`status-badge ${statusClass(tool.status)}`}>{STATUS_LABELS[tool.status]}</span>
@@ -127,7 +128,7 @@ const MessageBubble: React.FC<Props> = ({ discussionId, response }) => {
         </span>
         <div className="message-header-right">
           {response.duration_ms != null && (
-            <span className="message-header-duration"><i className="fas fa-clock"></i> {formatDuration(response.duration_ms)}</span>
+            <span className="message-header-duration"><i className={`fas ${ICONS.duration}`}></i> {formatDuration(response.duration_ms)}</span>
           )}
           <span className={`status-badge ${statusClass(response.status)}`}>{STATUS_LABELS[response.status]}</span>
         </div>
@@ -140,10 +141,10 @@ const MessageBubble: React.FC<Props> = ({ discussionId, response }) => {
       {!collapsed && (
         <>
           <div className="message-meta">
-            {response.model && <span><i className="fas fa-microchip"></i> {response.model}</span>}
-            {response.task_name && <span><i className="fas fa-list-check"></i> {response.task_name}</span>}
-            {response.iteration != null && <span><i className="fas fa-rotate"></i> итерация {response.iteration}</span>}
-            {response.duration_ms != null && <span><i className="fas fa-clock"></i> {formatDuration(response.duration_ms)}</span>}
+            {response.model && <span><i className={`fas ${ICONS.agentModel}`}></i> {response.model}</span>}
+            {response.task_name && <span><i className={`fas ${ICONS.task}`}></i> {response.task_name}</span>}
+            {response.iteration != null && <span><i className={`fas ${ICONS.iteration}`}></i> итерация {response.iteration}</span>}
+            {response.duration_ms != null && <span><i className={`fas ${ICONS.duration}`}></i> {formatDuration(response.duration_ms)}</span>}
           </div>
 
           <div className="message-text markdown-body">
@@ -153,7 +154,7 @@ const MessageBubble: React.FC<Props> = ({ discussionId, response }) => {
           <div className="message-footer">
             <span className="message-time">{formatDateTime(response.timestamp)}</span>
             <button className="tools-toggle" onClick={handleToggleTools}>
-              <i className={`fas ${tools !== null ? 'fa-chevron-up' : 'fa-wrench'}`}></i>
+              <i className={`fas ${tools !== null ? ICONS.collapse : ICONS.tools}`}></i>
               {tools !== null ? ' Скрыть инструменты' : ' Инструменты'}
             </button>
           </div>

--- a/frontend/src/components/agents/RunPipelineForm.tsx
+++ b/frontend/src/components/agents/RunPipelineForm.tsx
@@ -3,6 +3,8 @@ import { datasetService } from '../../services/datasetService';
 import { agentsService } from '../../services/agentsService';
 import type { Dataset } from '../../types/dataset';
 import { useNotification } from '../../contexts/NotificationContext';
+import Combobox from '../common/Combobox';
+import ChipListEditor from '../common/ChipListEditor';
 
 interface Props {
   // Вызывается после успешного старта пайплайна с id созданной дискуссии.
@@ -28,35 +30,11 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
   const [title, setTitle] = useState('');
   // Теги добавляются по одному в список.
   const [tagList, setTagList] = useState<string[]>([]);
-  const [tagDraft, setTagDraft] = useState('');
   // Запрещённые гипотезы добавляются по одной в список.
   const [deniedList, setDeniedList] = useState<string[]>([]);
-  const [deniedDraft, setDeniedDraft] = useState('');
   const [maxIter, setMaxIter] = useState(2);
 
   const [submitting, setSubmitting] = useState(false);
-
-  // Добавить тег (из черновика или переданный из предложенных), без дублей.
-  const addTag = (raw?: string) => {
-    const value = (raw ?? tagDraft).trim();
-    if (!value) return;
-    setTagList(prev => (prev.includes(value) ? prev : [...prev, value]));
-    setTagDraft('');
-  };
-  const removeTag = (index: number) => {
-    setTagList(prev => prev.filter((_, i) => i !== index));
-  };
-
-  // Добавить запрещённую гипотезу из черновика в список (без дублей).
-  const addDenied = () => {
-    const value = deniedDraft.trim();
-    if (!value) return;
-    setDeniedList(prev => (prev.includes(value) ? prev : [...prev, value]));
-    setDeniedDraft('');
-  };
-  const removeDenied = (index: number) => {
-    setDeniedList(prev => prev.filter((_, i) => i !== index));
-  };
 
   useEffect(() => {
     const fetchDatasets = async () => {
@@ -135,7 +113,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
   };
 
   return (
-    <form className="run-pipeline-form" onSubmit={handleSubmit}>
+    <form className="run-pipeline-form" onSubmit={handleSubmit} autoComplete="off">
       <h2>Запуск пайплайна разработки</h2>
 
       <div className="form-section">
@@ -146,39 +124,34 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
         <div className="form-grid">
           <div className="form-field">
             <label htmlFor="run-dataset">Имя датасета <span className="required-star">*</span></label>
-            <input
+            <Combobox
               id="run-dataset"
-              type="text"
-              list="run-datasets-list"
+              icon="fas fa-database"
               placeholder="например: CIFAR-10"
               value={datasetName}
-              onChange={(e) => { setDatasetName(e.target.value); setVersionName(''); }}
+              options={datasets.map(d => d.name)}
+              onChange={(v) => { setDatasetName(v); setVersionName(''); }}
               disabled={submitting}
             />
-            <datalist id="run-datasets-list">
-              {datasets.map(d => <option key={d.id} value={d.name} />)}
-            </datalist>
           </div>
           <div className="form-field">
             <label htmlFor="run-version">Имя версии <span className="required-star">*</span></label>
-            <input
+            <Combobox
               id="run-version"
-              type="text"
-              list="run-versions-list"
+              icon="fas fa-code-branch"
               placeholder="например: v1.0"
               value={versionName}
-              onChange={(e) => setVersionName(e.target.value)}
+              options={matchedDataset?.versions.map(v => v.name) ?? []}
+              onChange={setVersionName}
               disabled={submitting}
             />
-            <datalist id="run-versions-list">
-              {matchedDataset?.versions.map(v => <option key={v.id} value={v.name} />)}
-            </datalist>
           </div>
           <div className="form-field">
             <label htmlFor="run-model">Имя модели <span className="required-star">*</span></label>
             <input
               id="run-model"
               type="text"
+              autoComplete="off"
               placeholder="придумайте сами, например: my-model"
               value={modelName}
               onChange={(e) => setModelName(e.target.value)}
@@ -190,6 +163,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
             <label htmlFor="run-max-iter">Попыток обучения</label>
             <input
               id="run-max-iter"
+              className="no-spinner"
               type="number"
               min={1}
               value={maxIter}
@@ -210,6 +184,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
             <label htmlFor="run-business">Бизнес-требования <span className="required-star">*</span></label>
             <textarea
               id="run-business"
+              autoComplete="off"
               placeholder="Что нужно бизнесу от модели"
               value={businessRequirements}
               onChange={(e) => setBusinessRequirements(e.target.value)}
@@ -221,6 +196,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
             <label htmlFor="run-deployment">Ограничения прода <span className="required-star">*</span></label>
             <textarea
               id="run-deployment"
+              autoComplete="off"
               placeholder="Технические ограничения, например: только CPU, ≤100 МБ"
               value={deploymentConstraints}
               onChange={(e) => setDeploymentConstraints(e.target.value)}
@@ -230,46 +206,14 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
           </div>
           <div className="form-field full-width">
             <label htmlFor="run-denied">Запрещённые гипотезы и практики</label>
-            <div className="denied-input-row">
-              <input
-                id="run-denied"
-                type="text"
-                placeholder="Например: не использовать аугментацию поворотом"
-                value={deniedDraft}
-                onChange={(e) => setDeniedDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') { e.preventDefault(); addDenied(); }
-                }}
-                disabled={submitting}
-              />
-              <button
-                type="button"
-                className="button secondary small"
-                onClick={addDenied}
-                disabled={submitting || !deniedDraft.trim()}
-              >
-                <i className="fas fa-plus"></i> Добавить
-              </button>
-            </div>
-            {deniedList.length > 0 && (
-              <ul className="denied-list">
-                {deniedList.map((item, index) => (
-                  <li key={item} className="denied-item">
-                    <span className="denied-item-text">{item}</span>
-                    <button
-                      type="button"
-                      className="denied-item-remove"
-                      onClick={() => removeDenied(index)}
-                      disabled={submitting}
-                      aria-label="Удалить"
-                      title="Удалить"
-                    >
-                      <i className="fas fa-xmark"></i>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
+            <ChipListEditor
+              id="run-denied"
+              variant="row"
+              items={deniedList}
+              onChange={setDeniedList}
+              placeholder="Например: не использовать аугментацию поворотом"
+              disabled={submitting}
+            />
           </div>
         </div>
       </div>
@@ -285,6 +229,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
             <input
               id="run-title"
               type="text"
+              autoComplete="off"
               placeholder="Необязательно — иначе сгенерируется автоматически"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -293,62 +238,15 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
           </div>
           <div className="form-field full-width">
             <label htmlFor="run-tags">Теги</label>
-            <div className="denied-input-row">
-              <input
-                id="run-tags"
-                type="text"
-                placeholder="Например: эксперимент"
-                value={tagDraft}
-                onChange={(e) => setTagDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') { e.preventDefault(); addTag(); }
-                }}
-                disabled={submitting}
-              />
-              <button
-                type="button"
-                className="button secondary small"
-                onClick={() => addTag()}
-                disabled={submitting || !tagDraft.trim()}
-              >
-                <i className="fas fa-plus"></i> Добавить
-              </button>
-            </div>
-            {SUGGESTED_TAGS.filter(t => !tagList.includes(t)).length > 0 && (
-              <div className="tag-suggestions">
-                <span className="tag-suggestions-label">Предложенные:</span>
-                {SUGGESTED_TAGS.filter(t => !tagList.includes(t)).map(t => (
-                  <button
-                    key={t}
-                    type="button"
-                    className="tag-suggestion"
-                    onClick={() => addTag(t)}
-                    disabled={submitting}
-                  >
-                    <i className="fas fa-plus"></i> {t}
-                  </button>
-                ))}
-              </div>
-            )}
-            {tagList.length > 0 && (
-              <ul className="tag-list">
-                {tagList.map((tag, index) => (
-                  <li key={tag} className="tag-chip">
-                    <span className="tag-chip-text">{tag}</span>
-                    <button
-                      type="button"
-                      className="tag-chip-remove"
-                      onClick={() => removeTag(index)}
-                      disabled={submitting}
-                      aria-label="Удалить тег"
-                      title="Удалить"
-                    >
-                      <i className="fas fa-xmark"></i>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
+            <ChipListEditor
+              id="run-tags"
+              variant="chip"
+              items={tagList}
+              onChange={setTagList}
+              placeholder="Например: эксперимент"
+              suggestions={SUGGESTED_TAGS}
+              disabled={submitting}
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/components/agents/RunPipelineForm.tsx
+++ b/frontend/src/components/agents/RunPipelineForm.tsx
@@ -5,6 +5,7 @@ import type { Dataset } from '../../types/dataset';
 import { useNotification } from '../../contexts/NotificationContext';
 import Combobox from '../common/Combobox';
 import ChipListEditor from '../common/ChipListEditor';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   // Вызывается после успешного старта пайплайна с id созданной дискуссии.
@@ -118,7 +119,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
 
       <div className="form-section">
         <div className="form-section-head">
-          <h3><i className="fas fa-database"></i> Данные и модель</h3>
+          <h3><i className={`fas ${ICONS.dataset}`}></i> Данные и модель</h3>
           <p className="form-section-hint">Что обучаем и на каких данных.</p>
         </div>
         <div className="form-grid">
@@ -126,7 +127,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
             <label htmlFor="run-dataset">Имя датасета <span className="required-star">*</span></label>
             <Combobox
               id="run-dataset"
-              icon="fas fa-database"
+              icon={`fas ${ICONS.dataset}`}
               placeholder="например: CIFAR-10"
               value={datasetName}
               options={datasets.map(d => d.name)}
@@ -138,7 +139,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
             <label htmlFor="run-version">Имя версии <span className="required-star">*</span></label>
             <Combobox
               id="run-version"
-              icon="fas fa-code-branch"
+              icon={`fas ${ICONS.version}`}
               placeholder="например: v1.0"
               value={versionName}
               options={matchedDataset?.versions.map(v => v.name) ?? []}
@@ -176,7 +177,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
 
       <div className="form-section">
         <div className="form-section-head">
-          <h3><i className="fas fa-circle-info"></i> Контекст для агентов</h3>
+          <h3><i className={`fas ${ICONS.info}`}></i> Контекст для агентов</h3>
           <p className="form-section-hint">Эту информацию агенты используют при подборе решения.</p>
         </div>
         <div className="form-grid">
@@ -220,7 +221,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
 
       <div className="form-section">
         <div className="form-section-head">
-          <h3><i className="fas fa-tag"></i> Параметры запуска</h3>
+          <h3><i className={`fas ${ICONS.tag}`}></i> Параметры запуска</h3>
           <p className="form-section-hint">Как этот запуск будет назван в истории.</p>
         </div>
         <div className="form-grid">
@@ -254,9 +255,9 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
       <div className="run-pipeline-actions">
         <button type="submit" className="button" disabled={submitting}>
           {submitting ? (
-            <><i className="fas fa-spinner fa-spin"></i> Запуск...</>
+            <><i className={`fas ${ICONS.loading} fa-spin`}></i> Запуск...</>
           ) : (
-            <><i className="fas fa-play"></i> Запустить</>
+            <><i className={`fas ${ICONS.play}`}></i> Запустить</>
           )}
         </button>
       </div>

--- a/frontend/src/components/common/ChipListEditor.css
+++ b/frontend/src/components/common/ChipListEditor.css
@@ -1,0 +1,120 @@
+/* Редактор списка строк: draft-input + chip-список. Общий для агентов и датасетов. */
+
+.chip-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Строка добавления: input + кнопка */
+.chip-input-row {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.chip-input-row input {
+  flex: 1;
+}
+
+.chip-input-row .button {
+  white-space: nowrap;
+}
+
+/* Предложенные значения (chip-подсказки) */
+.chip-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.chip-suggestions-label {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.chip-suggestion {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px dashed var(--color-accent);
+  color: var(--color-accent-light);
+  border-radius: 40px;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.chip-suggestion:hover:not(:disabled) {
+  background: var(--color-accent-soft);
+}
+
+/* Список добавленных элементов */
+.chip-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* Вариант 'chip' — компактные пилюли с переносом */
+.chip-list--chip {
+  flex-wrap: wrap;
+}
+
+.chip-list--chip .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.4rem 0.3rem 0.8rem;
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent);
+  border-radius: 40px;
+  font-size: 0.85rem;
+  color: var(--color-text-primary);
+}
+
+/* Вариант 'row' — строки во всю ширину */
+.chip-list--row {
+  flex-direction: column;
+}
+
+.chip-list--row .chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.8rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 8px;
+}
+
+.chip-text {
+  font-size: 0.9rem;
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+
+.chip-remove {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+  transition: var(--transition);
+}
+
+.chip-remove:hover:not(:disabled) {
+  color: var(--color-accent-light);
+  background: var(--color-accent-soft);
+}

--- a/frontend/src/components/common/ChipListEditor.tsx
+++ b/frontend/src/components/common/ChipListEditor.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import './ChipListEditor.css';
+
+interface Props {
+  /** Текущий список строк. */
+  items: string[];
+  /** Вызывается с новым списком при добавлении/удалении. */
+  onChange: (items: string[]) => void;
+  placeholder?: string;
+  /** Подпись на кнопке добавления (по умолчанию «Добавить»). */
+  addLabel?: string;
+  /** Предложенные значения — рендерятся как chip-подсказки над списком. */
+  suggestions?: string[];
+  /** Подпись к блоку предложенных. */
+  suggestionsLabel?: string;
+  /** 'chip' — компактные пилюли с переносом; 'row' — список строк во всю ширину. */
+  variant?: 'chip' | 'row';
+  disabled?: boolean;
+  id?: string;
+}
+
+/**
+ * Редактор списка строк по паттерну «draft-input → Enter/кнопка → chip с крестиком».
+ * Владеет состоянием черновика; наружу отдаёт только готовый список через onChange.
+ * Trim + дедупликация при добавлении.
+ */
+const ChipListEditor: React.FC<Props> = ({
+  items,
+  onChange,
+  placeholder,
+  addLabel = 'Добавить',
+  suggestions,
+  suggestionsLabel = 'Предложенные:',
+  variant = 'chip',
+  disabled,
+  id,
+}) => {
+  const [draft, setDraft] = useState('');
+
+  const add = (raw?: string) => {
+    const value = (raw ?? draft).trim();
+    if (!value) return;
+    if (!items.includes(value)) onChange([...items, value]);
+    setDraft('');
+  };
+
+  const remove = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  const visibleSuggestions = suggestions?.filter((s) => !items.includes(s)) ?? [];
+
+  return (
+    <div className="chip-editor">
+      <div className="chip-input-row">
+        <input
+          id={id}
+          type="text"
+          autoComplete="off"
+          placeholder={placeholder}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              add();
+            }
+          }}
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          className="button secondary small"
+          onClick={() => add()}
+          disabled={disabled || !draft.trim()}
+        >
+          <i className="fas fa-plus"></i> {addLabel}
+        </button>
+      </div>
+
+      {visibleSuggestions.length > 0 && (
+        <div className="chip-suggestions">
+          <span className="chip-suggestions-label">{suggestionsLabel}</span>
+          {visibleSuggestions.map((s) => (
+            <button
+              key={s}
+              type="button"
+              className="chip-suggestion"
+              onClick={() => add(s)}
+              disabled={disabled}
+            >
+              <i className="fas fa-plus"></i> {s}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <ul className={`chip-list chip-list--${variant}`}>
+          {items.map((item, index) => (
+            <li key={item} className="chip">
+              <span className="chip-text">{item}</span>
+              <button
+                type="button"
+                className="chip-remove"
+                onClick={() => remove(index)}
+                disabled={disabled}
+                aria-label="Удалить"
+                title="Удалить"
+              >
+                <i className="fas fa-xmark"></i>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default ChipListEditor;

--- a/frontend/src/components/common/ChipListEditor.tsx
+++ b/frontend/src/components/common/ChipListEditor.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ICONS } from '../../constants/icons';
 import './ChipListEditor.css';
 
 interface Props {
@@ -74,7 +75,7 @@ const ChipListEditor: React.FC<Props> = ({
           onClick={() => add()}
           disabled={disabled || !draft.trim()}
         >
-          <i className="fas fa-plus"></i> {addLabel}
+          <i className={`fas ${ICONS.add}`}></i> {addLabel}
         </button>
       </div>
 
@@ -89,7 +90,7 @@ const ChipListEditor: React.FC<Props> = ({
               onClick={() => add(s)}
               disabled={disabled}
             >
-              <i className="fas fa-plus"></i> {s}
+              <i className={`fas ${ICONS.add}`}></i> {s}
             </button>
           ))}
         </div>
@@ -108,7 +109,7 @@ const ChipListEditor: React.FC<Props> = ({
                 aria-label="Удалить"
                 title="Удалить"
               >
-                <i className="fas fa-xmark"></i>
+                <i className={`fas ${ICONS.close}`}></i>
               </button>
             </li>
           ))}

--- a/frontend/src/components/common/Collapse.tsx
+++ b/frontend/src/components/common/Collapse.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ICONS } from '../../constants/icons';
 
 interface CollapseChevronProps {
   open: boolean;
@@ -12,7 +13,7 @@ interface CollapseChevronProps {
  */
 export const CollapseChevron: React.FC<CollapseChevronProps> = ({ open, className }) => (
   <i
-    className={`fas fa-chevron-right collapse-chevron${open ? ' open' : ''}${className ? ` ${className}` : ''}`}
+    className={`fas ${ICONS.pageNext} collapse-chevron${open ? ' open' : ''}${className ? ` ${className}` : ''}`}
     aria-hidden="true"
   />
 );

--- a/frontend/src/components/common/Combobox.css
+++ b/frontend/src/components/common/Combobox.css
@@ -1,0 +1,120 @@
+/* Поле с автодополнением в стилистике кастомного Select. */
+.combobox {
+  position: relative;
+  width: 100%;
+}
+
+.combobox-control {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  background: var(--color-bg-secondary);
+  border: var(--border-subtle);
+  border-radius: var(--radius-input);
+  padding: 0.55rem 1rem;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.combobox-control:hover {
+  border-color: var(--color-border-strong);
+}
+
+.combobox--open .combobox-control {
+  border-color: var(--color-accent);
+}
+
+.combobox-icon {
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+
+.combobox-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-family: var(--font-primary);
+  font-size: 0.95rem;
+}
+
+.combobox-input::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.combobox-input:disabled {
+  cursor: not-allowed;
+}
+
+.combobox-caret {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+  transition: transform 0.18s ease, color 0.15s;
+}
+
+.combobox--open .combobox-caret {
+  transform: rotate(180deg);
+  color: var(--color-accent);
+}
+
+.combobox-menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  background: var(--color-bg-secondary);
+  border: var(--border-soft);
+  border-radius: var(--radius-input);
+  box-shadow: var(--shadow-md);
+  max-height: 16rem;
+  overflow-y: auto;
+  animation: combobox-menu-in 0.14s ease;
+}
+
+@keyframes combobox-menu-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.combobox-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: calc(var(--radius-input) - 2px);
+  cursor: pointer;
+  font-size: 0.92rem;
+  color: var(--color-text-primary);
+  transition: background 0.12s, color 0.12s;
+}
+
+.combobox-option-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.combobox-option--active {
+  background: var(--color-bg-primary);
+}
+
+.combobox-option--selected {
+  color: var(--color-accent);
+}
+
+.combobox-option-check {
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/common/Combobox.tsx
+++ b/frontend/src/components/common/Combobox.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import './Combobox.css';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  /** Подсказки для выпадающего списка. Ввод при этом остаётся свободным. */
+  options: string[];
+  placeholder?: string;
+  /** Иконка-префикс (класс Font Awesome). */
+  icon?: string;
+  disabled?: boolean;
+  id?: string;
+}
+
+/**
+ * Поле с автодополнением: можно выбрать из списка (выпадашка в стиле фронтенда,
+ * как кастомный Select) либо ввести значение вручную. По мере ввода список
+ * фильтруется по подстроке.
+ */
+const Combobox: React.FC<Props> = ({ value, onChange, options, placeholder, icon, disabled, id }) => {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Фильтрация по подстроке; если значение точно совпадает с пунктом — показываем весь список.
+  const filtered = useMemo(() => {
+    const q = value.trim().toLowerCase();
+    if (!q || options.some((o) => o.toLowerCase() === q)) return options;
+    return options.filter((o) => o.toLowerCase().includes(q));
+  }, [value, options]);
+
+  // Закрытие по клику вне компонента.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [open]);
+
+  const choose = (v: string) => {
+    onChange(v);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!open) { setOpen(true); setActiveIndex(0); return; }
+      setActiveIndex((i) => Math.min(filtered.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter') {
+      if (open && filtered[activeIndex]) {
+        e.preventDefault();
+        choose(filtered[activeIndex]);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className={`combobox${open ? ' combobox--open' : ''}`} ref={rootRef}>
+      <div className="combobox-control">
+        {icon && <i className={`${icon} combobox-icon`}></i>}
+        <input
+          id={id}
+          type="text"
+          className="combobox-input"
+          value={value}
+          placeholder={placeholder}
+          disabled={disabled}
+          autoComplete="off"
+          onChange={(e) => { onChange(e.target.value); setOpen(true); setActiveIndex(0); }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={handleKeyDown}
+        />
+        {options.length > 0 && (
+          <button
+            type="button"
+            className="combobox-caret"
+            tabIndex={-1}
+            disabled={disabled}
+            aria-label="Показать варианты"
+            onClick={() => setOpen((o) => !o)}
+          >
+            <i className="fas fa-chevron-down"></i>
+          </button>
+        )}
+      </div>
+
+      {open && filtered.length > 0 && (
+        <ul className="combobox-menu" role="listbox">
+          {filtered.map((o, i) => (
+            <li
+              key={o}
+              role="option"
+              aria-selected={o === value}
+              className={`combobox-option${o === value ? ' combobox-option--selected' : ''}${i === activeIndex ? ' combobox-option--active' : ''}`}
+              onMouseEnter={() => setActiveIndex(i)}
+              onMouseDown={(e) => { e.preventDefault(); choose(o); }}
+            >
+              <span className="combobox-option-label">{o}</span>
+              {o === value && <i className="fas fa-check combobox-option-check"></i>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Combobox;

--- a/frontend/src/components/common/Combobox.tsx
+++ b/frontend/src/components/common/Combobox.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ICONS } from '../../constants/icons';
 import './Combobox.css';
 
 interface Props {
@@ -90,7 +91,7 @@ const Combobox: React.FC<Props> = ({ value, onChange, options, placeholder, icon
             aria-label="Показать варианты"
             onClick={() => setOpen((o) => !o)}
           >
-            <i className="fas fa-chevron-down"></i>
+            <i className={`fas ${ICONS.expand}`}></i>
           </button>
         )}
       </div>
@@ -107,7 +108,7 @@ const Combobox: React.FC<Props> = ({ value, onChange, options, placeholder, icon
               onMouseDown={(e) => { e.preventDefault(); choose(o); }}
             >
               <span className="combobox-option-label">{o}</span>
-              {o === value && <i className="fas fa-check combobox-option-check"></i>}
+              {o === value && <i className={`fas ${ICONS.selected} combobox-option-check`}></i>}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/common/ConfirmModal.tsx
+++ b/frontend/src/components/common/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { ICONS } from '../../constants/icons';
 import './ConfirmModal.css';
 
 interface Props {
@@ -43,7 +44,7 @@ const ConfirmModal: React.FC<Props> = ({
         onClick={(e) => e.stopPropagation()}
       >
         <div className={`confirm-icon ${danger ? 'confirm-icon--danger' : ''}`}>
-          <i className={`fas ${danger ? 'fa-trash' : 'fa-circle-question'}`}></i>
+          <i className={`fas ${danger ? ICONS.delete : ICONS.question}`}></i>
         </div>
         <h3 className="confirm-title">{title}</h3>
         {message && <p className="confirm-message">{message}</p>}

--- a/frontend/src/components/common/Select.css
+++ b/frontend/src/components/common/Select.css
@@ -1,0 +1,109 @@
+.select {
+  position: relative;
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.select-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  background: var(--color-bg-secondary);
+  border: var(--border-subtle);
+  border-radius: var(--radius-input);
+  padding: 0.55rem 1rem;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  font-family: var(--font-primary);
+  font-size: 0.95rem;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.select-trigger:hover {
+  border-color: var(--color-border-strong);
+}
+
+.select--open .select-trigger {
+  border-color: var(--color-accent);
+}
+
+.select-trigger > i:first-child {
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+
+.select-value {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.select-caret {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+  transition: transform 0.18s ease;
+}
+
+.select--open .select-caret {
+  transform: rotate(180deg);
+  color: var(--color-accent);
+}
+
+.select-menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  background: var(--color-bg-secondary);
+  border: var(--border-soft);
+  border-radius: var(--radius-input);
+  box-shadow: var(--shadow-md);
+  max-height: 16rem;
+  overflow-y: auto;
+  animation: select-menu-in 0.14s ease;
+}
+
+@keyframes select-menu-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.select-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: calc(var(--radius-input) - 2px);
+  cursor: pointer;
+  font-size: 0.92rem;
+  color: var(--color-text-primary);
+  transition: background 0.12s, color 0.12s;
+}
+
+.select-option-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.select-option--active {
+  background: var(--color-bg-primary);
+}
+
+.select-option--selected {
+  color: var(--color-accent);
+}
+
+.select-option-check {
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/common/Select.tsx
+++ b/frontend/src/components/common/Select.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { ICONS } from '../../constants/icons';
 import './Select.css';
 
 export interface SelectOption {
@@ -97,7 +98,7 @@ const Select: React.FC<Props> = ({ value, options, onChange, icon, placeholder, 
       >
         {icon && <i className={icon}></i>}
         <span className="select-value">{selected?.label}</span>
-        <i className="fas fa-chevron-down select-caret"></i>
+        <i className={`fas ${ICONS.expand} select-caret`}></i>
       </button>
 
       {open && (
@@ -112,7 +113,7 @@ const Select: React.FC<Props> = ({ value, options, onChange, icon, placeholder, 
               onClick={() => choose(o.value)}
             >
               <span className="select-option-label">{o.label}</span>
-              {o.value === value && <i className="fas fa-check select-option-check"></i>}
+              {o.value === value && <i className={`fas ${ICONS.selected} select-option-check`}></i>}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/common/Select.tsx
+++ b/frontend/src/components/common/Select.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import './Select.css';
 
 export interface SelectOption {
   value: string;

--- a/frontend/src/components/datasets/AddVersionForm.tsx
+++ b/frontend/src/components/datasets/AddVersionForm.tsx
@@ -29,22 +29,8 @@ const AddVersionForm: React.FC<AddVersionFormProps> = ({
     onVersionChange({ ...version, [field]: value });
   };
 
-  const handleSourceChange = (index: number, field: keyof SourceItem, value: string) => {
-    const sources = [...version.sources];
-    sources[index] = { ...sources[index], [field]: field === 'url' ? (value || null) : value };
+  const handleSourcesChange = (sources: SourceItem[]) => {
     onVersionChange({ ...version, sources });
-  };
-
-  const handleSourceAdd = () => {
-    onVersionChange({
-      ...version,
-      sources: [...version.sources, { type: 'kaggle', url: null, description: '' }],
-    });
-  };
-
-  const handleSourceRemove = (index: number) => {
-    if (version.sources.length <= 1) return;
-    onVersionChange({ ...version, sources: version.sources.filter((_, i) => i !== index) });
   };
 
   return (
@@ -69,9 +55,7 @@ const AddVersionForm: React.FC<AddVersionFormProps> = ({
       <SourcesEditor
         sources={version.sources}
         loading={loading}
-        onAdd={handleSourceAdd}
-        onRemove={handleSourceRemove}
-        onChange={handleSourceChange}
+        onChange={handleSourcesChange}
       />
 
       <h5>Файл версии</h5>

--- a/frontend/src/components/datasets/DatasetCard.tsx
+++ b/frontend/src/components/datasets/DatasetCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { formatDateTime } from '../../utils/format';
 import { useCopyToClipboard } from '../../hooks';
+import { ICONS } from '../../constants/icons';
 import type { Dataset } from '../../types/dataset';
 
 interface DatasetCardProps {
@@ -43,15 +44,15 @@ const DatasetCard: React.FC<DatasetCardProps> = ({ dataset, onDelete }) => {
     >
       <div className="dataset-header">
         <div className="dataset-title-group">
-          <span className="dataset-badge"><i className="fas fa-tag"></i> {dataset.type} / {dataset.task}</span>
+          <span className="dataset-badge"><i className={`fas ${ICONS.tag}`}></i> {dataset.type} / {dataset.task}</span>
           <h2>{dataset.name}</h2>
           <span
             className="dataset-id"
             title="Нажмите, чтобы скопировать ID"
             onClick={handleCopyId}
           >
-            <i className="fas fa-hashtag"></i>{dataset.id}
-            <i className="fas fa-copy dataset-id-copy-icon"></i>
+            <i className={`fas ${ICONS.id}`}></i>{dataset.id}
+            <i className={`fas ${ICONS.copy} dataset-id-copy-icon`}></i>
           </span>
         </div>
         <div className="dataset-actions">
@@ -61,19 +62,19 @@ const DatasetCard: React.FC<DatasetCardProps> = ({ dataset, onDelete }) => {
             aria-label="Удалить датасет"
             onClick={handleDelete}
           >
-            <i className="fas fa-trash"></i>
+            <i className={`fas ${ICONS.delete}`}></i>
           </button>
         </div>
       </div>
 
       <div className="dataset-meta">
-        <span><i className="fas fa-tags"></i> Классов: {dataset.classes_count}</span>
-        <span><i className="fas fa-code-branch"></i> Версий: {dataset.versions.length}</span>
+        <span><i className={`fas ${ICONS.classes}`}></i> Классов: {dataset.classes_count}</span>
+        <span><i className={`fas ${ICONS.version}`}></i> Версий: {dataset.versions.length}</span>
       </div>
 
       <div className="dataset-meta dataset-meta--dates">
-        <span title="Создан"><i className="fas fa-calendar-alt"></i> Создан: {formatDateTime(dataset.created_at)}</span>
-        <span title="Изменён"><i className="fas fa-clock-rotate-left"></i> Изменён: {formatDateTime(dataset.updated_at)}</span>
+        <span title="Создан"><i className={`fas ${ICONS.dateCreated}`}></i> Создан: {formatDateTime(dataset.created_at)}</span>
+        <span title="Изменён"><i className={`fas ${ICONS.dateUpdated}`}></i> Изменён: {formatDateTime(dataset.updated_at)}</span>
       </div>
 
       {dataset.classes_names.length > 0 && (

--- a/frontend/src/components/datasets/DatasetCard.tsx
+++ b/frontend/src/components/datasets/DatasetCard.tsx
@@ -1,55 +1,54 @@
-import React, { useState } from 'react';
-import { formatBytes, formatDateTime } from '../../utils/format';
-import type { Dataset, VersionSplitsResponse } from '../../types/dataset';
-import { datasetService } from '../../services/datasetService';
-import VersionSplitsStats from './VersionSplitsStats';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { formatDateTime } from '../../utils/format';
 import { useCopyToClipboard } from '../../hooks';
+import type { Dataset } from '../../types/dataset';
 
 interface DatasetCardProps {
   dataset: Dataset;
-  loading: boolean;
-  showVersionForm: boolean;
-  onAddVersion: () => void;
-  onDelete: () => void;
-  onDeleteVersion: (versionId: string) => void;
-  versionForm?: React.ReactNode;
+  onDelete: (dataset: Dataset) => void;
 }
 
-const DatasetCard: React.FC<DatasetCardProps> = ({
-  dataset,
-  loading,
-  showVersionForm,
-  onAddVersion,
-  onDelete,
-  onDeleteVersion,
-  versionForm,
-}) => {
-  const [versionStats, setVersionStats] = useState<Record<string, VersionSplitsResponse | 'loading' | 'error'>>({});
+// Сколько классов показываем в превью карточки, остальные сворачиваем в "+N ещё"
+const CLASSES_PREVIEW_LIMIT = 10;
+
+// Компактное превью датасета. Клик открывает страницу с полной информацией.
+const DatasetCard: React.FC<DatasetCardProps> = ({ dataset, onDelete }) => {
+  const navigate = useNavigate();
+  const open = () => navigate(`/datasets/${dataset.id}`);
   const copyToClipboard = useCopyToClipboard();
 
-  const handleShowVersionStats = async (versionId: string) => {
-    if (versionStats[versionId]) {
-      setVersionStats(prev => { const next = { ...prev }; delete next[versionId]; return next; });
-      return;
-    }
-    setVersionStats(prev => ({ ...prev, [versionId]: 'loading' }));
-    try {
-      const data = await datasetService.getVersionSplits(dataset.id, versionId);
-      setVersionStats(prev => ({ ...prev, [versionId]: data }));
-    } catch {
-      setVersionStats(prev => ({ ...prev, [versionId]: 'error' }));
-    }
+  const handleCopyId = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    copyToClipboard(dataset.id);
+  };
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete(dataset);
   };
 
   return (
-    <div className="card dataset-card">
+    <div
+      className="card card--hoverable dataset-card"
+      onClick={open}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          open();
+        }
+      }}
+    >
       <div className="dataset-header">
         <div className="dataset-title-group">
+          <span className="dataset-badge"><i className="fas fa-tag"></i> {dataset.type} / {dataset.task}</span>
           <h2>{dataset.name}</h2>
           <span
             className="dataset-id"
             title="Нажмите, чтобы скопировать ID"
-            onClick={() => copyToClipboard(dataset.id)}
+            onClick={handleCopyId}
           >
             <i className="fas fa-hashtag"></i>{dataset.id}
             <i className="fas fa-copy dataset-id-copy-icon"></i>
@@ -57,18 +56,10 @@ const DatasetCard: React.FC<DatasetCardProps> = ({
         </div>
         <div className="dataset-actions">
           <button
-            className="icon-button"
-            onClick={onAddVersion}
-            title="Добавить версию"
-            disabled={loading}
-          >
-            <i className="fas fa-code-branch"></i>
-          </button>
-          <button
-            className="icon-button"
-            onClick={onDelete}
+            className="icon-button icon-button--danger"
             title="Удалить датасет"
-            disabled={loading}
+            aria-label="Удалить датасет"
+            onClick={handleDelete}
           >
             <i className="fas fa-trash"></i>
           </button>
@@ -76,101 +67,37 @@ const DatasetCard: React.FC<DatasetCardProps> = ({
       </div>
 
       <div className="dataset-meta">
-        <span><i className="fas fa-tag"></i> {dataset.type} / {dataset.task}</span>
-        <span><i className="fas fa-calendar-alt"></i> Создан: {formatDateTime(dataset.created_at)}</span>
-        <span><i className="fas fa-sync-alt"></i> Обновлён: {formatDateTime(dataset.updated_at)}</span>
+        <span><i className="fas fa-tags"></i> Классов: {dataset.classes_count}</span>
+        <span><i className="fas fa-code-branch"></i> Версий: {dataset.versions.length}</span>
       </div>
 
-      <p className="dataset-description">
-        <span className="dataset-description-label">Описание:</span> {dataset.description}
-      </p>
+      <div className="dataset-meta dataset-meta--dates">
+        <span title="Создан"><i className="fas fa-calendar-alt"></i> Создан: {formatDateTime(dataset.created_at)}</span>
+        <span title="Изменён"><i className="fas fa-clock-rotate-left"></i> Изменён: {formatDateTime(dataset.updated_at)}</span>
+      </div>
 
       {dataset.classes_names.length > 0 && (
         <div className="dataset-classes">
-          <h4>Классы ({dataset.classes_count})</h4>
+          <span className="dataset-classes-label">Классы:</span>
           <div className="tag-list">
-            {dataset.classes_names.slice(0, 10).map(className => (
+            {dataset.classes_names.slice(0, CLASSES_PREVIEW_LIMIT).map(className => (
               <span key={className} className="tag">{className}</span>
             ))}
-            {dataset.classes_names.length > 10 && <span className="tag">...</span>}
+            {dataset.classes_names.length > CLASSES_PREVIEW_LIMIT && (
+              <span className="tag tag--more">
+                +{dataset.classes_names.length - CLASSES_PREVIEW_LIMIT} ещё
+              </span>
+            )}
           </div>
         </div>
       )}
 
-      {showVersionForm && versionForm}
-
-      <div className="versions-section">
-        <h4>Версии ({dataset.versions.length})</h4>
-        {dataset.versions.length === 0 ? (
-          <p className="no-versions">Нет версий</p>
-        ) : (
-          <div className="versions-list">
-            {dataset.versions.map(ver => (
-              <div key={ver.id} className="version-item">
-                <div className="version-header">
-                  <span className="version-name">
-                    {ver.name}
-                    {ver.id === dataset.default_version_id && (
-                      <span className="default-badge-inline"> (по умолчанию)</span>
-                    )}
-                  </span>
-                  <div className="version-actions">
-                    <span className="version-size">{formatBytes(ver.size_bytes)}</span>
-                    <button
-                      className="icon-button small"
-                      onClick={() => handleShowVersionStats(ver.id)}
-                      title="Статистика"
-                    >
-                      <i className="fas fa-chart-bar"></i>
-                    </button>
-                    <button
-                      className="icon-button small"
-                      onClick={() => onDeleteVersion(ver.id)}
-                      title="Удалить версию"
-                      disabled={loading}
-                    >
-                      <i className="fas fa-trash"></i>
-                    </button>
-                  </div>
-                </div>
-                <span className="version-date">Дата загрузки: {formatDateTime(ver.created_at)}</span>
-                <p className="version-description">Описание: {ver.description}</p>
-                <div className="version-stats">
-                  <span>Всего: {ver.num_samples.toLocaleString()}</span>
-                </div>
-                {ver.sources.length > 0 && (
-                  <div className="dataset-sources">
-                    {ver.sources.map((src, idx) => (
-                      <div key={idx} className="source-item">
-                        {src.url ? (
-                          <a href={src.url} target="_blank" rel="noopener noreferrer" className="source-type-badge source-type-badge--link">
-                            {src.type}
-                          </a>
-                        ) : (
-                          <span className="source-type-badge">{src.type}</span>
-                        )}
-                        {src.description && <span className="source-description">{src.description}</span>}
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {versionStats[ver.id] === 'loading' && (
-                  <p className="stats-loading">Загрузка статистики...</p>
-                )}
-                {versionStats[ver.id] === 'error' && (
-                  <p className="stats-error">Не удалось загрузить статистику</p>
-                )}
-                {typeof versionStats[ver.id] === 'object' && (
-                  <VersionSplitsStats
-                    stats={versionStats[ver.id] as VersionSplitsResponse}
-                    onClose={() => handleShowVersionStats(ver.id)}
-                  />
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+      {dataset.description && (
+        <p className="dataset-description dataset-description--clamped">
+          <span className="dataset-description-label">Описание: </span>
+          {dataset.description}
+        </p>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/datasets/DatasetForm.tsx
+++ b/frontend/src/components/datasets/DatasetForm.tsx
@@ -1,7 +1,23 @@
 import React from 'react';
 import FileUploader from '../FileUploader';
 import SourcesEditor from './SourcesEditor';
+import Select from '../common/Select';
 import type { NewDataset, NewVersion, SourceItem } from '../../types/dataset';
+
+const TYPE_OPTIONS = [
+  { value: 'image', label: 'Image' },
+  { value: 'text', label: 'Text' },
+  { value: 'tabular', label: 'Tabular' },
+  { value: 'other', label: 'Other' },
+];
+
+const TASK_OPTIONS = [
+  { value: 'classification', label: 'Classification' },
+  { value: 'regression', label: 'Regression' },
+  { value: 'detection', label: 'Detection' },
+  { value: 'segmentation', label: 'Segmentation' },
+  { value: 'other', label: 'Other' },
+];
 
 type VersionFormData = Omit<NewVersion, 'id_data'>;
 
@@ -10,9 +26,7 @@ interface DatasetFormProps {
   loading: boolean;
   onNewDatasetChange: (field: keyof Omit<NewDataset, 'version'>, value: string) => void;
   onVersionChange: (field: keyof VersionFormData, value: string) => void;
-  onVersionSourceAdd: () => void;
-  onVersionSourceRemove: (index: number) => void;
-  onVersionSourceChange: (index: number, field: keyof SourceItem, value: string) => void;
+  onVersionSourcesChange: (sources: SourceItem[]) => void;
   onFileSelect: (file: File | null) => void;
   onSubmit: () => void;
   onCancel: () => void;
@@ -23,25 +37,29 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
   loading,
   onNewDatasetChange,
   onVersionChange,
-  onVersionSourceAdd,
-  onVersionSourceRemove,
-  onVersionSourceChange,
+  onVersionSourcesChange,
   onFileSelect,
   onSubmit,
   onCancel,
 }) => {
   return (
     <div className="add-dataset-form">
-      <h2>Создать новый датасет</h2>
+      <div className="add-dataset-form-head">
+        <h2>Создать новый датасет</h2>
+      </div>
 
       <div className="form-section">
-        <h3>Основная информация</h3>
+        <div className="form-section-head">
+          <h3><i className="fas fa-circle-info"></i> Основная информация</h3>
+          <p className="form-section-hint">Как датасет будет называться и о чём он.</p>
+        </div>
         <div className="form-grid">
           <div className="form-field">
             <label htmlFor="dataset-name">Название <span className="required-star">*</span></label>
             <input
               id="dataset-name"
               type="text"
+              autoComplete="off"
               placeholder="например: CIFAR-10"
               value={newDataset.name}
               onChange={(e) => onNewDatasetChange('name', e.target.value)}
@@ -52,6 +70,7 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
             <label htmlFor="dataset-description">Описание</label>
             <textarea
               id="dataset-description"
+              autoComplete="off"
               placeholder="Краткое описание датасета"
               value={newDataset.description}
               onChange={(e) => onNewDatasetChange('description', e.target.value)}
@@ -63,48 +82,46 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
       </div>
 
       <div className="form-section">
-        <h3>Тип и задача</h3>
+        <div className="form-section-head">
+          <h3><i className="fas fa-shapes"></i> Тип и задача</h3>
+          <p className="form-section-hint">Какого вида данные и для чего модель.</p>
+        </div>
         <div className="form-row">
           <div className="form-field">
             <label htmlFor="dataset-type">Тип данных</label>
-            <select
-              id="dataset-type"
+            <Select
+              icon="fas fa-shapes"
+              ariaLabel="Тип данных"
               value={newDataset.type}
-              onChange={(e) => onNewDatasetChange('type', e.target.value)}
-              disabled={loading}
-            >
-              <option value="image">Image</option>
-              <option value="text">Text</option>
-              <option value="tabular">Tabular</option>
-              <option value="other">Other</option>
-            </select>
+              options={TYPE_OPTIONS}
+              onChange={(v) => onNewDatasetChange('type', v)}
+            />
           </div>
           <div className="form-field">
             <label htmlFor="dataset-task">Задача</label>
-            <select
-              id="dataset-task"
+            <Select
+              icon="fas fa-bullseye"
+              ariaLabel="Задача"
               value={newDataset.task}
-              onChange={(e) => onNewDatasetChange('task', e.target.value)}
-              disabled={loading}
-            >
-              <option value="classification">Classification</option>
-              <option value="regression">Regression</option>
-              <option value="detection">Detection</option>
-              <option value="segmentation">Segmentation</option>
-              <option value="other">Other</option>
-            </select>
+              options={TASK_OPTIONS}
+              onChange={(v) => onNewDatasetChange('task', v)}
+            />
           </div>
         </div>
       </div>
 
       <div className="form-section">
-        <h3>Начальная версия <span className="required-star">*</span></h3>
+        <div className="form-section-head">
+          <h3><i className="fas fa-code-branch"></i> Начальная версия <span className="required-star">*</span></h3>
+          <p className="form-section-hint">Первая версия данных и откуда они взяты.</p>
+        </div>
         <div className="form-grid">
           <div className="form-field">
             <label htmlFor="version-name">Название версии <span className="required-star">*</span></label>
             <input
               id="version-name"
               type="text"
+              autoComplete="off"
               placeholder="например: v1.0"
               value={newDataset.version.name}
               onChange={(e) => onVersionChange('name', e.target.value)}
@@ -116,6 +133,7 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
             <input
               id="version-description"
               type="text"
+              autoComplete="off"
               placeholder="Краткое описание"
               value={newDataset.version.description}
               onChange={(e) => onVersionChange('description', e.target.value)}
@@ -128,14 +146,15 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
         <SourcesEditor
           sources={newDataset.version.sources}
           loading={loading}
-          onAdd={onVersionSourceAdd}
-          onRemove={onVersionSourceRemove}
-          onChange={onVersionSourceChange}
+          onChange={onVersionSourcesChange}
         />
       </div>
 
       <div className="form-section">
-        <h3>Файл датасета</h3>
+        <div className="form-section-head">
+          <h3><i className="fas fa-file-zipper"></i> Файл датасета</h3>
+          <p className="form-section-hint">Архив с изображениями, разложенными по классам.</p>
+        </div>
         <FileUploader
           onFileSelect={onFileSelect}
           accept=".zip"

--- a/frontend/src/components/datasets/DatasetForm.tsx
+++ b/frontend/src/components/datasets/DatasetForm.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import FileUploader from '../FileUploader';
 import SourcesEditor from './SourcesEditor';
 import Select from '../common/Select';
+import { ICONS } from '../../constants/icons';
 import type { NewDataset, NewVersion, SourceItem } from '../../types/dataset';
 
 const TYPE_OPTIONS = [
@@ -50,7 +51,7 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
 
       <div className="form-section">
         <div className="form-section-head">
-          <h3><i className="fas fa-circle-info"></i> Основная информация</h3>
+          <h3><i className={`fas ${ICONS.info}`}></i> Основная информация</h3>
           <p className="form-section-hint">Как датасет будет называться и о чём он.</p>
         </div>
         <div className="form-grid">
@@ -83,14 +84,14 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
 
       <div className="form-section">
         <div className="form-section-head">
-          <h3><i className="fas fa-shapes"></i> Тип и задача</h3>
+          <h3><i className={`fas ${ICONS.datasetType}`}></i> Тип и задача</h3>
           <p className="form-section-hint">Какого вида данные и для чего модель.</p>
         </div>
         <div className="form-row">
           <div className="form-field">
             <label htmlFor="dataset-type">Тип данных</label>
             <Select
-              icon="fas fa-shapes"
+              icon={`fas ${ICONS.datasetType}`}
               ariaLabel="Тип данных"
               value={newDataset.type}
               options={TYPE_OPTIONS}
@@ -100,7 +101,7 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
           <div className="form-field">
             <label htmlFor="dataset-task">Задача</label>
             <Select
-              icon="fas fa-bullseye"
+              icon={`fas ${ICONS.taskTarget}`}
               ariaLabel="Задача"
               value={newDataset.task}
               options={TASK_OPTIONS}
@@ -112,7 +113,7 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
 
       <div className="form-section">
         <div className="form-section-head">
-          <h3><i className="fas fa-code-branch"></i> Начальная версия <span className="required-star">*</span></h3>
+          <h3><i className={`fas ${ICONS.version}`}></i> Начальная версия <span className="required-star">*</span></h3>
           <p className="form-section-hint">Первая версия данных и откуда они взяты.</p>
         </div>
         <div className="form-grid">
@@ -152,7 +153,7 @@ const DatasetForm: React.FC<DatasetFormProps> = ({
 
       <div className="form-section">
         <div className="form-section-head">
-          <h3><i className="fas fa-file-zipper"></i> Файл датасета</h3>
+          <h3><i className={`fas ${ICONS.fileArchive}`}></i> Файл датасета</h3>
           <p className="form-section-hint">Архив с изображениями, разложенными по классам.</p>
         </div>
         <FileUploader

--- a/frontend/src/components/datasets/SourcesEditor.css
+++ b/frontend/src/components/datasets/SourcesEditor.css
@@ -1,0 +1,88 @@
+/* Редактор источников версии: draft-блок + список добавленных источников. */
+
+.sources-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Черновик нового источника: тип + url + описание + кнопка */
+.source-draft {
+  display: grid;
+  grid-template-columns: minmax(150px, auto) 1fr 1fr auto;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.source-draft input {
+  width: 100%;
+}
+
+.source-draft .button {
+  white-space: nowrap;
+}
+
+/* Список добавленных источников */
+.source-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.source-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.8rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-strong);
+  border-radius: 8px;
+}
+
+.source-row-type {
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.source-row-url {
+  font-size: 0.85rem;
+  color: var(--color-accent-light);
+  word-break: break-all;
+}
+
+.source-row-desc {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  word-break: break-word;
+}
+
+.source-row-remove {
+  flex-shrink: 0;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+  transition: var(--transition);
+}
+
+.source-row-remove:hover:not(:disabled) {
+  color: var(--color-accent-light);
+  background: var(--color-accent-soft);
+}
+
+@media (max-width: 640px) {
+  .source-draft {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/datasets/SourcesEditor.tsx
+++ b/frontend/src/components/datasets/SourcesEditor.tsx
@@ -1,74 +1,114 @@
-import React from 'react';
+import React, { useState } from 'react';
+import Select from '../common/Select';
+import './SourcesEditor.css';
 import type { SourceItem } from '../../types/dataset';
+
+const SOURCE_TYPE_OPTIONS = [
+  { value: 'kaggle', label: '📊 Kaggle' },
+  { value: 'url', label: '🌐 URL' },
+  { value: 'huggingface', label: '🤗 Hugging Face' },
+  { value: 'other', label: '📁 Другой' },
+];
+
+const TYPE_LABEL: Record<SourceItem['type'], string> = {
+  kaggle: '📊 Kaggle',
+  url: '🌐 URL',
+  huggingface: '🤗 Hugging Face',
+  other: '📁 Другой',
+};
+
+const EMPTY_DRAFT = (): SourceItem => ({ type: 'kaggle', url: null, description: '' });
 
 interface SourcesEditorProps {
   sources: SourceItem[];
   loading: boolean;
-  onAdd: () => void;
-  onRemove: (index: number) => void;
-  onChange: (index: number, field: keyof SourceItem, value: string) => void;
+  onChange: (sources: SourceItem[]) => void;
 }
 
-// Редактор списка источников данных версии: тип, URL, описание + добавление/удаление.
+// Редактор источников по паттерну draft → chip: поля черновика (тип + URL + описание)
+// добавляются кнопкой в список, каждый добавленный источник — строка с крестиком.
 // Единый блок для формы создания датасета и формы добавления версии.
-const SourcesEditor: React.FC<SourcesEditorProps> = ({ sources, loading, onAdd, onRemove, onChange }) => (
-  <div className="sources-container">
-    {sources.map((source, index) => (
-      <div key={index} className="source-card">
-        <div className="source-header">
-          <select
-            value={source.type}
-            onChange={(e) => onChange(index, 'type', e.target.value)}
-            className="source-type-select"
-            disabled={loading}
-          >
-            <option value="kaggle">📊 Kaggle</option>
-            <option value="url">🌐 URL</option>
-            <option value="huggingface">🤗 Hugging Face</option>
-            <option value="other">📁 Другой</option>
-          </select>
-          {sources.length > 1 && (
-            <button
-              type="button"
-              className="source-remove-btn"
-              onClick={() => onRemove(index)}
-              title="Удалить источник"
-              disabled={loading}
-            >
-              <i className="fas fa-trash-alt"></i>
-            </button>
-          )}
+const SourcesEditor: React.FC<SourcesEditorProps> = ({ sources, loading, onChange }) => {
+  const [draft, setDraft] = useState<SourceItem>(EMPTY_DRAFT());
+
+  const canAdd = Boolean(draft.url?.trim() || draft.description.trim());
+
+  const addSource = () => {
+    if (!canAdd) return;
+    onChange([...sources, { ...draft, url: draft.url?.trim() || null, description: draft.description.trim() }]);
+    setDraft(EMPTY_DRAFT());
+  };
+
+  const removeSource = (index: number) => {
+    onChange(sources.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="sources-editor">
+      <div className="source-draft">
+        <div className="source-draft-type">
+          <Select
+            ariaLabel="Тип источника"
+            value={draft.type}
+            options={SOURCE_TYPE_OPTIONS}
+            onChange={(v) => setDraft((d) => ({ ...d, type: v as SourceItem['type'] }))}
+          />
         </div>
-        <div className="source-fields">
-          <div className="form-field">
-            <label>URL источника</label>
-            <input
-              type="url"
-              placeholder="https://..."
-              value={source.url ?? ''}
-              onChange={(e) => onChange(index, 'url', e.target.value)}
-              className="source-input"
-              disabled={loading}
-            />
-          </div>
-          <div className="form-field">
-            <label>Описание</label>
-            <input
-              type="text"
-              placeholder="например: оригинальный источник"
-              value={source.description}
-              onChange={(e) => onChange(index, 'description', e.target.value)}
-              className="source-input"
-              disabled={loading}
-            />
-          </div>
-        </div>
+        <input
+          type="url"
+          autoComplete="off"
+          placeholder="https://..."
+          value={draft.url ?? ''}
+          onChange={(e) => setDraft((d) => ({ ...d, url: e.target.value || null }))}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') { e.preventDefault(); addSource(); }
+          }}
+          disabled={loading}
+        />
+        <input
+          type="text"
+          autoComplete="off"
+          placeholder="Описание, например: оригинальный источник"
+          value={draft.description}
+          onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') { e.preventDefault(); addSource(); }
+          }}
+          disabled={loading}
+        />
+        <button
+          type="button"
+          className="button secondary small"
+          onClick={addSource}
+          disabled={loading || !canAdd}
+        >
+          <i className="fas fa-plus"></i> Добавить
+        </button>
       </div>
-    ))}
-    <button type="button" className="add-source-btn" onClick={onAdd} disabled={loading}>
-      <i className="fas fa-plus-circle"></i> Добавить ещё источник
-    </button>
-  </div>
-);
+
+      {sources.length > 0 && (
+        <ul className="source-list">
+          {sources.map((source, index) => (
+            <li key={index} className="source-row">
+              <span className="source-row-type">{TYPE_LABEL[source.type]}</span>
+              {source.url && <span className="source-row-url">{source.url}</span>}
+              {source.description && <span className="source-row-desc">{source.description}</span>}
+              <button
+                type="button"
+                className="source-row-remove"
+                onClick={() => removeSource(index)}
+                disabled={loading}
+                aria-label="Удалить источник"
+                title="Удалить источник"
+              >
+                <i className="fas fa-xmark"></i>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
 
 export default SourcesEditor;

--- a/frontend/src/components/datasets/SourcesEditor.tsx
+++ b/frontend/src/components/datasets/SourcesEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Select from '../common/Select';
 import './SourcesEditor.css';
+import { ICONS } from '../../constants/icons';
 import type { SourceItem } from '../../types/dataset';
 
 const SOURCE_TYPE_OPTIONS = [
@@ -82,7 +83,7 @@ const SourcesEditor: React.FC<SourcesEditorProps> = ({ sources, loading, onChang
           onClick={addSource}
           disabled={loading || !canAdd}
         >
-          <i className="fas fa-plus"></i> Добавить
+          <i className={`fas ${ICONS.add}`}></i> Добавить
         </button>
       </div>
 
@@ -101,7 +102,7 @@ const SourcesEditor: React.FC<SourcesEditorProps> = ({ sources, loading, onChang
                 aria-label="Удалить источник"
                 title="Удалить источник"
               >
-                <i className="fas fa-xmark"></i>
+                <i className={`fas ${ICONS.close}`}></i>
               </button>
             </li>
           ))}

--- a/frontend/src/components/datasets/VersionSplitsStats.tsx
+++ b/frontend/src/components/datasets/VersionSplitsStats.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ICONS } from '../../constants/icons';
 import type { VersionSplitsResponse } from '../../types/dataset';
 
 interface Props {
@@ -20,7 +21,7 @@ const VersionSplitsStats: React.FC<Props> = ({ stats, onClose }) => {
       <div className="splits-stats-header">
         <span className="splits-stats-title">Статистика сплитов</span>
         <button className="icon-button small" onClick={onClose} title="Скрыть">
-          <i className="fas fa-times"></i>
+          <i className={`fas ${ICONS.close}`}></i>
         </button>
       </div>
       <div className="splits-overall">

--- a/frontend/src/components/datasets/index.ts
+++ b/frontend/src/components/datasets/index.ts
@@ -1,3 +1,4 @@
 export { default as DatasetForm } from './DatasetForm';
 export { default as DatasetCard } from './DatasetCard';
 export { default as AddVersionForm } from './AddVersionForm';
+export { default as VersionSplitsStats } from './VersionSplitsStats';

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ICONS } from '../../constants/icons';
 import './Footer.css';
 
 const Footer: React.FC = () => {
@@ -42,7 +43,7 @@ const Footer: React.FC = () => {
             </a>
           </div>
           <button className="back-to-top" onClick={scrollToTop}>
-            <i className="fas fa-arrow-up"></i> Наверх
+            <i className={`fas ${ICONS.toTop}`}></i> Наверх
           </button>
         </div>
       </div>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -30,7 +30,7 @@ const Footer: React.FC = () => {
               className="social-link"
               title="Telegram"
             >
-              <i className="fab fa-telegram"></i>
+              <i className={`fab ${ICONS.brandTelegram}`}></i>
             </a>
             <a
               href="https://github.com/kisinwi-dev/kisinwi-plt"
@@ -39,7 +39,7 @@ const Footer: React.FC = () => {
               className="social-link"
               title="GitHub"
             >
-              <i className="fab fa-github"></i>
+              <i className={`fab ${ICONS.brandGithub}`}></i>
             </a>
           </div>
           <button className="back-to-top" onClick={scrollToTop}>

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -24,15 +24,6 @@ const Footer: React.FC = () => {
           <h4 className="footer-title">Связь</h4>
           <div className="social-links">
             <a
-              href="https://t.me/andrySin"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="social-link"
-              title="Telegram"
-            >
-              <i className={`fab ${ICONS.brandTelegram}`}></i>
-            </a>
-            <a
               href="https://github.com/kisinwi-dev/kisinwi-plt"
               target="_blank"
               rel="noopener noreferrer"
@@ -50,7 +41,7 @@ const Footer: React.FC = () => {
 
       <div className="footer-bottom">
         <p className="footer-copyright">
-          © {currentYear} KiSinWi. Все права защищены.
+          © {currentYear} KiSinWi. Лицензия MIT.
         </p>
       </div>
     </footer>

--- a/frontend/src/components/layout/Header.css
+++ b/frontend/src/components/layout/Header.css
@@ -6,16 +6,44 @@
   background: var(--color-header-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid transparent;
   position: sticky;
   top: 0;
   z-index: 100;
-  box-shadow: var(--shadow-sm);
+  box-shadow: none;
   transition: var(--transition);
 }
 
-.header:hover {
+/* Уплотнение появляется только при прокрутке страницы. */
+.header.scrolled {
+  border-bottom-color: var(--color-border);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Skip-link — спрятан, проявляется при фокусе с клавиатуры. */
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 0.6rem;
+  z-index: 300;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-input);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  font-weight: 600;
   box-shadow: var(--shadow-md);
+  transform: translateY(-150%);
+  opacity: 0;
+  pointer-events: none;
+  transition: var(--transition);
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* Логотип */
@@ -37,75 +65,153 @@
   opacity: 0.9;
 }
 
+.logo a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
 /* Правая часть шапки: навигация + переключатель темы */
 .header-right {
   display: flex;
   align-items: center;
-  gap: 2rem;
+  gap: 1.25rem;
 }
 
 /* Навигация */
 .nav {
   display: flex;
-  gap: 2rem;
+  gap: 0.35rem;
 }
 
 .nav a {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   color: var(--color-text-secondary);
   font-family: 'Inter', sans-serif;
   font-weight: 500;
   text-decoration: none !important;
   font-size: 0.95rem;
-  padding: 0.5rem 0.2rem;
-  position: relative;
-  transition: var(--transition);
+  padding: 0.5rem 0.95rem;
+  border-radius: var(--radius-pill);
   border: none;
+  transition: var(--transition);
+}
+
+.nav a i {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  transition: var(--transition);
 }
 
 .nav a:hover {
   color: var(--color-text-primary);
+  background: var(--color-accent-soft);
 }
 
-/* Активная ссылка */
+.nav a:hover i {
+  color: inherit;
+}
+
+/* Активная ссылка — мягкая pill-подложка */
 .nav a.active {
   color: var(--color-accent-light);
+  background: var(--color-accent-soft);
   font-weight: 600;
 }
 
-/* Акцентная линия под активной ссылкой */
-.nav a::after {
-  content: '';
-  position: absolute;
-  left: 0.2rem;
-  right: 0.2rem;
-  bottom: 0;
-  height: 2px;
-  border-radius: 2px;
-  background: var(--color-accent);
-  transform: scaleX(0);
-  transition: var(--transition);
+.nav a.active i {
+  color: inherit;
 }
 
-.nav a.active::after {
-  transform: scaleX(1);
+.nav a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* Кнопка-бургер — стиль как у переключателя темы, скрыта на десктопе */
+.nav-toggle {
+  display: none;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  border: var(--border-subtle);
+  border-radius: 50%;
+  font-size: 1rem;
+  box-shadow: none;
+}
+
+.nav-toggle:hover {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  transform: none;
+  box-shadow: none;
+}
+
+.nav-toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* Адаптивность */
 @media (max-width: 768px) {
   .header {
-    flex-direction: column;
     padding: 0.8rem 1.5rem;
-    gap: 0.8rem;
   }
-  .header-right {
-    flex-direction: column;
-    gap: 0.8rem;
+
+  .nav-toggle {
+    display: flex;
   }
+
+  /* Навигация превращается в выпадающую панель (как меню темы) */
   .nav {
-    flex-wrap: wrap;
-    justify-content: center;
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 1.5rem;
+    flex-direction: column;
+    gap: 0.15rem;
+    min-width: 200px;
+    padding: 0.4rem;
+    background: var(--color-bg-secondary);
+    border: var(--border-soft);
+    border-radius: var(--radius-input);
+    box-shadow: var(--shadow-md);
+    z-index: 200;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-6px);
+    transition: var(--transition);
   }
+
+  .nav.open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  .nav a {
+    width: 100%;
+    border-radius: 8px;
+  }
+
   .logo a {
     font-size: 1.6rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header,
+  .skip-link,
+  .logo a,
+  .nav,
+  .nav a,
+  .nav a i,
+  .nav-toggle {
+    transition: none;
   }
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,21 +1,86 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import ThemeSwitcher from './ThemeSwitcher';
+import { ICONS } from '../../constants/icons';
 import './Header.css';
 
+// Пункты навигации описаны данными, чтобы не дублировать разметку
+// между десктопным рядом ссылок и мобильным выпадающим меню.
+const NAV_ITEMS = [
+  { to: '/', label: 'Главная', icon: ICONS.home },
+  { to: '/datasets', label: 'Датасеты', icon: ICONS.dataset },
+  { to: '/agents', label: 'Агенты', icon: ICONS.agent },
+  { to: '/models', label: 'Модели', icon: ICONS.model },
+] as const;
+
 const Header: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+  const navRef = useRef<HTMLDivElement>(null);
+
+  // Тень/уплотнение шапки появляются только после прокрутки страницы.
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Закрываем меню по клику вне него и по Escape (паттерн как в ThemeSwitcher).
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (navRef.current && !navRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
   return (
-    <header className="header">
+    <header className={`header ${scrolled ? 'scrolled' : ''}`}>
+      <a className="skip-link" href="#main-content">Перейти к содержимому</a>
+
       <div className="logo">
-        <NavLink to="/">KiSinWi</NavLink>
+        <NavLink to="/" onClick={() => setOpen(false)}>KiSinWi</NavLink>
       </div>
-      <div className="header-right">
-        <nav className="nav">
-          <NavLink to="/" className={({ isActive }) => isActive ? 'active' : ''}>Главная</NavLink>
-          <NavLink to="/datasets" className={({ isActive }) => isActive ? 'active' : ''}>Датасеты</NavLink>
-          <NavLink to="/agents" className={({ isActive }) => isActive ? 'active' : ''}>Агенты</NavLink>
-          <NavLink to="/models" className={({ isActive }) => isActive ? 'active' : ''}>Модели</NavLink>
+
+      <div className="header-right" ref={navRef}>
+        <button
+          className="nav-toggle"
+          onClick={() => setOpen((v) => !v)}
+          aria-label={open ? 'Закрыть меню' : 'Открыть меню'}
+          aria-haspopup="true"
+          aria-expanded={open}
+          aria-controls="primary-nav"
+        >
+          <i className={`fas ${open ? ICONS.menuClose : ICONS.menu}`}></i>
+        </button>
+
+        <nav
+          id="primary-nav"
+          className={`nav ${open ? 'open' : ''}`}
+          aria-label="Основная навигация"
+        >
+          {NAV_ITEMS.map(({ to, label, icon }) => (
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }) => (isActive ? 'active' : '')}
+              onClick={() => setOpen(false)}
+            >
+              <i className={`fas ${icon}`}></i>
+              <span>{label}</span>
+            </NavLink>
+          ))}
         </nav>
+
         <ThemeSwitcher />
       </div>
     </header>

--- a/frontend/src/components/layout/ThemeSwitcher.tsx
+++ b/frontend/src/components/layout/ThemeSwitcher.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { THEMES, applyTheme, getStoredTheme, type ThemeId } from '../../theme/themes';
+import { ICONS } from '../../constants/icons';
 import './ThemeSwitcher.css';
 
 const ThemeSwitcher: React.FC = () => {
@@ -48,7 +49,7 @@ const ThemeSwitcher: React.FC = () => {
               >
                 <i className={`fas ${t.icon}`}></i>
                 <span>{t.label}</span>
-                {t.id === theme && <i className="fas fa-check theme-switcher-check"></i>}
+                {t.id === theme && <i className={`fas ${ICONS.selected} theme-switcher-check`}></i>}
               </button>
             </li>
           ))}

--- a/frontend/src/components/models/ModelCard.tsx
+++ b/frontend/src/components/models/ModelCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { MLModel } from '../../types/mlModels';
 import { formatDateTime } from '../../utils/format';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   model: MLModel;
@@ -28,7 +29,7 @@ const ModelCard: React.FC<Props> = ({ model }) => {
         <div className="model-title-group">
           <h2>{model.name}</h2>
           <span className="model-version" title="Версия">
-            <i className="fas fa-code-branch"></i> v{model.version}
+            <i className={`fas ${ICONS.version}`}></i> v{model.version}
           </span>
         </div>
         <span className={`status-badge status-${model.status}`}>{model.status}</span>
@@ -37,23 +38,23 @@ const ModelCard: React.FC<Props> = ({ model }) => {
       <div className="model-meta">
         {model.model_type && (
           <span title="Тип модели">
-            <i className="fas fa-cube"></i>
+            <i className={`fas ${ICONS.model}`}></i>
             <span className="meta-label">Тип:</span> {model.model_type}
           </span>
         )}
         {model.framework && (
           <span title="Фреймворк">
-            <i className="fas fa-layer-group"></i>
+            <i className={`fas ${ICONS.framework}`}></i>
             <span className="meta-label">Фреймворк:</span> {model.framework}
             {model.framework_version ? ` ${model.framework_version}` : ''}
           </span>
         )}
         <span title="Количество классов">
-          <i className="fas fa-tags"></i>
+          <i className={`fas ${ICONS.classes}`}></i>
           <span className="meta-label">Классов:</span> {model.classes.length}
         </span>
         <span title="Дата создания">
-          <i className="fas fa-calendar-alt"></i>
+          <i className={`fas ${ICONS.dateCreated}`}></i>
           <span className="meta-label">Создана:</span> {formatDateTime(model.created_at)}
         </span>
       </div>

--- a/frontend/src/components/models/ModelCard.tsx
+++ b/frontend/src/components/models/ModelCard.tsx
@@ -36,16 +36,26 @@ const ModelCard: React.FC<Props> = ({ model }) => {
 
       <div className="model-meta">
         {model.model_type && (
-          <span><i className="fas fa-cube"></i> {model.model_type}</span>
+          <span title="Тип модели">
+            <i className="fas fa-cube"></i>
+            <span className="meta-label">Тип:</span> {model.model_type}
+          </span>
         )}
         {model.framework && (
-          <span>
-            <i className="fas fa-layer-group"></i> {model.framework}
+          <span title="Фреймворк">
+            <i className="fas fa-layer-group"></i>
+            <span className="meta-label">Фреймворк:</span> {model.framework}
             {model.framework_version ? ` ${model.framework_version}` : ''}
           </span>
         )}
-        <span><i className="fas fa-tags"></i> {model.classes.length} классов</span>
-        <span><i className="fas fa-calendar-alt"></i> {formatDateTime(model.created_at)}</span>
+        <span title="Количество классов">
+          <i className="fas fa-tags"></i>
+          <span className="meta-label">Классов:</span> {model.classes.length}
+        </span>
+        <span title="Дата создания">
+          <i className="fas fa-calendar-alt"></i>
+          <span className="meta-label">Создана:</span> {formatDateTime(model.created_at)}
+        </span>
       </div>
 
       {model.description && (

--- a/frontend/src/components/models/ModelGroupCard.tsx
+++ b/frontend/src/components/models/ModelGroupCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { MLModelGroup, MLModel } from '../../types/mlModels';
-import { formatDateParts } from '../../utils/format';
+import { formatDateParts, formatDateTime } from '../../utils/format';
 import { mlModelsService } from '../../services/mlModelsService';
 import { useNotification } from '../../contexts/NotificationContext';
 import ConfirmModal from '../common/ConfirmModal';
@@ -20,11 +20,19 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
   const { showNotification } = useNotification();
   const latest = group.versions[0];
   const [sortAsc, setSortAsc] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const [pending, setPending] = useState<PendingDelete | null>(null);
 
   const sorted = [...group.versions].sort((a, b) =>
     sortAsc ? Number(a.version) - Number(b.version) : Number(b.version) - Number(a.version)
   );
+
+  // По умолчанию показываем только COLLAPSED_COUNT свежих версий, чтобы не растягивать
+  // страницу. Остальные — под кнопкой «показать все».
+  const COLLAPSED_COUNT = 3;
+  const collapsible = sorted.length > COLLAPSED_COUNT;
+  const visible = collapsible && !expanded ? sorted.slice(0, COLLAPSED_COUNT) : sorted;
+  const hiddenCount = sorted.length - visible.length;
 
   const handleConfirmDelete = async () => {
     if (!pending) return;
@@ -47,21 +55,12 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
     <>
       <div className="card model-group-card">
         <div className="model-group-header">
-          <div className="model-title-group">
-            <h2>{group.name}</h2>
-            <span className="model-group-count">
-              <i className="fas fa-code-branch"></i> {group.versions.length} {group.versions.length === 1 ? 'версия' : group.versions.length < 5 ? 'версии' : 'версий'}
-            </span>
-          </div>
-          <div className="model-group-header-actions">
-            <div className="model-meta">
-              {latest.framework && (
-                <span>
-                  <i className="fas fa-layer-group"></i> {latest.framework}
-                  {latest.framework_version ? ` ${latest.framework_version}` : ''}
-                </span>
-              )}
-              <span><i className="fas fa-tags"></i> {latest.classes.length} классов</span>
+          <div className="model-group-header-top">
+            <div className="model-title-group">
+              <h2>{group.name}</h2>
+              <span className="model-group-count">
+                <i className="fas fa-code-branch"></i> {group.versions.length} {group.versions.length === 1 ? 'версия' : group.versions.length < 5 ? 'версии' : 'версий'}
+              </span>
             </div>
             <button
               className="btn-icon btn-icon--danger"
@@ -70,6 +69,16 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
             >
               <i className="fas fa-trash"></i>
             </button>
+          </div>
+          <div className="model-meta model-group-meta">
+            {latest.framework && (
+              <span>
+                <i className="fas fa-layer-group"></i> {latest.framework}
+                {latest.framework_version ? ` ${latest.framework_version}` : ''}
+              </span>
+            )}
+            <span><i className="fas fa-tags"></i> {latest.classes.length} классов</span>
+            <span><i className="fas fa-calendar-alt"></i> {formatDateTime(latest.created_at)}</span>
           </div>
         </div>
 
@@ -99,7 +108,7 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
               </tr>
             </thead>
             <tbody>
-              {sorted.map((v) => (
+              {visible.map((v) => (
                 <tr
                   key={v.id}
                   className="model-version-row"
@@ -134,6 +143,18 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
               ))}
             </tbody>
           </table>
+
+          {collapsible && (
+            <button
+              className="versions-toggle"
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+            >
+              {expanded
+                ? <><i className="fas fa-chevron-up"></i> Свернуть</>
+                : <><i className="fas fa-chevron-down"></i> Показать ещё {hiddenCount}</>}
+            </button>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/models/ModelGroupCard.tsx
+++ b/frontend/src/components/models/ModelGroupCard.tsx
@@ -5,6 +5,7 @@ import { formatDateParts, formatDateTime } from '../../utils/format';
 import { mlModelsService } from '../../services/mlModelsService';
 import { useNotification } from '../../contexts/NotificationContext';
 import ConfirmModal from '../common/ConfirmModal';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   group: MLModelGroup;
@@ -59,7 +60,7 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
             <div className="model-title-group">
               <h2>{group.name}</h2>
               <span className="model-group-count">
-                <i className="fas fa-code-branch"></i> {group.versions.length} {group.versions.length === 1 ? 'версия' : group.versions.length < 5 ? 'версии' : 'версий'}
+                <i className={`fas ${ICONS.version}`}></i> {group.versions.length} {group.versions.length === 1 ? 'версия' : group.versions.length < 5 ? 'версии' : 'версий'}
               </span>
             </div>
             <button
@@ -67,23 +68,23 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
               title="Удалить все версии"
               onClick={(e) => { e.stopPropagation(); setPending({ kind: 'group', name: group.name, count: group.versions.length }); }}
             >
-              <i className="fas fa-trash"></i>
+              <i className={`fas ${ICONS.delete}`}></i>
             </button>
           </div>
           <div className="model-meta model-group-meta">
             {latest.framework && (
               <span title="Фреймворк (последняя версия)">
-                <i className="fas fa-layer-group"></i>
+                <i className={`fas ${ICONS.framework}`}></i>
                 <span className="meta-label">Фреймворк:</span> {latest.framework}
                 {latest.framework_version ? ` ${latest.framework_version}` : ''}
               </span>
             )}
             <span title="Количество классов (последняя версия)">
-              <i className="fas fa-tags"></i>
+              <i className={`fas ${ICONS.classes}`}></i>
               <span className="meta-label">Классов:</span> {latest.classes.length}
             </span>
             <span title="Дата последней версии">
-              <i className="fas fa-calendar-alt"></i>
+              <i className={`fas ${ICONS.dateUpdated}`}></i>
               <span className="meta-label">Обновлена:</span> {formatDateTime(latest.created_at)}
             </span>
           </div>
@@ -104,8 +105,8 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
                 >
                   Версия
                   <span className={`sort-icon${sortAsc ? ' sort-asc' : ' sort-desc'}`}>
-                    <i className="fas fa-chevron-up sort-icon-up"></i>
-                    <i className="fas fa-chevron-down sort-icon-down"></i>
+                    <i className={`fas ${ICONS.collapse} sort-icon-up`}></i>
+                    <i className={`fas ${ICONS.expand} sort-icon-down`}></i>
                   </span>
                 </th>
                 <th>Тип</th>
@@ -130,7 +131,7 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
                   }}
                 >
                   <td className="model-version-label">
-                    <i className="fas fa-code-branch"></i> v{v.version}
+                    <i className={`fas ${ICONS.version}`}></i> v{v.version}
                   </td>
                   <td className="model-version-type">{v.model_type ?? '—'}</td>
                   <td><span className={`status-badge status-${v.status}`}>{v.status}</span></td>
@@ -143,7 +144,7 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
                       title="Удалить версию"
                       onClick={(e) => { e.stopPropagation(); setPending({ kind: 'version', model: v }); }}
                     >
-                      <i className="fas fa-trash"></i>
+                      <i className={`fas ${ICONS.delete}`}></i>
                     </button>
                   </td>
                 </tr>
@@ -158,8 +159,8 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
               aria-expanded={expanded}
             >
               {expanded
-                ? <><i className="fas fa-chevron-up"></i> Свернуть</>
-                : <><i className="fas fa-chevron-down"></i> Показать ещё {hiddenCount}</>}
+                ? <><i className={`fas ${ICONS.collapse}`}></i> Свернуть</>
+                : <><i className={`fas ${ICONS.expand}`}></i> Показать ещё {hiddenCount}</>}
             </button>
           )}
         </div>

--- a/frontend/src/components/models/ModelGroupCard.tsx
+++ b/frontend/src/components/models/ModelGroupCard.tsx
@@ -63,7 +63,7 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
               </span>
             </div>
             <button
-              className="btn-icon btn-icon--danger"
+              className="icon-button icon-button--danger"
               title="Удалить все версии"
               onClick={(e) => { e.stopPropagation(); setPending({ kind: 'group', name: group.name, count: group.versions.length }); }}
             >
@@ -72,13 +72,20 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
           </div>
           <div className="model-meta model-group-meta">
             {latest.framework && (
-              <span>
-                <i className="fas fa-layer-group"></i> {latest.framework}
+              <span title="Фреймворк (последняя версия)">
+                <i className="fas fa-layer-group"></i>
+                <span className="meta-label">Фреймворк:</span> {latest.framework}
                 {latest.framework_version ? ` ${latest.framework_version}` : ''}
               </span>
             )}
-            <span><i className="fas fa-tags"></i> {latest.classes.length} классов</span>
-            <span><i className="fas fa-calendar-alt"></i> {formatDateTime(latest.created_at)}</span>
+            <span title="Количество классов (последняя версия)">
+              <i className="fas fa-tags"></i>
+              <span className="meta-label">Классов:</span> {latest.classes.length}
+            </span>
+            <span title="Дата последней версии">
+              <i className="fas fa-calendar-alt"></i>
+              <span className="meta-label">Обновлена:</span> {formatDateTime(latest.created_at)}
+            </span>
           </div>
         </div>
 
@@ -132,7 +139,7 @@ const ModelGroupCard: React.FC<Props> = ({ group, onReload }) => {
                   </td>
                   <td className="model-version-actions">
                     <button
-                      className="btn-icon btn-icon--danger btn-icon--sm"
+                      className="icon-button icon-button--danger small"
                       title="Удалить версию"
                       onClick={(e) => { e.stopPropagation(); setPending({ kind: 'version', model: v }); }}
                     >

--- a/frontend/src/components/models/ModelMetricsCharts.tsx
+++ b/frontend/src/components/models/ModelMetricsCharts.tsx
@@ -11,6 +11,7 @@ import {
 import { metricsService } from '../../services/metricsService';
 import { usePolling } from '../../hooks';
 import { POLL_INTERVAL_METRICS_MS } from '../../constants';
+import { ICONS } from '../../constants/icons';
 
 interface Props {
   modelId: string;
@@ -43,7 +44,7 @@ const ModelMetricsCharts: React.FC<Props> = ({ modelId }) => {
   if (status === 'loading') {
     return (
       <div className="metrics-charts-placeholder">
-        <i className="fas fa-spinner fa-spin"></i> Загрузка графиков…
+        <i className={`fas ${ICONS.loading} fa-spin`}></i> Загрузка графиков…
       </div>
     );
   }
@@ -51,7 +52,7 @@ const ModelMetricsCharts: React.FC<Props> = ({ modelId }) => {
   if (status === 'error') {
     return (
       <div className="metrics-charts-placeholder metrics-charts-placeholder--error">
-        <i className="fas fa-triangle-exclamation"></i> Не удалось загрузить данные из сервиса метрик.
+        <i className={`fas ${ICONS.warning}`}></i> Не удалось загрузить данные из сервиса метрик.
       </div>
     );
   }
@@ -59,7 +60,7 @@ const ModelMetricsCharts: React.FC<Props> = ({ modelId }) => {
   if (status === 'empty') {
     return (
       <div className="metrics-charts-placeholder">
-        <i className="fas fa-chart-line"></i> Данные по эпохам отсутствуют.
+        <i className={`fas ${ICONS.metrics}`}></i> Данные по эпохам отсутствуют.
       </div>
     );
   }

--- a/frontend/src/components/notification/NotificationToast.tsx
+++ b/frontend/src/components/notification/NotificationToast.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 // Импортируем хук для доступа к контексту уведомлений.
 import { useNotification } from '../../contexts/NotificationContext';
+import { ICONS } from '../../constants/icons';
 // Подключаем стили для компонента уведомлений.
 import './NotificationToast.css';
 
 /**
- * Возвращает иконку в зависимости от типа уведомления.
+ * Возвращает класс иконки Font Awesome в зависимости от типа уведомления.
  * @param type - тип уведомления ('error', 'success', 'warning', 'info').
- * @returns строка с эмодзи, соответствующая типу.
+ * @returns класс иконки Font Awesome.
  */
 const getIcon = (type: string) => {
   switch (type) {
-    case 'error': return '❌';   // Ошибка – красный крестик
-    case 'success': return '✅'; // Успех – зелёная галочка
-    case 'warning': return '⚠️'; // Предупреждение – жёлтый знак опасности
-    case 'info': return 'ℹ️';    // Информация – синяя буква i
-    default: return '•';         // Если тип неизвестен, просто точка
+    case 'error': return ICONS.error;
+    case 'success': return ICONS.success;
+    case 'warning': return ICONS.warning;
+    case 'info': return ICONS.info;
+    default: return ICONS.info;
   }
 };
 
@@ -40,13 +41,13 @@ const NotificationToast: React.FC = () => {
         <div key={n.id} className={`notification notification-${n.type}`}>
           <div className="notification-content">
             {/* Иконка, соответствующая типу */}
-            <span className="notification-icon">{getIcon(n.type)}</span>
+            <span className="notification-icon"><i className={`fas ${getIcon(n.type)}`}></i></span>
             {/* Текст сообщения */}
             <span className="notification-message">{n.message}</span>
           </div>
           {/* Кнопка закрытия – при клике удаляем уведомление по id */}
           <button className="notification-close" onClick={() => removeNotification(n.id)}>
-            ✕
+            <i className={`fas ${ICONS.close}`}></i>
           </button>
         </div>
       ))}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -3,9 +3,6 @@
 // Сколько моделей грузим на одну страницу списка моделей.
 export const MODELS_PAGE_SIZE = 12;
 
-// Сколько агентов показываем в карточке дискуссии до сворачивания.
-export const DISCUSSION_AGENTS_LIMIT = 3;
-
 // Интервал опроса прогресса активной дискуссии (meta и лента сообщений).
 export const POLL_INTERVAL_DISCUSSION_MS = 3000;
 

--- a/frontend/src/constants/icons.ts
+++ b/frontend/src/constants/icons.ts
@@ -1,0 +1,90 @@
+// Единый реестр иконок интерфейса (Font Awesome 6, CDN подключён в index.html).
+// Значения хранятся без префикса `fas`/`fab` — как в theme/themes.ts и SYSTEM_ICONS.
+// Использование в JSX: <i className={`fas ${ICONS.delete}`} />
+//   loading-спиннер: <i className={`fas ${ICONS.loading} fa-spin`} />
+// Ключи — это семантические РОЛИ, поэтому совпадение значений у разных ролей
+// (например classes/tags = fa-tags) допустимо и намеренно.
+
+export const ICONS = {
+  // --- действия ---
+  add: 'fa-plus',
+  delete: 'fa-trash',          // удаление сущности (датасет, версия, модель, дискуссия)
+  close: 'fa-xmark',           // закрытие/сброс/удаление элемента списка/файла
+  search: 'fa-search',
+  copy: 'fa-copy',
+  filter: 'fa-filter',
+  back: 'fa-arrow-left',
+  toTop: 'fa-arrow-up',
+  external: 'fa-arrow-up-right-from-square',
+  download: 'fa-download',
+  star: 'fa-star',             // версия по умолчанию
+  play: 'fa-play',             // запуск pipeline
+  expand: 'fa-chevron-down',
+  collapse: 'fa-chevron-up',
+  pagePrev: 'fa-chevron-left',
+  pageNext: 'fa-chevron-right',
+  selected: 'fa-check',        // выбранный пункт в списке/дропдауне
+  listView: 'fa-list',         // переключатель «плоский список»
+  groupedView: 'fa-layer-group', // переключатель «группировка по моделям»
+
+  // --- статусы ---
+  loading: 'fa-spinner',       // + fa-spin
+  info: 'fa-circle-info',
+  success: 'fa-circle-check',
+  warning: 'fa-triangle-exclamation',
+  error: 'fa-circle-exclamation',
+  notFound: 'fa-triangle-exclamation',
+  question: 'fa-circle-question',
+  empty: 'fa-box-open',        // пустой список результатов
+
+  // --- сущности ---
+  dataset: 'fa-database',
+  datasetType: 'fa-shapes',
+  model: 'fa-cube',
+  framework: 'fa-layer-group', // ML-фреймворк (PyTorch/TF и т.п.)
+  version: 'fa-code-branch',
+  agent: 'fa-robot',
+  agentsGroup: 'fa-users',
+  agentModel: 'fa-brain',       // LLM-модель агента
+  discussion: 'fa-comments',    // обсуждение / ответы агентов
+  noMessages: 'fa-comment-slash',
+  pipeline: 'fa-diagram-project',
+  task: 'fa-list-check',
+  tools: 'fa-wrench',
+  trainingParams: 'fa-sliders',
+  metrics: 'fa-chart-line',
+  datasetStats: 'fa-chart-bar', // статистика splits версии датасета
+  report: 'fa-file-lines',
+  weights: 'fa-file-arrow-down',
+  file: 'fa-file',
+
+  // --- данные / мета ---
+  id: 'fa-hashtag',
+  tag: 'fa-tag',                // тип/задача (одиночный ярлык)
+  tags: 'fa-tags',             // классы / множество ярлыков
+  classes: 'fa-tags',
+  samples: 'fa-images',
+  link: 'fa-link',
+  description: 'fa-align-left',
+  taskTarget: 'fa-bullseye',   // поле «Задача» датасета
+  dateCreated: 'fa-calendar-alt',
+  dateUpdated: 'fa-rotate',
+  dateFinished: 'fa-flag-checkered',
+  duration: 'fa-clock',
+  iteration: 'fa-rotate',
+  history: 'fa-clock-rotate-left',
+
+  // --- файлы (FileUploader) ---
+  upload: 'fa-cloud-arrow-up',
+  fileArchive: 'fa-file-zipper',
+  fileImage: 'fa-file-image',
+  fileTable: 'fa-file-csv',
+  fileText: 'fa-file-lines',
+
+  // --- темы оформления (переключатель) ---
+  themeDark: 'fa-moon',
+  themeLight: 'fa-sun',
+  themeMidnight: 'fa-cloud-moon',
+} as const;
+
+export type IconKey = keyof typeof ICONS;

--- a/frontend/src/constants/icons.ts
+++ b/frontend/src/constants/icons.ts
@@ -27,6 +27,8 @@ export const ICONS = {
   selected: 'fa-check',        // выбранный пункт в списке/дропдауне
   listView: 'fa-list',         // переключатель «плоский список»
   groupedView: 'fa-layer-group', // переключатель «группировка по моделям»
+  menu: 'fa-bars',             // открыть мобильное меню (бургер)
+  menuClose: 'fa-xmark',       // закрыть мобильное меню (бургер в открытом состоянии)
 
   // --- статусы ---
   loading: 'fa-spinner',       // + fa-spin
@@ -39,6 +41,7 @@ export const ICONS = {
   empty: 'fa-box-open',        // пустой список результатов
 
   // --- сущности ---
+  home: 'fa-house',            // главная страница (пункт навигации)
   dataset: 'fa-database',
   datasetType: 'fa-shapes',
   model: 'fa-cube',

--- a/frontend/src/constants/icons.ts
+++ b/frontend/src/constants/icons.ts
@@ -1,6 +1,7 @@
 // Единый реестр иконок интерфейса (Font Awesome 6, CDN подключён в index.html).
 // Значения хранятся без префикса `fas`/`fab` — как в theme/themes.ts и SYSTEM_ICONS.
 // Использование в JSX: <i className={`fas ${ICONS.delete}`} />
+//   brand-иконки (секция «бренды») идут с префиксом `fab`: <i className={`fab ${ICONS.brandGithub}`} />
 //   loading-спиннер: <i className={`fas ${ICONS.loading} fa-spin`} />
 // Ключи — это семантические РОЛИ, поэтому совпадение значений у разных ролей
 // (например classes/tags = fa-tags) допустимо и намеренно.
@@ -85,6 +86,10 @@ export const ICONS = {
   themeDark: 'fa-moon',
   themeLight: 'fa-sun',
   themeMidnight: 'fa-cloud-moon',
+
+  // --- бренды (использование с префиксом `fab`, а не `fas`) ---
+  brandTelegram: 'fa-telegram',
+  brandGithub: 'fa-github',
 } as const;
 
 export type IconKey = keyof typeof ICONS;

--- a/frontend/src/constants/icons.ts
+++ b/frontend/src/constants/icons.ts
@@ -88,7 +88,6 @@ export const ICONS = {
   themeMidnight: 'fa-cloud-moon',
 
   // --- бренды (использование с префиксом `fab`, а не `fas`) ---
-  brandTelegram: 'fa-telegram',
   brandGithub: 'fa-github',
 } as const;
 

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useCopyToClipboard } from './useCopyToClipboard';
 export { usePolling } from './usePolling';
+export { useDebouncedValue } from './useDebouncedValue';
 export { useModelFilters } from './useModelFilters';
 export type { ModelFilters } from './useModelFilters';

--- a/frontend/src/hooks/useCopyToClipboard.ts
+++ b/frontend/src/hooks/useCopyToClipboard.ts
@@ -6,13 +6,18 @@ import { useNotification } from '../contexts/NotificationContext';
  * Возвращает стабильный колбэк (text) => void.
  * e.stopPropagation() при необходимости вызывать на месте (хук работает только с текстом).
  */
-export const useCopyToClipboard = (successMessage = 'ID скопирован'): ((text: string) => void) => {
+export const useCopyToClipboard = (
+  successMessage = 'ID скопирован',
+  errorMessage = 'Не удалось скопировать',
+): ((text: string) => void) => {
   const { showNotification } = useNotification();
   return useCallback(
     (text: string) => {
-      navigator.clipboard.writeText(text);
-      showNotification(successMessage, 'success');
+      navigator.clipboard.writeText(text).then(
+        () => showNotification(successMessage, 'success'),
+        () => showNotification(errorMessage, 'error'),
+      );
     },
-    [showNotification, successMessage],
+    [showNotification, successMessage, errorMessage],
   );
 };

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Возвращает значение с задержкой: обновляется только после паузы во вводе.
+ * Полезно, чтобы не слать запрос на каждое нажатие клавиши.
+ */
+export const useDebouncedValue = <T>(value: T, delay = 350): T => {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+};

--- a/frontend/src/pages/AgentDiscussion.tsx
+++ b/frontend/src/pages/AgentDiscussion.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { DiscussionDetail } from '../components/agents';
+import './Agents.css';
+
+// Отдельная страница детального просмотра дискуссии (/agents/discussion/:discussionId).
+// Сама загрузка meta и ленты сообщений — внутри DiscussionDetail.
+const AgentDiscussion: React.FC = () => {
+  const { discussionId } = useParams<{ discussionId: string }>();
+  const navigate = useNavigate();
+
+  if (!discussionId) {
+    return <Navigate to="/agents" replace />;
+  }
+
+  return (
+    <div className="page">
+      <DiscussionDetail discussionId={discussionId} onBack={() => navigate('/agents')} />
+    </div>
+  );
+};
+
+export default AgentDiscussion;

--- a/frontend/src/pages/Agents.css
+++ b/frontend/src/pages/Agents.css
@@ -620,6 +620,26 @@
   gap: 1rem;
 }
 
+.discussion-running {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 1rem;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+  animation: discussion-running-pulse 1.6s ease-in-out infinite;
+}
+
+.discussion-running i {
+  color: var(--color-info);
+}
+
+@keyframes discussion-running-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
 .message-bubble {
   background: var(--color-bg-secondary);
   border-radius: 14px;

--- a/frontend/src/pages/Agents.css
+++ b/frontend/src/pages/Agents.css
@@ -427,19 +427,116 @@
   margin-right: 0.3rem;
 }
 
-/* ── Лента диалога ───────────────────────────────────────────────────────────── */
-.discussion-feed {
+/* ── Лента диалога: вертикальный timeline ────────────────────────────────────── */
+.discussion-timeline {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
+/* Строка ленты: [узел на оси] [контент]. Ось — псевдоэлемент за узлом. */
+.timeline-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: var(--timeline-node-size, 38px) 1fr;
+  gap: 0.9rem;
+  align-items: start;
+}
+
+/* Соединительная линия оси: непрерывна по всей высоте строки, узлы перекрывают её
+   своим фоном — поэтому размер/выравнивание узла не рвёт линию. */
+.timeline-row::before {
+  content: '';
+  position: absolute;
+  z-index: 0;
+  left: calc(var(--timeline-node-size, 38px) / 2);
+  top: 0;
+  bottom: calc(-1rem - 1px);
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--color-border-strong);
+}
+
+.discussion-timeline > .timeline-row:last-child::before {
+  display: none;
+}
+
+/* Узел на оси. */
+.timeline-node {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--timeline-node-size, 38px);
+  height: var(--timeline-node-size, 38px);
+  border-radius: 50%;
+  font-size: 0.85rem;
+  background: var(--color-bg-secondary);
+  border: 2px solid var(--color-border-strong);
+  color: var(--color-text-secondary);
+}
+
+/* Цвет узла-ответа по статусу запуска агента. */
+.timeline-node.status-succeed {
+  border-color: var(--color-success);
+  background: var(--color-success-soft);
+  color: var(--color-success);
+}
+.timeline-node.status-error {
+  border-color: var(--color-danger);
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+}
+.timeline-node.status-in-progress {
+  border-color: var(--color-info);
+  background: var(--color-info-soft);
+  color: var(--color-info);
+}
+
+/* Узел системного сообщения — цвет наследуется от msg-* на строке. */
+.timeline-node--system {
+  width: 30px;
+  height: 30px;
+  margin: 0 auto;
+  font-size: 0.75rem;
+}
+.timeline-row--system { align-items: center; }
+.msg-info .timeline-node--system { border-color: var(--color-info); color: var(--color-info); }
+.msg-warning .timeline-node--system { border-color: var(--color-warning); color: var(--color-warning); }
+.msg-error .timeline-node--system { border-color: var(--color-danger); color: var(--color-danger); }
+
+.timeline-content {
+  min-width: 0;
+}
+
+/* Активный узел в конце оси — «агенты работают». */
+.timeline-row--active { align-items: center; }
+
+.timeline-node--active {
+  border-color: var(--color-info);
+  background: var(--color-info-soft);
+  color: var(--color-info);
+}
+
+.timeline-node-pulse {
+  position: absolute;
+  inset: -2px;
+  border-radius: 50%;
+  border: 2px solid var(--color-info);
+  animation: timeline-node-pulse 1.6s ease-out infinite;
+}
+
+@keyframes timeline-node-pulse {
+  0% { transform: scale(1); opacity: 0.7; }
+  100% { transform: scale(1.6); opacity: 0; }
+}
+
 .discussion-running {
   display: flex;
   align-items: center;
-  justify-content: center;
   gap: 0.6rem;
-  padding: 1rem;
+  padding: 0.55rem 0;
   color: var(--color-text-secondary);
   font-size: 0.95rem;
   animation: discussion-running-pulse 1.6s ease-in-out infinite;
@@ -453,6 +550,52 @@
   0%, 100% { opacity: 0.55; }
   50% { opacity: 1; }
 }
+
+/* ── Skeleton загрузки ленты ──────────────────────────────────────────────────── */
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--color-surface-faint);
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--color-text-secondary) 12%, transparent),
+    transparent
+  );
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  100% { transform: translateX(100%); }
+}
+
+.timeline-node--skeleton {
+  border-color: var(--color-border-soft);
+}
+
+.message-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1.2rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+}
+
+.skeleton-line {
+  height: 0.7rem;
+  border-radius: 6px;
+}
+.skeleton-line--head { width: 35%; height: 0.9rem; }
+.skeleton-line--short { width: 60%; }
 
 .message-bubble {
   background: var(--color-bg-secondary);
@@ -507,10 +650,33 @@
   font-weight: 600;
   font-size: 1.05rem;
   color: var(--color-accent-light);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.message-role i {
-  margin-right: 0.4rem;
+.message-header-duration {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.message-header-duration i {
+  margin-right: 0.25rem;
+  opacity: 0.7;
+}
+
+/* Превью текста в свёрнутой карточке — позволяет сканировать ленту без раскрытия. */
+.message-preview {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .message-meta {
@@ -670,7 +836,34 @@
   border-radius: 10px;
   padding: 0.9rem;
   border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-border-strong);
 }
+
+/* Цветовая кодировка статуса вызова инструмента (левая полоса). */
+.tool-item.status-succeed { border-left-color: var(--color-success); }
+.tool-item.status-error { border-left-color: var(--color-danger); }
+.tool-item.status-in-progress { border-left-color: var(--color-info); }
+
+/* Мини-bar относительной длительности вызова. */
+.tool-latency-bar {
+  display: inline-block;
+  width: 48px;
+  height: 5px;
+  border-radius: 3px;
+  background: var(--color-surface-faint);
+  overflow: hidden;
+  vertical-align: middle;
+  margin-right: 0.1rem;
+}
+
+.tool-latency-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--color-accent);
+}
+
+.tool-item.status-error .tool-latency-bar-fill { background: var(--color-danger); }
 
 .tool-header {
   display: flex;
@@ -713,8 +906,16 @@
   color: var(--color-text-secondary);
 }
 
-.tool-header-right i {
-  margin-right: 0.3rem;
+.tool-duration {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  white-space: nowrap;
+}
+
+.tool-duration i {
+  margin: 0;
+  opacity: 0.7;
 }
 
 .tool-details {
@@ -759,22 +960,16 @@
   color: var(--color-danger-light);
 }
 
-/* ── Системные сообщения ─────────────────────────────────────────────────────── */
+/* ── Системные сообщения (компактная строка на дорожке timeline) ─────────────── */
 .system-message {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 0.6rem;
-  max-width: 80%;
-  margin: 0 auto;
-  padding: 0.6rem 1rem;
-  border-radius: 30px;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-input);
   font-size: 0.85rem;
-  background: var(--color-bg-secondary);
+  background: var(--color-surface-faint);
   border: 1px solid var(--color-border);
-}
-
-.system-message i {
-  flex-shrink: 0;
 }
 
 .system-message-text {
@@ -789,21 +984,88 @@
   white-space: nowrap;
 }
 
-.msg-info i { color: var(--color-info); }
-.msg-warning i { color: var(--color-warning); }
-.msg-warning { border-color: var(--color-warning-soft); }
-.msg-error i { color: var(--color-danger); }
-.msg-error { border-color: color-mix(in srgb, var(--color-danger) 30%, transparent); }
+.msg-warning .system-message { border-color: var(--color-warning-soft); }
+.msg-error .system-message { border-color: color-mix(in srgb, var(--color-danger) 30%, transparent); }
+
+/* ── Stat-чипы инфо-панели ───────────────────────────────────────────────────── */
+.discussion-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.stat-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.5rem 0.85rem;
+  background: var(--color-surface-faint);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-input);
+}
+
+.stat-chip i {
+  align-self: center;
+  color: var(--color-accent);
+  font-size: 0.85rem;
+}
+
+.stat-chip-value {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+
+.stat-chip-label {
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+}
+
+/* ── Точка статуса в бейдже (инфо-панель) ────────────────────────────────────── */
+.discussion-info-header .status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.status-dot--pulse {
+  animation: status-dot-pulse 1.6s ease-in-out infinite;
+  box-shadow: 0 0 0 0 currentColor;
+}
+
+@keyframes status-dot-pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 60%, transparent); }
+  70% { box-shadow: 0 0 0 0.4rem transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
 
 /* ── Адаптивность ────────────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
-  .system-message {
-    max-width: 100%;
-  }
+  .discussion-timeline { --timeline-node-size: 32px; }
   .message-footer {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
+  }
+}
+
+/* ── Уважение к настройке «уменьшить движение» ───────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after,
+  .timeline-node-pulse,
+  .discussion-running,
+  .status-dot--pulse,
+  .fa-spin {
+    animation: none !important;
   }
 }
 

--- a/frontend/src/pages/Agents.css
+++ b/frontend/src/pages/Agents.css
@@ -1,55 +1,5 @@
 /* Стили, специфичные для страницы агентов. Общие примитивы — в styles/components.css. */
 
-/* ── Вкладки ─────────────────────────────────────────────────────────────────── */
-.agents-tabs {
-  display: flex;
-  justify-content: center;
-  gap: 0.5rem;
-  margin-bottom: 2rem;
-  padding: 0.3rem;
-  background: var(--color-bg-secondary);
-  border-radius: 40px;
-  width: fit-content;
-  margin-left: auto;
-  margin-right: auto;
-  border: 1px solid var(--color-border);
-}
-
-.agents-tab {
-  background: transparent;
-  color: var(--color-text-secondary);
-  border: none;
-  padding: 0.5rem 1.5rem;
-  border-radius: 30px;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  box-shadow: none;
-  transition: var(--transition);
-}
-
-.agents-tab:hover {
-  color: var(--color-accent);
-  background: var(--color-accent-soft);
-  transform: none;
-  box-shadow: none;
-}
-
-.agents-tab.active {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-  box-shadow: var(--shadow-sm);
-}
-
-.agents-tab.active:hover {
-  background: var(--color-accent-light);
-  color: var(--color-on-accent);
-}
-
-.agents-tab i {
-  margin-right: 0.4rem;
-}
-
 /* ── Форма вкладки «Запуск» ──────────────────────────────────────────────────── */
 .run-pipeline-form {
   background: var(--color-bg-secondary);
@@ -145,133 +95,6 @@
   opacity: 0.8;
 }
 
-/* Поле добавления запрещённых гипотез */
-.denied-input-row {
-  display: flex;
-  gap: 0.6rem;
-  align-items: center;
-}
-
-.denied-input-row input {
-  flex: 1;
-}
-
-.denied-input-row .button {
-  white-space: nowrap;
-}
-
-.denied-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.denied-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.5rem 0.8rem;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 8px;
-}
-
-.denied-item-text {
-  font-size: 0.9rem;
-  color: var(--color-text-primary);
-  word-break: break-word;
-}
-
-.denied-item-remove {
-  flex-shrink: 0;
-  background: transparent;
-  border: none;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  padding: 0.2rem 0.4rem;
-  border-radius: 6px;
-  transition: var(--transition);
-}
-
-.denied-item-remove:hover:not(:disabled) {
-  color: var(--color-accent-light);
-  background: var(--color-accent-soft);
-}
-
-/* Предложенные теги (заглушка) */
-.tag-suggestions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.tag-suggestions-label {
-  font-size: 0.8rem;
-  color: var(--color-text-secondary);
-}
-
-.tag-suggestion {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.25rem 0.7rem;
-  font-size: 0.85rem;
-  background: transparent;
-  border: 1px dashed var(--color-accent);
-  color: var(--color-accent-light);
-  border-radius: 40px;
-  cursor: pointer;
-  transition: var(--transition);
-}
-
-.tag-suggestion:hover:not(:disabled) {
-  background: var(--color-accent-soft);
-}
-
-/* Добавленные теги */
-.tag-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.tag-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.4rem 0.3rem 0.8rem;
-  background: var(--color-accent-soft);
-  border: 1px solid var(--color-accent);
-  border-radius: 40px;
-  font-size: 0.85rem;
-  color: var(--color-text-primary);
-}
-
-.tag-chip-remove {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  padding: 0.1rem 0.3rem;
-  border-radius: 50%;
-  transition: var(--transition);
-}
-
-.tag-chip-remove:hover:not(:disabled) {
-  color: var(--color-accent-light);
-}
-
 .run-pipeline-actions {
   display: flex;
   justify-content: flex-end;
@@ -293,58 +116,75 @@
 .discussion-card {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.75rem;
+  border: var(--border-subtle);
 }
 
+/* Интервалы между блоками карточки задаёт gap — обнуляем отступы детей */
+.discussion-card > .discussion-card-header,
+.discussion-card > .discussion-meta,
+.discussion-card > .discussion-tags {
+  margin: 0;
+}
+
+/* Строка с датами — подстрочник к строке мета, прижимаем ближе */
+.discussion-card > .discussion-meta--dates {
+  margin-top: -0.6rem;
+}
+
+/* Чёткое состояние наведения и фокуса с клавиатуры */
+.discussion-card.card--hoverable:hover {
+  border-color: var(--color-accent);
+}
+
+.discussion-card:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft), var(--shadow-md);
+}
 
 .discussion-card-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
-  cursor: pointer;
+  margin-bottom: 0.5rem;
 }
 
 .discussion-title-group {
   min-width: 0;
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 0.2rem;
   flex: 1;
 }
 
-.discussion-title-inner {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
+/* Название пайплайна — бейдж-надзаголовок над названием дискуссии */
+.discussion-badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 0.35rem;
+  margin-bottom: 0.1rem;
+  padding: 0.15rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-light);
+  border: 1px solid var(--color-accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
-/* Выравнивание единого chevron по верхней строке заголовка карточки. */
-.discussion-title-group > .collapse-chevron {
-  margin-top: 0.45rem;
-}
-
-.discussion-card--collapsed {
-  gap: 0;
-}
-
-.discussion-card-summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem 1rem;
-  font-size: 0.85rem;
-  color: var(--color-text-secondary);
-}
-
-.discussion-card-summary i {
-  margin-right: 0.3rem;
+.discussion-badge i {
+  margin-right: 0;
+  font-size: 0.7rem;
 }
 
 .discussion-card-header h2 {
-  font-size: 1.4rem;
+  font-size: 1.5rem;
   margin: 0;
+  color: var(--color-text-primary);
   word-break: break-word;
 }
 
@@ -358,49 +198,17 @@
   color: var(--color-text-secondary);
   opacity: 0.6;
   word-break: break-all;
-}
-
-.discussion-id i {
-  font-size: 0.7rem;
-}
-
-.discussion-card-title {
-  cursor: pointer;
-  position: relative;
-  width: fit-content;
-  transition: color 0.2s ease;
-}
-
-.discussion-card-title::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  width: 100%;
-  height: 2px;
-  background: var(--color-accent);
-  border-radius: 2px;
-  transform: scaleX(0);
-  transform-origin: left center;
-  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.discussion-card-title:hover {
-  color: var(--color-accent);
-}
-
-.discussion-card-title:hover::after {
-  transform: scaleX(1);
-}
-
-.discussion-id--copyable {
   cursor: pointer;
   transition: opacity 0.15s, color 0.15s;
 }
 
-.discussion-id--copyable:hover {
+.discussion-id:hover {
   opacity: 1;
   color: var(--color-accent);
+}
+
+.discussion-id i {
+  font-size: 0.7rem;
 }
 
 .discussion-id-copy-icon {
@@ -410,21 +218,15 @@
   margin-left: 0.1rem;
 }
 
-.discussion-id--copyable:hover .discussion-id-copy-icon {
+.discussion-id:hover .discussion-id-copy-icon {
   opacity: 0.7;
 }
-
 
 .discussion-card-actions {
   display: flex;
   align-items: center;
   gap: 0.6rem;
   flex-shrink: 0;
-}
-
-.discussion-card-actions .icon-button:hover {
-  background: var(--color-danger-soft);
-  color: var(--color-danger);
 }
 
 .discussion-meta {
@@ -437,6 +239,12 @@
 
 .discussion-meta i {
   margin-right: 0.3rem;
+}
+
+/* Отдельная строка с датами старта/завершения */
+.discussion-meta--dates {
+  font-size: 0.85rem;
+  opacity: 0.85;
 }
 
 .discussion-section-title {
@@ -462,6 +270,12 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
+}
+
+.discussion-tags-label {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-size: 0.9rem;
 }
 
 .discussion-agents {
@@ -991,4 +805,16 @@
     align-items: flex-start;
     gap: 0.5rem;
   }
+}
+
+/* Убираем стрелки увеличения/уменьшения у number input. */
+.no-spinner {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+.no-spinner::-webkit-outer-spin-button,
+.no-spinner::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { DiscussionHistory, RunPipelineForm } from '../components/agents';
 import './Agents.css';
 
@@ -7,12 +7,11 @@ type AgentsTab = 'run' | 'history';
 
 const Agents: React.FC = () => {
   const [activeTab, setActiveTab] = useState<AgentsTab>('history');
-  const [, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
 
-  // После старта пайплайна — переключаемся на историю и открываем дискуссию.
+  // После старта пайплайна — открываем страницу дискуссии.
   const handleStarted = (discussionId: string) => {
-    setActiveTab('history');
-    setSearchParams({ discussion: discussionId });
+    navigate(`/agents/discussion/${discussionId}`);
   };
 
   return (

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -25,15 +25,15 @@ const Agents: React.FC = () => {
       </div>
 
       {/* Переключатель вкладок */}
-      <div className="agents-tabs">
+      <div className="page-tabs">
         <button
-          className={`agents-tab ${activeTab === 'run' ? 'active' : ''}`}
+          className={`page-tab ${activeTab === 'run' ? 'active' : ''}`}
           onClick={() => setActiveTab('run')}
         >
           <i className="fas fa-play"></i> Запуск
         </button>
         <button
-          className={`agents-tab ${activeTab === 'history' ? 'active' : ''}`}
+          className={`page-tab ${activeTab === 'history' ? 'active' : ''}`}
           onClick={() => setActiveTab('history')}
         >
           <i className="fas fa-clock-rotate-left"></i> История

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DiscussionHistory, RunPipelineForm } from '../components/agents';
+import { ICONS } from '../constants/icons';
 import './Agents.css';
 
 type AgentsTab = 'run' | 'history';
@@ -29,13 +30,13 @@ const Agents: React.FC = () => {
           className={`page-tab ${activeTab === 'run' ? 'active' : ''}`}
           onClick={() => setActiveTab('run')}
         >
-          <i className="fas fa-play"></i> Запуск
+          <i className={`fas ${ICONS.play}`}></i> Запуск
         </button>
         <button
           className={`page-tab ${activeTab === 'history' ? 'active' : ''}`}
           onClick={() => setActiveTab('history')}
         >
-          <i className="fas fa-clock-rotate-left"></i> История
+          <i className={`fas ${ICONS.history}`}></i> История
         </button>
       </div>
 

--- a/frontend/src/pages/DatasetDetail.tsx
+++ b/frontend/src/pages/DatasetDetail.tsx
@@ -1,0 +1,425 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { datasetService } from '../services/datasetService';
+import { useNotification } from '../contexts/NotificationContext';
+import { useCopyToClipboard } from '../hooks';
+import { formatBytes, formatDateTime } from '../utils/format';
+import type { Dataset, SourceItem, VersionSplitsResponse } from '../types/dataset';
+import { AddVersionForm, VersionSplitsStats } from '../components/datasets';
+import ConfirmModal from '../components/common/ConfirmModal';
+import './Datasets.css';
+
+const makeUploadId = () => `upload_${Date.now()}`;
+
+const EMPTY_VERSION = () => ({
+  name: '',
+  description: '',
+  sources: [] as SourceItem[],
+  file: null as File | null,
+});
+
+const DatasetDetail: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { showNotification } = useNotification();
+  const copyToClipboard = useCopyToClipboard();
+
+  const [dataset, setDataset] = useState<Dataset | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [showVersionForm, setShowVersionForm] = useState(false);
+  const [versionFilter, setVersionFilter] = useState('');
+  const [newVersion, setNewVersion] = useState(EMPTY_VERSION);
+  const [versionStats, setVersionStats] = useState<Record<string, VersionSplitsResponse | 'loading' | 'error'>>({});
+
+  // Ожидающее подтверждения удаление: весь датасет либо конкретная версия.
+  const [pendingDelete, setPendingDelete] = useState<
+    { kind: 'dataset' } | { kind: 'version'; id: string; name: string } | null
+  >(null);
+
+  const loadDataset = React.useCallback(async () => {
+    if (!id) return;
+    try {
+      const data = await datasetService.getDataset(id);
+      setDataset(data);
+    } catch (err) {
+      showNotification(err instanceof Error ? err.message : 'Не удалось загрузить датасет', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [id, showNotification]);
+
+  useEffect(() => {
+    setLoading(true);
+    loadDataset();
+  }, [loadDataset]);
+
+  const handleShowVersionStats = async (versionId: string) => {
+    if (!id) return;
+    if (versionStats[versionId]) {
+      setVersionStats(prev => { const next = { ...prev }; delete next[versionId]; return next; });
+      return;
+    }
+    setVersionStats(prev => ({ ...prev, [versionId]: 'loading' }));
+    try {
+      const data = await datasetService.getVersionSplits(id, versionId);
+      setVersionStats(prev => ({ ...prev, [versionId]: data }));
+    } catch {
+      setVersionStats(prev => ({ ...prev, [versionId]: 'error' }));
+    }
+  };
+
+  const handleAddVersion = async () => {
+    if (!id) return;
+    if (!newVersion.name) {
+      showNotification('Введите название версии', 'warning');
+      return;
+    }
+    try {
+      setBusy(true);
+      const id_data = makeUploadId();
+      if (newVersion.file) {
+        const uploaded = await datasetService.uploadFile(id_data, newVersion.file);
+        if (!uploaded) throw new Error('Не удалось загрузить файл');
+      }
+      await datasetService.createVersion(id, {
+        id_data,
+        name: newVersion.name,
+        description: newVersion.description,
+        sources: newVersion.sources,
+      });
+      await loadDataset();
+      setShowVersionForm(false);
+      setNewVersion(EMPTY_VERSION);
+      showNotification('Версия успешно добавлена', 'success');
+    } catch (err) {
+      showNotification(err instanceof Error ? err.message : 'Ошибка добавления версии', 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDeleteVersion = async (versionId: string) => {
+    if (!id) return;
+    try {
+      setBusy(true);
+      const deleted = await datasetService.deleteVersion(id, versionId);
+      if (!deleted) throw new Error('Не удалось удалить версию');
+      await loadDataset();
+      showNotification('Версия удалена', 'success');
+    } catch (err) {
+      showNotification(err instanceof Error ? err.message : 'Ошибка удаления версии', 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSetDefaultVersion = async (versionId: string) => {
+    if (!id) return;
+    try {
+      setBusy(true);
+      const ok = await datasetService.setDefaultVersion(id, versionId);
+      if (!ok) throw new Error('Не удалось установить версию по умолчанию');
+      await loadDataset();
+      showNotification('Версия по умолчанию обновлена', 'success');
+    } catch (err) {
+      showNotification(err instanceof Error ? err.message : 'Ошибка установки версии', 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDeleteDataset = async () => {
+    if (!id) return;
+    try {
+      setBusy(true);
+      const deleted = await datasetService.deleteDataset(id);
+      if (!deleted) throw new Error('Не удалось удалить датасет');
+      showNotification('Датасет удалён', 'success');
+      navigate('/datasets');
+    } catch (err) {
+      showNotification(err instanceof Error ? err.message : 'Ошибка удаления датасета', 'error');
+      setBusy(false);
+    }
+  };
+
+  const handleConfirmDelete = () => {
+    if (!pendingDelete) return;
+    const target = pendingDelete;
+    setPendingDelete(null);
+    if (target.kind === 'dataset') {
+      handleDeleteDataset();
+    } else {
+      handleDeleteVersion(target.id);
+    }
+  };
+
+  const filteredVersions = useMemo(() => {
+    const q = versionFilter.trim().toLowerCase();
+    const versions = dataset?.versions ?? [];
+    if (!q) return versions;
+    return versions.filter(ver =>
+      ver.name.toLowerCase().includes(q) || ver.description.toLowerCase().includes(q)
+    );
+  }, [dataset?.versions, versionFilter]);
+
+  if (loading) {
+    return (
+      <div className="page">
+        <div className="loading-state">
+          <i className="fas fa-spinner fa-spin"></i> Загрузка датасета…
+        </div>
+      </div>
+    );
+  }
+
+  if (!dataset) {
+    return (
+      <div className="page">
+        <button className="button secondary" onClick={() => navigate('/datasets')}>
+          <i className="fas fa-arrow-left"></i> К списку
+        </button>
+        <div className="empty-state">
+          <i className="fas fa-triangle-exclamation"></i> Датасет не найден.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page dataset-detail">
+      <button className="detail-back-link" onClick={() => navigate('/datasets')}>
+        <i className="fas fa-arrow-left"></i> К списку датасетов
+      </button>
+
+      <header className="dataset-detail-header">
+        <div className="dataset-detail-heading">
+          <div className="dataset-detail-title">
+            <h1>{dataset.name}</h1>
+            <span className="dataset-badge">
+              <i className="fas fa-tag"></i> {dataset.type} / {dataset.task}
+            </span>
+          </div>
+          <span
+            className="dataset-id"
+            title="Нажмите, чтобы скопировать ID"
+            onClick={() => copyToClipboard(dataset.id)}
+          >
+            <i className="fas fa-hashtag"></i>{dataset.id}
+            <i className="fas fa-copy dataset-id-copy-icon"></i>
+          </span>
+        </div>
+        <button
+          className="button danger dataset-detail-delete"
+          onClick={() => setPendingDelete({ kind: 'dataset' })}
+          disabled={busy}
+        >
+          <i className="fas fa-trash"></i> Удалить датасет
+        </button>
+      </header>
+
+      <section className="detail-section">
+        <h3 className="detail-section-title"><i className="fas fa-circle-info"></i> Общая информация</h3>
+        <div className="detail-fields">
+          <div className="detail-field"><span className="detail-label"><i className="fas fa-shapes"></i> Тип</span><span>{dataset.type || '—'}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className="fas fa-bullseye"></i> Задача</span><span>{dataset.task || '—'}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className="fas fa-tags"></i> Классов</span><span>{dataset.classes_count}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className="fas fa-layer-group"></i> Версий</span><span>{dataset.versions.length}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className="fas fa-calendar-plus"></i> Создан</span><span>{formatDateTime(dataset.created_at)}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className="fas fa-sync-alt"></i> Обновлён</span><span>{formatDateTime(dataset.updated_at)}</span></div>
+          <div className="detail-field detail-field--full">
+            <span className="detail-label"><i className="fas fa-tags"></i> Классы</span>
+            {dataset.classes_names.length > 0 ? (
+              <div className="tag-list">
+                {dataset.classes_names.map(className => (
+                  <span key={className} className="tag">{className}</span>
+                ))}
+              </div>
+            ) : (
+              <span className="detail-empty">Классы не указаны.</span>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {dataset.description && (
+        <section className="detail-section">
+          <h3 className="detail-section-title"><i className="fas fa-align-left"></i> Описание</h3>
+          <p className="dataset-detail-description">{dataset.description}</p>
+        </section>
+      )}
+
+      <section className="detail-section versions-section">
+        <div className="versions-section-head">
+          <h3 className="detail-section-title"><i className="fas fa-layer-group"></i> Версии ({dataset.versions.length})</h3>
+          <button
+            className="button small"
+            onClick={() => setShowVersionForm(v => !v)}
+            disabled={busy}
+          >
+            <i className="fas fa-plus"></i> Добавить версию
+          </button>
+        </div>
+
+        {showVersionForm && (
+          <AddVersionForm
+            version={newVersion}
+            loading={busy}
+            onVersionChange={setNewVersion}
+            onSubmit={handleAddVersion}
+            onCancel={() => setShowVersionForm(false)}
+          />
+        )}
+
+        {dataset.versions.length > 1 && (
+          <div className="filter-field versions-filter">
+            <i className="fas fa-search"></i>
+            <input
+              type="text"
+              placeholder="Поиск по названию или описанию версии"
+              value={versionFilter}
+              onChange={(e) => setVersionFilter(e.target.value)}
+            />
+            {versionFilter && (
+              <button
+                type="button"
+                className="versions-filter-clear"
+                onClick={() => setVersionFilter('')}
+                title="Сбросить фильтр"
+              >
+                <i className="fas fa-xmark"></i>
+              </button>
+            )}
+          </div>
+        )}
+
+        {dataset.versions.length === 0 ? (
+          <p className="no-versions">Нет версий</p>
+        ) : filteredVersions.length === 0 ? (
+          <p className="no-versions">Версии не найдены</p>
+        ) : (
+          <div className="versions-list">
+            {filteredVersions.map(ver => (
+              <div
+                key={ver.id}
+                className={`version-item${ver.id === dataset.default_version_id ? ' version-item--default' : ''}`}
+              >
+                <div className="version-header">
+                  <span className="version-name">
+                    {ver.name}
+                    {ver.id === dataset.default_version_id && (
+                      <span className="default-badge-inline">по умолчанию</span>
+                    )}
+                  </span>
+                  <div className="version-actions">
+                    {ver.id !== dataset.default_version_id && (
+                      <button
+                        className="icon-button small"
+                        onClick={() => handleSetDefaultVersion(ver.id)}
+                        title="Сделать версией по умолчанию"
+                        disabled={busy}
+                      >
+                        <i className="fas fa-star"></i>
+                      </button>
+                    )}
+                    <button
+                      className="icon-button small"
+                      onClick={() => handleShowVersionStats(ver.id)}
+                      title="Статистика"
+                    >
+                      <i className="fas fa-chart-bar"></i>
+                    </button>
+                    <button
+                      className="icon-button small icon-button--danger"
+                      onClick={() => setPendingDelete({ kind: 'version', id: ver.id, name: ver.name })}
+                      title="Удалить версию"
+                      disabled={busy}
+                    >
+                      <i className="fas fa-trash"></i>
+                    </button>
+                  </div>
+                </div>
+                <div className="version-meta">
+                  <span className="version-meta-item">
+                    <span className="version-meta-label"><i className="fas fa-database"></i> Размер</span>
+                    <span className="version-meta-value">{formatBytes(ver.size_bytes)}</span>
+                  </span>
+                  <span className="version-meta-item">
+                    <span className="version-meta-label"><i className="fas fa-images"></i> Образцов</span>
+                    <span className="version-meta-value">{ver.num_samples.toLocaleString()}</span>
+                  </span>
+                  <span className="version-meta-item">
+                    <span className="version-meta-label"><i className="fas fa-calendar-alt"></i> Загружено</span>
+                    <span className="version-meta-value">{formatDateTime(ver.created_at)}</span>
+                  </span>
+                </div>
+                {ver.description && (
+                  <p className="version-description">
+                    <span className="version-field-label">Описание:</span> {ver.description}
+                  </p>
+                )}
+                {ver.sources.length > 0 && (
+                  <div className="dataset-sources">
+                    <span className="dataset-sources-label">
+                      <i className="fas fa-link"></i> Источники ({ver.sources.length})
+                    </span>
+                    {ver.sources.map((src, idx) => (
+                      <div key={idx} className="source-item">
+                        <span className="source-type-badge">{src.type}</span>
+                        {src.url ? (
+                          <a
+                            href={src.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="source-link"
+                            title={src.url}
+                          >
+                            <i className="fas fa-arrow-up-right-from-square"></i>
+                            <span className="source-link-text">{src.description || src.url}</span>
+                          </a>
+                        ) : (
+                          <span className="source-description">{src.description || '—'}</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {versionStats[ver.id] === 'loading' && (
+                  <p className="stats-loading">Загрузка статистики...</p>
+                )}
+                {versionStats[ver.id] === 'error' && (
+                  <p className="stats-error">Не удалось загрузить статистику</p>
+                )}
+                {typeof versionStats[ver.id] === 'object' && (
+                  <VersionSplitsStats
+                    stats={versionStats[ver.id] as VersionSplitsResponse}
+                    onClose={() => handleShowVersionStats(ver.id)}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <ConfirmModal
+        open={pendingDelete !== null}
+        danger
+        title={pendingDelete?.kind === 'version' ? 'Удалить версию?' : 'Удалить датасет?'}
+        message={
+          pendingDelete?.kind === 'version'
+            ? `Версия «${pendingDelete.name}» будет удалена безвозвратно.`
+            : pendingDelete?.kind === 'dataset'
+            ? `Датасет «${dataset.name}» будет удалён безвозвратно вместе со всеми версиями.`
+            : undefined
+        }
+        confirmLabel="Удалить"
+        cancelLabel="Отмена"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </div>
+  );
+};
+
+export default DatasetDetail;

--- a/frontend/src/pages/DatasetDetail.tsx
+++ b/frontend/src/pages/DatasetDetail.tsx
@@ -7,6 +7,7 @@ import { formatBytes, formatDateTime } from '../utils/format';
 import type { Dataset, SourceItem, VersionSplitsResponse } from '../types/dataset';
 import { AddVersionForm, VersionSplitsStats } from '../components/datasets';
 import ConfirmModal from '../components/common/ConfirmModal';
+import { ICONS } from '../constants/icons';
 import './Datasets.css';
 
 const makeUploadId = () => `upload_${Date.now()}`;
@@ -167,7 +168,7 @@ const DatasetDetail: React.FC = () => {
     return (
       <div className="page">
         <div className="loading-state">
-          <i className="fas fa-spinner fa-spin"></i> Загрузка датасета…
+          <i className={`fas ${ICONS.loading} fa-spin`}></i> Загрузка датасета…
         </div>
       </div>
     );
@@ -177,10 +178,10 @@ const DatasetDetail: React.FC = () => {
     return (
       <div className="page">
         <button className="button secondary" onClick={() => navigate('/datasets')}>
-          <i className="fas fa-arrow-left"></i> К списку
+          <i className={`fas ${ICONS.back}`}></i> К списку
         </button>
         <div className="empty-state">
-          <i className="fas fa-triangle-exclamation"></i> Датасет не найден.
+          <i className={`fas ${ICONS.notFound}`}></i> Датасет не найден.
         </div>
       </div>
     );
@@ -189,7 +190,7 @@ const DatasetDetail: React.FC = () => {
   return (
     <div className="page dataset-detail">
       <button className="detail-back-link" onClick={() => navigate('/datasets')}>
-        <i className="fas fa-arrow-left"></i> К списку датасетов
+        <i className={`fas ${ICONS.back}`}></i> К списку датасетов
       </button>
 
       <header className="dataset-detail-header">
@@ -197,7 +198,7 @@ const DatasetDetail: React.FC = () => {
           <div className="dataset-detail-title">
             <h1>{dataset.name}</h1>
             <span className="dataset-badge">
-              <i className="fas fa-tag"></i> {dataset.type} / {dataset.task}
+              <i className={`fas ${ICONS.tag}`}></i> {dataset.type} / {dataset.task}
             </span>
           </div>
           <span
@@ -205,8 +206,8 @@ const DatasetDetail: React.FC = () => {
             title="Нажмите, чтобы скопировать ID"
             onClick={() => copyToClipboard(dataset.id)}
           >
-            <i className="fas fa-hashtag"></i>{dataset.id}
-            <i className="fas fa-copy dataset-id-copy-icon"></i>
+            <i className={`fas ${ICONS.id}`}></i>{dataset.id}
+            <i className={`fas ${ICONS.copy} dataset-id-copy-icon`}></i>
           </span>
         </div>
         <button
@@ -214,21 +215,21 @@ const DatasetDetail: React.FC = () => {
           onClick={() => setPendingDelete({ kind: 'dataset' })}
           disabled={busy}
         >
-          <i className="fas fa-trash"></i> Удалить датасет
+          <i className={`fas ${ICONS.delete}`}></i> Удалить датасет
         </button>
       </header>
 
       <section className="detail-section">
-        <h3 className="detail-section-title"><i className="fas fa-circle-info"></i> Общая информация</h3>
+        <h3 className="detail-section-title"><i className={`fas ${ICONS.info}`}></i> Общая информация</h3>
         <div className="detail-fields">
-          <div className="detail-field"><span className="detail-label"><i className="fas fa-shapes"></i> Тип</span><span>{dataset.type || '—'}</span></div>
-          <div className="detail-field"><span className="detail-label"><i className="fas fa-bullseye"></i> Задача</span><span>{dataset.task || '—'}</span></div>
-          <div className="detail-field"><span className="detail-label"><i className="fas fa-tags"></i> Классов</span><span>{dataset.classes_count}</span></div>
-          <div className="detail-field"><span className="detail-label"><i className="fas fa-layer-group"></i> Версий</span><span>{dataset.versions.length}</span></div>
-          <div className="detail-field"><span className="detail-label"><i className="fas fa-calendar-plus"></i> Создан</span><span>{formatDateTime(dataset.created_at)}</span></div>
-          <div className="detail-field"><span className="detail-label"><i className="fas fa-sync-alt"></i> Обновлён</span><span>{formatDateTime(dataset.updated_at)}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className={`fas ${ICONS.datasetType}`}></i> Тип</span><span>{dataset.type || '—'}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className={`fas ${ICONS.taskTarget}`}></i> Задача</span><span>{dataset.task || '—'}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className={`fas ${ICONS.classes}`}></i> Классов</span><span>{dataset.classes_count}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className={`fas ${ICONS.version}`}></i> Версий</span><span>{dataset.versions.length}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className={`fas ${ICONS.dateCreated}`}></i> Создан</span><span>{formatDateTime(dataset.created_at)}</span></div>
+          <div className="detail-field"><span className="detail-label"><i className={`fas ${ICONS.dateUpdated}`}></i> Обновлён</span><span>{formatDateTime(dataset.updated_at)}</span></div>
           <div className="detail-field detail-field--full">
-            <span className="detail-label"><i className="fas fa-tags"></i> Классы</span>
+            <span className="detail-label"><i className={`fas ${ICONS.classes}`}></i> Классы</span>
             {dataset.classes_names.length > 0 ? (
               <div className="tag-list">
                 {dataset.classes_names.map(className => (
@@ -244,20 +245,20 @@ const DatasetDetail: React.FC = () => {
 
       {dataset.description && (
         <section className="detail-section">
-          <h3 className="detail-section-title"><i className="fas fa-align-left"></i> Описание</h3>
+          <h3 className="detail-section-title"><i className={`fas ${ICONS.description}`}></i> Описание</h3>
           <p className="dataset-detail-description">{dataset.description}</p>
         </section>
       )}
 
       <section className="detail-section versions-section">
         <div className="versions-section-head">
-          <h3 className="detail-section-title"><i className="fas fa-layer-group"></i> Версии ({dataset.versions.length})</h3>
+          <h3 className="detail-section-title"><i className={`fas ${ICONS.version}`}></i> Версии ({dataset.versions.length})</h3>
           <button
             className="button small"
             onClick={() => setShowVersionForm(v => !v)}
             disabled={busy}
           >
-            <i className="fas fa-plus"></i> Добавить версию
+            <i className={`fas ${ICONS.add}`}></i> Добавить версию
           </button>
         </div>
 
@@ -273,7 +274,7 @@ const DatasetDetail: React.FC = () => {
 
         {dataset.versions.length > 1 && (
           <div className="filter-field versions-filter">
-            <i className="fas fa-search"></i>
+            <i className={`fas ${ICONS.search}`}></i>
             <input
               type="text"
               placeholder="Поиск по названию или описанию версии"
@@ -287,7 +288,7 @@ const DatasetDetail: React.FC = () => {
                 onClick={() => setVersionFilter('')}
                 title="Сбросить фильтр"
               >
-                <i className="fas fa-xmark"></i>
+                <i className={`fas ${ICONS.close}`}></i>
               </button>
             )}
           </div>
@@ -319,7 +320,7 @@ const DatasetDetail: React.FC = () => {
                         title="Сделать версией по умолчанию"
                         disabled={busy}
                       >
-                        <i className="fas fa-star"></i>
+                        <i className={`fas ${ICONS.star}`}></i>
                       </button>
                     )}
                     <button
@@ -327,7 +328,7 @@ const DatasetDetail: React.FC = () => {
                       onClick={() => handleShowVersionStats(ver.id)}
                       title="Статистика"
                     >
-                      <i className="fas fa-chart-bar"></i>
+                      <i className={`fas ${ICONS.datasetStats}`}></i>
                     </button>
                     <button
                       className="icon-button small icon-button--danger"
@@ -335,21 +336,21 @@ const DatasetDetail: React.FC = () => {
                       title="Удалить версию"
                       disabled={busy}
                     >
-                      <i className="fas fa-trash"></i>
+                      <i className={`fas ${ICONS.delete}`}></i>
                     </button>
                   </div>
                 </div>
                 <div className="version-meta">
                   <span className="version-meta-item">
-                    <span className="version-meta-label"><i className="fas fa-database"></i> Размер</span>
+                    <span className="version-meta-label"><i className={`fas ${ICONS.dataset}`}></i> Размер</span>
                     <span className="version-meta-value">{formatBytes(ver.size_bytes)}</span>
                   </span>
                   <span className="version-meta-item">
-                    <span className="version-meta-label"><i className="fas fa-images"></i> Образцов</span>
+                    <span className="version-meta-label"><i className={`fas ${ICONS.samples}`}></i> Образцов</span>
                     <span className="version-meta-value">{ver.num_samples.toLocaleString()}</span>
                   </span>
                   <span className="version-meta-item">
-                    <span className="version-meta-label"><i className="fas fa-calendar-alt"></i> Загружено</span>
+                    <span className="version-meta-label"><i className={`fas ${ICONS.dateCreated}`}></i> Загружено</span>
                     <span className="version-meta-value">{formatDateTime(ver.created_at)}</span>
                   </span>
                 </div>
@@ -361,7 +362,7 @@ const DatasetDetail: React.FC = () => {
                 {ver.sources.length > 0 && (
                   <div className="dataset-sources">
                     <span className="dataset-sources-label">
-                      <i className="fas fa-link"></i> Источники ({ver.sources.length})
+                      <i className={`fas ${ICONS.link}`}></i> Источники ({ver.sources.length})
                     </span>
                     {ver.sources.map((src, idx) => (
                       <div key={idx} className="source-item">
@@ -374,7 +375,7 @@ const DatasetDetail: React.FC = () => {
                             className="source-link"
                             title={src.url}
                           >
-                            <i className="fas fa-arrow-up-right-from-square"></i>
+                            <i className={`fas ${ICONS.external}`}></i>
                             <span className="source-link-text">{src.description || src.url}</span>
                           </a>
                         ) : (

--- a/frontend/src/pages/DatasetDetail.tsx
+++ b/frontend/src/pages/DatasetDetail.tsx
@@ -51,8 +51,11 @@ const DatasetDetail: React.FC = () => {
   }, [id, showNotification]);
 
   useEffect(() => {
-    setLoading(true);
-    loadDataset();
+    const init = async () => {
+      setLoading(true);
+      await loadDataset();
+    };
+    init();
   }, [loadDataset]);
 
   const handleShowVersionStats = async (versionId: string) => {

--- a/frontend/src/pages/Datasets.css
+++ b/frontend/src/pages/Datasets.css
@@ -10,21 +10,68 @@
   border: 1px solid var(--color-border);
 }
 
-.add-dataset-form h3 {
-  margin-top: 0;
-  margin-bottom: 1rem;
+.add-dataset-form-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.add-dataset-form-head h2 {
+  margin: 0;
+}
+
+.form-close-btn {
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 8px;
+  color: var(--color-text-secondary);
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.form-close-btn:hover:not(:disabled) {
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+  background: var(--color-danger-soft);
+}
+
+.form-close-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .add-dataset-form input,
 .add-dataset-form textarea {
   width: 100%;
   padding: 0.8rem;
-  margin-bottom: 1rem;
-  background: var(--color-bg-primary);
+  background: var(--color-bg-secondary);
   border: 1px solid var(--color-border-strong);
   border-radius: 8px;
   color: var(--color-text-primary);
-  font-family: var(--font-primary);
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: var(--transition);
+}
+
+.add-dataset-form input:focus,
+.add-dataset-form textarea:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.add-dataset-form input::placeholder,
+.add-dataset-form textarea::placeholder {
+  color: var(--color-text-secondary);
+  opacity: 0.6;
 }
 
 .add-dataset-form textarea {
@@ -32,18 +79,9 @@
 }
 
 .add-dataset-form h4 {
-  margin: 1rem 0 0.5rem;
-  color: var(--color-text-primary);
-}
-
-.form-row select {
-  flex: 1;
-  padding: 0.8rem;
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 8px;
-  color: var(--color-text-primary);
-  font-family: var(--font-primary);
+  margin: 1.25rem 0 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
 }
 
 .form-actions {
@@ -60,145 +98,11 @@
 }
 
 .required-star {
-  color: var(--color-accent);
+  color: var(--color-accent-light);
   margin-left: 2px;
 }
 
-/* Источники данных */
-.sources-container {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.source-card {
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border-soft);
-  border-radius: 12px;
-  padding: 1.2rem;
-  box-shadow: var(--shadow-sm);
-  transition: box-shadow 0.2s, border-color 0.2s;
-}
-
-.source-card:hover {
-  border-color: var(--color-accent-soft);
-  box-shadow: var(--shadow-md);
-}
-
-.source-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.source-type-wrapper {
-  flex: 1;
-}
-
-.source-type-select {
-  width: 100%;
-  max-width: 200px;
-  padding: 0.6rem 1rem;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 30px;
-  color: var(--color-text-primary);
-  font-family: var(--font-primary);
-  font-size: 0.95rem;
-  cursor: pointer;
-  transition: all 0.2s;
-  appearance: none;
-  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right 0.7rem center;
-  background-size: 1rem;
-}
-
-.source-type-select:hover {
-  border-color: var(--color-accent);
-  background-color: var(--color-bg-secondary);
-}
-
-.source-remove-btn {
-  background: transparent;
-  border: none;
-  color: var(--color-text-secondary);
-  font-size: 1.2rem;
-  cursor: pointer;
-  padding: 0.5rem;
-  border-radius: 50%;
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.2s;
-}
-
-.source-remove-btn:hover {
-  background: var(--color-danger-soft);
-  color: var(--color-danger);
-}
-
-.source-fields {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-}
-
-.source-input {
-  padding: 0.8rem 1rem;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  color: var(--color-text-primary);
-  font-family: var(--font-primary);
-  font-size: 0.95rem;
-  transition: all 0.2s;
-}
-
-.source-input:focus {
-  outline: none;
-  border-color: var(--color-accent);
-  box-shadow: 0 0 0 3px var(--color-accent-soft);
-}
-
-.source-input::placeholder {
-  color: var(--color-text-secondary);
-  opacity: 0.5;
-}
-
-.add-source-btn {
-  background: transparent;
-  border: 3px dashed var(--color-accent);
-  border-radius: 40px;
-  padding: 0.8rem 1rem;
-  color: var(--color-accent);
-  font-family: var(--font-primary);
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  transition: all 0.2s;
-  width: fit-content;
-}
-
-.add-source-btn:hover {
-  background: var(--color-accent-soft);
-  border-style: solid;
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-sm);
-}
-
-.add-source-btn i {
-  font-size: 1.2rem;
-}
-
+/* Источники данных — стили в SourcesEditor.css. */
 
 /* Форма добавления версии */
 .add-version-form {
@@ -243,6 +147,129 @@
 .dataset-card {
   display: flex;
   flex-direction: column;
+  gap: 0.75rem;
+  border: var(--border-subtle);
+}
+
+/* Чёткое состояние наведения и фокуса с клавиатуры */
+.dataset-card.card--hoverable:hover {
+  border-color: var(--color-accent);
+}
+
+.dataset-card:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft), var(--shadow-md);
+}
+
+/* Интервалы между блоками карточки задаёт gap — обнуляем собственные отступы детей */
+.dataset-card > .dataset-header,
+.dataset-card > .dataset-meta,
+.dataset-card > .dataset-classes,
+.dataset-card > .dataset-description {
+  margin: 0;
+}
+
+/* Дата создания/изменения — подстрочник к строке мета, прижимаем ближе */
+.dataset-card > .dataset-meta--dates {
+  margin-top: -0.6rem;
+}
+
+/* ── Страница с информацией о датасете ───────────────────────────────────────── */
+
+/* Шапка: заголовок слева, действия справа, разделитель снизу */
+.dataset-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: var(--border-subtle);
+}
+
+.dataset-detail-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.dataset-detail-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.dataset-detail-title h1 {
+  margin: 0;
+  word-break: break-word;
+}
+
+.dataset-detail-heading .dataset-id {
+  margin-top: 0.1rem;
+}
+
+.dataset-detail-delete {
+  flex-shrink: 0;
+}
+
+/* На узких экранах действие уходит под заголовок */
+@media (max-width: 640px) {
+  .dataset-detail-header {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .dataset-detail-delete {
+    align-self: flex-start;
+  }
+}
+
+.dataset-detail-description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Иконки в подписях полей общей информации */
+.detail-field .detail-label i {
+  margin-right: 0.4rem;
+  opacity: 0.8;
+}
+
+/* Поле, занимающее всю ширину сетки (классы) */
+.detail-field--full {
+  grid-column: 1 / -1;
+}
+
+.detail-field--full .tag-list {
+  margin-top: 0.1rem;
+}
+
+.versions-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.2rem;
+}
+
+.versions-section-head .detail-section-title {
+  margin: 0;
+}
+
+/* Опасная кнопка (удаление) */
+.button.danger {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+.button.danger:hover:not(:disabled) {
+  background: var(--color-danger);
+  filter: brightness(1.1);
 }
 
 .dataset-header {
@@ -315,6 +342,17 @@
   color: var(--color-text-primary);
 }
 
+/* Длинное описание обрезаем до нескольких строк в карточке списка */
+.dataset-description--clamped {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
 .dataset-meta {
   display: flex;
   gap: 1rem;
@@ -327,21 +365,57 @@
   margin-right: 0.3rem;
 }
 
-/* Источники в карточке датасета */
+/* Тип/задача — винный бейдж-надзаголовок над названием датасета */
+.dataset-badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 0.35rem;
+  padding: 0.15rem 0.7rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-light);
+  border: 1px solid var(--color-accent);
+  text-transform: capitalize;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.dataset-badge i {
+  margin-right: 0;
+  font-size: 0.7rem;
+}
+
+/* Отдельная строка с датами создания/изменения */
+.dataset-meta--dates {
+  gap: 1rem;
+  margin-top: -0.5rem;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+/* Источники в карточке версии */
 .dataset-sources {
-  margin: 0.5rem 0;
+  margin: 0.75rem 0 0;
   padding: 1rem;
   background: var(--color-bg-primary);
   border-radius: 12px;
   border: 1px solid var(--color-border);
 }
 
-.dataset-sources h4 {
-  font-size: 1rem;
-  margin: 0 0 0.8rem 0;
+.dataset-sources-label {
+  display: block;
+  font-size: 0.72rem;
+  margin-bottom: 0.6rem;
   color: var(--color-text-secondary);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.3px;
+}
+
+.dataset-sources-label i {
+  margin-right: 0.3rem;
+  opacity: 0.8;
 }
 
 .source-item {
@@ -357,6 +431,7 @@
 }
 
 .source-type-badge {
+  flex-shrink: 0;
   background: var(--color-accent-soft);
   color: var(--color-accent);
   padding: 0.3rem 0.8rem;
@@ -367,41 +442,64 @@
   white-space: nowrap;
 }
 
-.source-type-badge--link {
-  cursor: pointer;
-  text-decoration: none;
-  transition: background 0.2s, color 0.2s;
-}
-
-.source-type-badge--link:hover {
-  background: var(--color-accent);
-  color: white;
-}
-
+/* Ссылка на источник — явно кликабельна: акцентный цвет, подчёркивание, иконка */
 .source-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   flex: 1;
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  word-break: break-all;
+  min-width: 0;
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
   font-size: 0.9rem;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.source-link i {
+  font-size: 0.78rem;
+  flex-shrink: 0;
+  opacity: 0.9;
+}
+
+.source-link-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .source-link:hover {
-  color: var(--color-accent);
-  text-decoration: underline;
+  color: var(--color-accent-light);
 }
 
 .source-description {
-  color: var(--color-text-primary);
+  flex: 1;
+  min-width: 0;
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
-  max-width: 200px;
-  text-align: right;
-  opacity: 0.8;
+  opacity: 0.85;
+  overflow-wrap: anywhere;
 }
 
 /* Классы в карточке датасета */
 .dataset-classes {
   margin: 0.5rem 0;
+}
+
+.dataset-classes-label {
+  display: block;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-text-primary);
+  margin-bottom: 0.35rem;
+}
+
+/* Лишние классы свёрнуты в "+N ещё" — бейдж намекает, что внутри их больше */
+.tag--more {
+  font-weight: 600;
+  background: transparent;
+  color: var(--color-accent-light);
 }
 
 .dataset-classes h4 {
@@ -410,66 +508,110 @@
   color: var(--color-text-primary);
 }
 
-/* Версии в карточке датасета */
-.versions-section {
-  margin-top: 0.75rem;
-  border-top: 1px solid var(--color-border);
-  padding-top: 0.75rem;
+/* Версии датасета */
+.versions-filter {
+  margin-bottom: 1rem;
 }
 
-.versions-section h4 {
-  font-size: 1rem;
-  margin: 0 0 0.5rem;
-  color: var(--color-text-primary);
+.versions-filter-clear {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 0.2rem;
+  font-size: 0.9rem;
+  box-shadow: none;
+  transition: color 0.15s;
+}
+
+.versions-filter-clear:hover {
+  color: var(--color-accent);
 }
 
 .versions-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 0.25rem;
+  gap: 0.75rem;
 }
 
 .version-item {
   background: var(--color-bg-primary);
   border-radius: 12px;
-  padding: 0.75rem;
+  padding: 1rem;
   border: 1px solid var(--color-border);
   position: relative;
+  transition: border-color 0.15s;
+}
+
+.version-item:hover {
+  border-color: var(--color-border-strong);
+}
+
+/* Версия по умолчанию — выделяем акцентной полосой слева */
+.version-item--default {
+  border-left: 3px solid var(--color-accent);
 }
 
 .version-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.5rem;
-  font-weight: 500;
+  gap: 0.75rem;
+  margin-bottom: 0.6rem;
 }
 
 .version-name {
-  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 600;
   color: var(--color-accent);
 }
 
-.version-date,
-.version-size {
+.version-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 2rem;
+}
+
+.version-meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.version-meta-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
   color: var(--color-text-secondary);
-  font-size: 0.9rem;
+}
+
+.version-meta-label i {
+  margin-right: 0.3rem;
+  opacity: 0.8;
+}
+
+.version-meta-value {
+  font-size: 0.95rem;
+  color: var(--color-text-primary);
+  font-weight: 500;
 }
 
 .version-description {
   color: var(--color-text-secondary);
   font-size: 0.9rem;
-  margin: 0.3rem 0;
-  font-style: italic;
+  margin: 0.75rem 0 0;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
-.version-stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  font-size: 0.85rem;
-  color: var(--color-text-secondary);
+.version-field-label {
+  font-weight: 600;
+  color: var(--color-text-primary);
 }
 
 .default-badge-inline {
@@ -520,15 +662,43 @@
   }
 }
 
-/* Стили для лейблов и подсказок */
-.form-section {
-  margin-bottom: 2rem;
+/* Секции формы — карточки с акцентной полосой слева (как в форме запуска пайплайна) */
+.add-dataset-form .form-section {
+  margin-bottom: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-soft);
+  border-left: 3px solid var(--color-accent);
+  border-radius: 12px;
+}
+
+.add-dataset-form .form-section-head {
+  margin-bottom: 1.25rem;
+}
+
+.add-dataset-form .form-section h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-text-primary);
+}
+
+.add-dataset-form .form-section h3 i {
+  color: var(--color-accent-light);
+}
+
+.add-dataset-form .form-section-hint {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
 }
 
 .form-field {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.5rem;
 }
 
 .form-field label {
@@ -539,6 +709,13 @@
 
 .form-field.full-width {
   grid-column: 1 / -1;
+}
+
+/* Кастомный Select внутри form-field: column-flex превращает flex-basis в высоту,
+   поэтому сбрасываем flex и растягиваем по ширине. */
+.form-field .select {
+  flex: none;
+  width: 100%;
 }
 
 .field-hint {

--- a/frontend/src/pages/Datasets.tsx
+++ b/frontend/src/pages/Datasets.tsx
@@ -1,13 +1,28 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { datasetService } from '../services/datasetService';
 import type { Dataset, NewDataset, SourceItem } from '../types/dataset';
 import './Datasets.css';
 import { useNotification } from '../contexts/NotificationContext';
-import { DatasetForm, DatasetCard, AddVersionForm } from '../components/datasets';
+import { DatasetForm, DatasetCard } from '../components/datasets';
+import Select from '../components/common/Select';
+import ConfirmModal from '../components/common/ConfirmModal';
 
-const EMPTY_SOURCE = (): SourceItem => ({ type: 'kaggle', url: null, description: '' });
+const TYPE_FILTER_OPTIONS = [
+  { value: 'image', label: 'Image' },
+  { value: 'text', label: 'Text' },
+  { value: 'tabular', label: 'Tabular' },
+  { value: 'other', label: 'Other' },
+];
 
-// Идентификатор загрузки для нового датасета/версии.
+const TASK_FILTER_OPTIONS = [
+  { value: 'classification', label: 'Classification' },
+  { value: 'regression', label: 'Regression' },
+  { value: 'detection', label: 'Detection' },
+  { value: 'segmentation', label: 'Segmentation' },
+  { value: 'other', label: 'Other' },
+];
+
+// Идентификатор загрузки для нового датасета.
 const makeUploadId = () => `upload_${Date.now()}`;
 
 const EMPTY_DATASET = () => ({
@@ -18,28 +33,38 @@ const EMPTY_DATASET = () => ({
   version: {
     name: '',
     description: '',
-    sources: [EMPTY_SOURCE()],
+    sources: [] as SourceItem[],
   },
   file: null as File | null,
 });
 
-const EMPTY_VERSION = () => ({
-  name: '',
-  description: '',
-  sources: [EMPTY_SOURCE()],
-  file: null as File | null,
-});
+type DatasetsTab = 'create' | 'list';
 
 const Datasets: React.FC = () => {
   const { showNotification } = useNotification();
 
   const [datasets, setDatasets] = useState<Dataset[]>([]);
   const [loading, setLoading] = useState(false);
-  const [showAddForm, setShowAddForm] = useState(false);
-  const [showVersionForm, setShowVersionForm] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<DatasetsTab>('list');
+
+  // Фильтры списка датасетов (клиентские — датасеты грузятся целиком).
+  const [nameFilter, setNameFilter] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [taskFilter, setTaskFilter] = useState('');
 
   const [newDataset, setNewDataset] = useState(EMPTY_DATASET);
-  const [newVersion, setNewVersion] = useState(EMPTY_VERSION);
+
+  // Датасет, ожидающий подтверждения удаления (null — модалка закрыта).
+  const [pendingDelete, setPendingDelete] = useState<Dataset | null>(null);
+
+  const filteredDatasets = useMemo(() => {
+    const name = nameFilter.trim().toLowerCase();
+    return datasets.filter(ds =>
+      (!name || ds.name.toLowerCase().includes(name)) &&
+      (!typeFilter || ds.type === typeFilter) &&
+      (!taskFilter || ds.task === taskFilter)
+    );
+  }, [datasets, nameFilter, typeFilter, taskFilter]);
 
   useEffect(() => {
     const fetchDatasets = async () => {
@@ -66,30 +91,9 @@ const Datasets: React.FC = () => {
     setNewDataset(prev => ({ ...prev, version: { ...prev.version, [field]: value } }));
   };
 
-  const handleVersionSourceAdd = () => {
-    setNewDataset(prev => ({
-      ...prev,
-      version: { ...prev.version, sources: [...prev.version.sources, EMPTY_SOURCE()] },
-    }));
+  const handleVersionSourcesChange = (sources: SourceItem[]) => {
+    setNewDataset(prev => ({ ...prev, version: { ...prev.version, sources } }));
   };
-
-  const handleVersionSourceRemove = (index: number) => {
-    if (newDataset.version.sources.length <= 1) return;
-    setNewDataset(prev => ({
-      ...prev,
-      version: { ...prev.version, sources: prev.version.sources.filter((_, i) => i !== index) },
-    }));
-  };
-
-  const handleVersionSourceChange = (index: number, field: keyof SourceItem, value: string) => {
-    setNewDataset(prev => {
-      const sources = [...prev.version.sources];
-      sources[index] = { ...sources[index], [field]: field === 'url' ? (value || null) : value };
-      return { ...prev, version: { ...prev.version, sources } };
-    });
-  };
-
-  // ── Dataset CRUD ───────────────────────────────────────────────────────────
 
   const handleCreateDataset = async () => {
     if (!newDataset.name || !newDataset.version.name) {
@@ -122,7 +126,7 @@ const Datasets: React.FC = () => {
       const updated = await datasetService.getDatasets();
       setDatasets(updated);
       setNewDataset(EMPTY_DATASET);
-      setShowAddForm(false);
+      setActiveTab('list');
       showNotification('Датасет успешно создан', 'success');
     } catch (err) {
       showNotification(err instanceof Error ? err.message : 'Ошибка создания датасета', 'error');
@@ -131,74 +135,18 @@ const Datasets: React.FC = () => {
     }
   };
 
-  const handleDeleteDataset = async (id: string) => {
-    if (!window.confirm('Вы уверены, что хотите удалить датасет?')) return;
-
+  const handleConfirmDelete = async () => {
+    if (!pendingDelete) return;
+    const dataset = pendingDelete;
+    setPendingDelete(null);
     try {
       setLoading(true);
-      const deleted = await datasetService.deleteDataset(id);
+      const deleted = await datasetService.deleteDataset(dataset.id);
       if (!deleted) throw new Error('Не удалось удалить датасет');
-      setDatasets(prev => prev.filter(ds => ds.id !== id));
+      setDatasets(prev => prev.filter(ds => ds.id !== dataset.id));
       showNotification('Датасет удалён', 'success');
     } catch (err) {
       showNotification(err instanceof Error ? err.message : 'Ошибка удаления датасета', 'error');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // ── Version CRUD ───────────────────────────────────────────────────────────
-
-  const handleOpenVersionForm = (datasetId: string) => {
-    setShowVersionForm(datasetId);
-    setNewVersion(EMPTY_VERSION);
-  };
-
-  const handleAddVersion = async (datasetId: string) => {
-    if (!newVersion.name) {
-      showNotification('Введите название версии', 'warning');
-      return;
-    }
-
-    try {
-      setLoading(true);
-      const id_data = makeUploadId();
-
-      if (newVersion.file) {
-        const uploaded = await datasetService.uploadFile(id_data, newVersion.file);
-        if (!uploaded) throw new Error('Не удалось загрузить файл');
-      }
-
-      await datasetService.createVersion(datasetId, {
-        id_data,
-        name: newVersion.name,
-        description: newVersion.description,
-        sources: newVersion.sources,
-      });
-
-      const updated = await datasetService.getDatasets();
-      setDatasets(updated);
-      setShowVersionForm(null);
-      showNotification('Версия успешно добавлена', 'success');
-    } catch (err) {
-      showNotification(err instanceof Error ? err.message : 'Ошибка добавления версии', 'error');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleDeleteVersion = async (datasetId: string, versionId: string) => {
-    if (!window.confirm('Вы уверены, что хотите удалить эту версию?')) return;
-
-    try {
-      setLoading(true);
-      const deleted = await datasetService.deleteVersion(datasetId, versionId);
-      if (!deleted) throw new Error('Не удалось удалить версию');
-      const updated = await datasetService.getDatasets();
-      setDatasets(updated);
-      showNotification('Версия удалена', 'success');
-    } catch (err) {
-      showNotification(err instanceof Error ? err.message : 'Ошибка удаления версии', 'error');
     } finally {
       setLoading(false);
     }
@@ -217,54 +165,92 @@ const Datasets: React.FC = () => {
         <p className="page-description">
           Загружайте, удаляйте и управляйте версиями датасетов для классификации изображений.
         </p>
-        {!showAddForm && (
-          <button className="button" onClick={() => setShowAddForm(true)} disabled={loading}>
-            <i className="fas fa-plus"></i> Новый датасет
-          </button>
-        )}
       </div>
 
-      {showAddForm && (
+      <div className="page-tabs">
+        <button
+          className={`page-tab ${activeTab === 'create' ? 'active' : ''}`}
+          onClick={() => setActiveTab('create')}
+        >
+          <i className="fas fa-plus"></i> Создать датасет
+        </button>
+        <button
+          className={`page-tab ${activeTab === 'list' ? 'active' : ''}`}
+          onClick={() => setActiveTab('list')}
+        >
+          <i className="fas fa-list"></i> Список датасетов
+        </button>
+      </div>
+
+      {activeTab === 'create' ? (
         <DatasetForm
           newDataset={newDataset}
           loading={loading}
           onNewDatasetChange={handleNewDatasetChange}
           onVersionChange={handleVersionFieldChange}
-          onVersionSourceAdd={handleVersionSourceAdd}
-          onVersionSourceRemove={handleVersionSourceRemove}
-          onVersionSourceChange={handleVersionSourceChange}
+          onVersionSourcesChange={handleVersionSourcesChange}
           onFileSelect={(file) => setNewDataset(prev => ({ ...prev, file }))}
           onSubmit={handleCreateDataset}
-          onCancel={() => setShowAddForm(false)}
+          onCancel={() => setActiveTab('list')}
         />
+      ) : (
+        <>
+          <div className="list-toolbar">
+            <div className="list-filters">
+              <div className="filter-field">
+                <i className="fas fa-search"></i>
+                <input
+                  type="text"
+                  placeholder="Поиск по имени"
+                  value={nameFilter}
+                  onChange={(e) => setNameFilter(e.target.value)}
+                />
+              </div>
+
+              <Select
+                icon="fas fa-shapes"
+                ariaLabel="Фильтр по типу"
+                placeholder="Все типы"
+                value={typeFilter}
+                options={TYPE_FILTER_OPTIONS}
+                onChange={setTypeFilter}
+              />
+
+              <Select
+                icon="fas fa-bullseye"
+                ariaLabel="Фильтр по задаче"
+                placeholder="Все задачи"
+                value={taskFilter}
+                options={TASK_FILTER_OPTIONS}
+                onChange={setTaskFilter}
+              />
+            </div>
+          </div>
+
+          <div className="datasets-list">
+            {datasets.length === 0 && !loading ? (
+              <p className="empty-state">Пока нет ни одного датасета. Создайте первый!</p>
+            ) : filteredDatasets.length === 0 ? (
+              <p className="empty-state">Датасеты не найдены.</p>
+            ) : (
+              filteredDatasets.map(dataset => (
+                <DatasetCard key={dataset.id} dataset={dataset} onDelete={setPendingDelete} />
+              ))
+            )}
+          </div>
+        </>
       )}
 
-      <div className="datasets-list">
-        {datasets.length === 0 && !loading ? (
-          <p className="empty-state">Пока нет ни одного датасета. Создайте первый!</p>
-        ) : (
-          datasets.map(dataset => (
-            <DatasetCard
-              key={dataset.id}
-              dataset={dataset}
-              loading={loading}
-              showVersionForm={showVersionForm === dataset.id}
-              onAddVersion={() => handleOpenVersionForm(dataset.id)}
-              onDelete={() => handleDeleteDataset(dataset.id)}
-              onDeleteVersion={(versionId) => handleDeleteVersion(dataset.id, versionId)}
-              versionForm={
-                <AddVersionForm
-                  version={newVersion}
-                  loading={loading}
-                  onVersionChange={setNewVersion}
-                  onSubmit={() => handleAddVersion(dataset.id)}
-                  onCancel={() => setShowVersionForm(null)}
-                />
-              }
-            />
-          ))
-        )}
-      </div>
+      <ConfirmModal
+        open={pendingDelete !== null}
+        danger
+        title="Удалить датасет?"
+        message={pendingDelete ? `Датасет «${pendingDelete.name}» будет удалён безвозвратно.` : undefined}
+        confirmLabel="Удалить"
+        cancelLabel="Отмена"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setPendingDelete(null)}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Datasets.tsx
+++ b/frontend/src/pages/Datasets.tsx
@@ -6,6 +6,7 @@ import { useNotification } from '../contexts/NotificationContext';
 import { DatasetForm, DatasetCard } from '../components/datasets';
 import Select from '../components/common/Select';
 import ConfirmModal from '../components/common/ConfirmModal';
+import { ICONS } from '../constants/icons';
 
 const TYPE_FILTER_OPTIONS = [
   { value: 'image', label: 'Image' },
@@ -172,13 +173,13 @@ const Datasets: React.FC = () => {
           className={`page-tab ${activeTab === 'create' ? 'active' : ''}`}
           onClick={() => setActiveTab('create')}
         >
-          <i className="fas fa-plus"></i> Создать датасет
+          <i className={`fas ${ICONS.add}`}></i> Создать датасет
         </button>
         <button
           className={`page-tab ${activeTab === 'list' ? 'active' : ''}`}
           onClick={() => setActiveTab('list')}
         >
-          <i className="fas fa-list"></i> Список датасетов
+          <i className={`fas ${ICONS.listView}`}></i> Список датасетов
         </button>
       </div>
 
@@ -198,7 +199,7 @@ const Datasets: React.FC = () => {
           <div className="list-toolbar">
             <div className="list-filters">
               <div className="filter-field">
-                <i className="fas fa-search"></i>
+                <i className={`fas ${ICONS.search}`}></i>
                 <input
                   type="text"
                   placeholder="Поиск по имени"
@@ -208,7 +209,7 @@ const Datasets: React.FC = () => {
               </div>
 
               <Select
-                icon="fas fa-shapes"
+                icon={`fas ${ICONS.datasetType}`}
                 ariaLabel="Фильтр по типу"
                 placeholder="Все типы"
                 value={typeFilter}
@@ -217,7 +218,7 @@ const Datasets: React.FC = () => {
               />
 
               <Select
-                icon="fas fa-bullseye"
+                icon={`fas ${ICONS.taskTarget}`}
                 ariaLabel="Фильтр по задаче"
                 placeholder="Все задачи"
                 value={taskFilter}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './Home.css';
+import { ICONS } from '../constants/icons';
 
 const Home: React.FC = () => {
   return (
@@ -25,21 +26,21 @@ const Home: React.FC = () => {
         <h2>Основные возможности</h2>
         <div className="feature-grid">
           <div className="card card--hoverable feature-card">
-            <h3>📁 Работа с датасетами</h3>
+            <h3><i className={`fas ${ICONS.dataset}`}></i> Работа с датасетами</h3>
             <p>
               Загружай, удаляй и версионируй датасеты. 
               Сейчас поддерживается <strong>Image Classification</strong>.
             </p>
           </div>
           <div className="card card--hoverable feature-card">
-            <h3>⚙️ Запуск обучения</h3>
+            <h3><i className={`fas ${ICONS.trainingParams}`}></i> Запуск обучения</h3>
             <p>
               Выбирай модель и параметры, запускай эксперименты 
               прямо из интерфейса. Всё прозрачно и настраиваемо.
             </p>
           </div>
           <div className="card card--hoverable feature-card">
-            <h3>🤖 Обучение с агентами</h3>
+            <h3><i className={`fas ${ICONS.agent}`}></i> Обучение с агентами</h3>
             <p>
               Агенты сами подбирают гиперпараметры, анализируют результаты 
               и предлагают улучшения — машинное обучение становится доступнее.

--- a/frontend/src/pages/ModelDetail.tsx
+++ b/frontend/src/pages/ModelDetail.tsx
@@ -9,6 +9,7 @@ import { formatBytes, formatDateTime } from '../utils/format';
 import { useCopyToClipboard } from '../hooks';
 import { CollapseChevron, getDisclosureProps } from '../components/common/Collapse';
 import { ModelMetricsCharts } from '../components/models';
+import { ICONS } from '../constants/icons';
 import './Models.css';
 
 const ModelDetail: React.FC = () => {
@@ -69,7 +70,7 @@ const ModelDetail: React.FC = () => {
     return (
       <div className="page">
         <div className="loading-state">
-          <i className="fas fa-spinner fa-spin"></i> Загрузка модели…
+          <i className={`fas ${ICONS.loading} fa-spin`}></i> Загрузка модели…
         </div>
       </div>
     );
@@ -79,10 +80,10 @@ const ModelDetail: React.FC = () => {
     return (
       <div className="page">
         <button className="detail-back-link" onClick={() => navigate('/models')}>
-          <i className="fas fa-arrow-left"></i> К списку моделей
+          <i className={`fas ${ICONS.back}`}></i> К списку моделей
         </button>
         <div className="empty-state">
-          <i className="fas fa-triangle-exclamation"></i> Модель не найдена.
+          <i className={`fas ${ICONS.notFound}`}></i> Модель не найдена.
         </div>
       </div>
     );
@@ -93,13 +94,13 @@ const ModelDetail: React.FC = () => {
   return (
     <div className="page model-detail">
       <button className="detail-back-link" onClick={() => navigate('/models')}>
-        <i className="fas fa-arrow-left"></i> К списку моделей
+        <i className={`fas ${ICONS.back}`}></i> К списку моделей
       </button>
 
       <div className="model-detail-header">
         <div className="model-detail-title">
           <h1>{model.name}</h1>
-          <span className="model-version"><i className="fas fa-code-branch"></i> v{model.version}</span>
+          <span className="model-version"><i className={`fas ${ICONS.version}`}></i> v{model.version}</span>
           <span className={`status-badge status-${model.status}`}>{model.status}</span>
         </div>
         <span
@@ -107,14 +108,14 @@ const ModelDetail: React.FC = () => {
           title="Нажмите, чтобы скопировать ID"
           onClick={() => handleCopyId(model.id)}
         >
-          <i className="fas fa-hashtag"></i>{model.id}
-          <i className="fas fa-copy model-detail-id-copy-icon"></i>
+          <i className={`fas ${ICONS.id}`}></i>{model.id}
+          <i className={`fas ${ICONS.copy} model-detail-id-copy-icon`}></i>
         </span>
         {model.description && <p className="model-detail-description">{model.description}</p>}
       </div>
 
       <section className="detail-section">
-        <h3 className="detail-section-title"><i className="fas fa-circle-info"></i> Общая информация</h3>
+        <h3 className="detail-section-title"><i className={`fas ${ICONS.info}`}></i> Общая информация</h3>
         <div className="detail-fields">
           <div className="detail-field"><span className="detail-label">Тип</span><span>{model.model_type || '—'}</span></div>
           <div className="detail-field"><span className="detail-label">Framework</span><span>{model.framework ?? '—'}{model.framework_version ? ` ${model.framework_version}` : ''}</span></div>
@@ -126,7 +127,7 @@ const ModelDetail: React.FC = () => {
               onClick={() => navigate('/datasets')}
               title={model.dataset_id}
             >
-              <i className="fas fa-database"></i>
+              <i className={`fas ${ICONS.dataset}`}></i>
               {dataset ? dataset.name : model.dataset_id}
             </button>
           </div>
@@ -137,7 +138,7 @@ const ModelDetail: React.FC = () => {
               onClick={() => navigate('/datasets')}
               title={model.dataset_version_id}
             >
-              <i className="fas fa-code-branch"></i>
+              <i className={`fas ${ICONS.version}`}></i>
               {dataset?.versions.find(v => v.id === model.dataset_version_id)?.name ?? model.dataset_version_id}
             </button>
           </div>
@@ -145,7 +146,7 @@ const ModelDetail: React.FC = () => {
       </section>
 
       <section className="detail-section">
-        <h3 className="detail-section-title"><i className="fas fa-tags"></i> Классы ({model.classes.length})</h3>
+        <h3 className="detail-section-title"><i className={`fas ${ICONS.classes}`}></i> Классы ({model.classes.length})</h3>
         {model.classes.length > 0 ? (
           <div className="tag-list">
             {model.classes.map((cls) => (
@@ -158,7 +159,7 @@ const ModelDetail: React.FC = () => {
       </section>
 
       <section className="detail-section">
-        <h3 className="detail-section-title"><i className="fas fa-chart-line"></i> Метрики</h3>
+        <h3 className="detail-section-title"><i className={`fas ${ICONS.metrics}`}></i> Метрики</h3>
         <ModelMetricsCharts modelId={model.id} />
         {model.metrics_report && (
           <div className="metrics-report-details">
@@ -167,7 +168,7 @@ const ModelDetail: React.FC = () => {
               {...getDisclosureProps(reportOpen, () => setReportOpen(o => !o))}
             >
               <CollapseChevron open={reportOpen} />
-              <i className="fas fa-file-lines"></i> Текстовый отчёт
+              <i className={`fas ${ICONS.report}`}></i> Текстовый отчёт
             </div>
             {reportOpen && <pre className="detail-pre metrics-report-pre">{model.metrics_report}</pre>}
           </div>
@@ -181,7 +182,7 @@ const ModelDetail: React.FC = () => {
         >
           <CollapseChevron open={paramsOpen} />
           <h3 className="detail-section-title" style={{ margin: 0 }}>
-            <i className="fas fa-sliders"></i> Параметры обучения
+            <i className={`fas ${ICONS.trainingParams}`}></i> Параметры обучения
           </h3>
         </div>
         {paramsOpen && (
@@ -196,13 +197,13 @@ const ModelDetail: React.FC = () => {
       </section>
 
       <section className="detail-section">
-        <h3 className="detail-section-title"><i className="fas fa-file-arrow-down"></i> Файлы весов ({files.length})</h3>
+        <h3 className="detail-section-title"><i className={`fas ${ICONS.weights}`}></i> Файлы весов ({files.length})</h3>
         {files.length > 0 ? (
           <div className="model-files">
             {files.map((file) => (
               <div key={file.id} className="model-file-row">
                 <div className="model-file-info">
-                  <span className="model-file-name"><i className="fas fa-file"></i> {file.filename}</span>
+                  <span className="model-file-name"><i className={`fas ${ICONS.file}`}></i> {file.filename}</span>
                   <span className="model-file-meta">
                     {formatBytes(file.file_size)} · {formatDateTime(file.created_at)}
                   </span>
@@ -213,9 +214,9 @@ const ModelDetail: React.FC = () => {
                   onClick={() => handleDownload(file)}
                 >
                   {downloadingId === file.id ? (
-                    <><i className="fas fa-spinner fa-spin"></i> Скачивание…</>
+                    <><i className={`fas ${ICONS.loading} fa-spin`}></i> Скачивание…</>
                   ) : (
-                    <><i className="fas fa-download"></i> Скачать</>
+                    <><i className={`fas ${ICONS.download}`}></i> Скачать</>
                   )}
                 </button>
               </div>

--- a/frontend/src/pages/ModelDetail.tsx
+++ b/frontend/src/pages/ModelDetail.tsx
@@ -78,8 +78,8 @@ const ModelDetail: React.FC = () => {
   if (!model) {
     return (
       <div className="page">
-        <button className="button secondary" onClick={() => navigate('/models')}>
-          <i className="fas fa-arrow-left"></i> К списку
+        <button className="detail-back-link" onClick={() => navigate('/models')}>
+          <i className="fas fa-arrow-left"></i> К списку моделей
         </button>
         <div className="empty-state">
           <i className="fas fa-triangle-exclamation"></i> Модель не найдена.
@@ -92,8 +92,8 @@ const ModelDetail: React.FC = () => {
 
   return (
     <div className="page model-detail">
-      <button className="button secondary back-button" onClick={() => navigate('/models')}>
-        <i className="fas fa-arrow-left"></i> К списку
+      <button className="detail-back-link" onClick={() => navigate('/models')}>
+        <i className="fas fa-arrow-left"></i> К списку моделей
       </button>
 
       <div className="model-detail-header">

--- a/frontend/src/pages/Models.css
+++ b/frontend/src/pages/Models.css
@@ -482,14 +482,18 @@
 .model-group-header {
   display: flex;
   flex-direction: column;
+  gap: 0.6rem;
+}
+
+.model-group-header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: 0.5rem;
 }
 
-.model-group-header-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
+.model-group-meta {
+  /* Сводка по последней версии — отдельной строкой под заголовком. */
 }
 
 .model-group-count {
@@ -507,6 +511,33 @@
   padding-top: 0.75rem;
 }
 
+.versions-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  width: 100%;
+  margin-top: 0.5rem;
+  padding: 0.45rem;
+  background: transparent;
+  border: none;
+  border-top: var(--border-subtle);
+  border-radius: 0;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-family: var(--font-primary);
+  font-size: 0.82rem;
+  transition: color 0.15s;
+}
+
+.versions-toggle:hover {
+  color: var(--color-accent);
+}
+
+.versions-toggle i {
+  font-size: 0.7rem;
+}
+
 .versions-table {
   width: 100%;
   table-layout: fixed;
@@ -516,8 +547,17 @@
 
 .versions-table colgroup col:nth-child(1) { width: 5rem; }
 .versions-table colgroup col:nth-child(2) { width: auto; }
-.versions-table colgroup col:nth-child(3) { width: 6rem; }
+.versions-table colgroup col:nth-child(3) { width: 8.5rem; }
 .versions-table colgroup col:nth-child(4) { width: 9rem; }
+
+/* Бейдж статуса не должен вылезать за пределы своей ячейки на колонку «Дата». */
+.versions-table .status-badge {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
 
 .versions-table thead th {
   text-align: left;
@@ -578,7 +618,7 @@
   color: var(--color-text-secondary);
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 0.1rem;
 }
 

--- a/frontend/src/pages/Models.css
+++ b/frontend/src/pages/Models.css
@@ -46,153 +46,20 @@
   color: #fff;
 }
 
-.filter-field {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  background: var(--color-bg-secondary);
-  border: var(--border-subtle);
-  border-radius: var(--radius-input);
-  padding: 0.55rem 1rem;
-  flex: 1 1 220px;
-}
-
-.filter-field i {
-  color: var(--color-text-secondary);
-}
-
-.filter-field input,
-.filter-field select {
-  background: transparent;
-  border: none;
-  outline: none;
-  color: var(--color-text-primary);
-  font-family: var(--font-primary);
-  font-size: 0.95rem;
-  width: 100%;
-}
-
-.filter-field select option {
-  background: var(--color-bg-secondary);
-  color: var(--color-text-primary);
-}
-
-/* ── Кастомный select (фильтры) ──────────────────────────────────────────────── */
-.select {
-  position: relative;
-  flex: 1 1 220px;
-  min-width: 0;
-}
-
-.select-trigger {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  width: 100%;
-  background: var(--color-bg-secondary);
-  border: var(--border-subtle);
-  border-radius: var(--radius-input);
-  padding: 0.55rem 1rem;
-  cursor: pointer;
-  color: var(--color-text-primary);
-  font-family: var(--font-primary);
-  font-size: 0.95rem;
-  text-align: left;
-  transition: border-color 0.15s, background 0.15s;
-}
-
-.select-trigger:hover {
-  border-color: var(--color-border-strong);
-}
-
-.select--open .select-trigger {
-  border-color: var(--color-accent);
-}
-
-.select-trigger > i:first-child {
-  color: var(--color-text-secondary);
-  flex-shrink: 0;
-}
-
-.select-value {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.select-caret {
-  flex-shrink: 0;
-  font-size: 0.7rem;
-  color: var(--color-text-secondary);
-  transition: transform 0.18s ease;
-}
-
-.select--open .select-caret {
-  transform: rotate(180deg);
-  color: var(--color-accent);
-}
-
-.select-menu {
-  position: absolute;
-  top: calc(100% + 0.4rem);
-  left: 0;
-  right: 0;
-  z-index: 50;
-  margin: 0;
-  padding: 0.35rem;
-  list-style: none;
-  background: var(--color-bg-secondary);
-  border: var(--border-soft);
-  border-radius: var(--radius-input);
-  box-shadow: var(--shadow-md);
-  max-height: 16rem;
-  overflow-y: auto;
-  animation: select-menu-in 0.14s ease;
-}
-
-@keyframes select-menu-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-.select-option {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.5rem 0.7rem;
-  border-radius: calc(var(--radius-input) - 2px);
-  cursor: pointer;
-  font-size: 0.92rem;
-  color: var(--color-text-primary);
-  transition: background 0.12s, color 0.12s;
-}
-
-.select-option-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.select-option--active {
-  background: var(--color-bg-primary);
-}
-
-.select-option--selected {
-  color: var(--color-accent);
-}
-
-.select-option-check {
-  font-size: 0.7rem;
-  flex-shrink: 0;
-}
+/* .filter-field — общий примитив, см. styles/components.css */
 
 /* ── Сетка карточек ──────────────────────────────────────────────────────────── */
 .models-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 520px), 1fr));
   gap: 1.5rem;
+}
+
+/* Во время фоновой подгрузки список не убираем, а слегка приглушаем. */
+.models-grid.is-refreshing {
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
 }
 
 .model-card-header {
@@ -232,6 +99,12 @@
 .model-meta i {
   margin-right: 0.3rem;
   color: var(--color-accent);
+}
+
+.model-meta .meta-label {
+  color: var(--color-text-tertiary, var(--color-text-secondary));
+  font-weight: 500;
+  opacity: 0.8;
 }
 
 .model-description {
@@ -315,116 +188,9 @@
   color: var(--color-text-secondary);
 }
 
-.detail-section {
-  background: var(--color-bg-secondary);
-  border: var(--border-subtle);
-  border-radius: var(--radius-card);
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
-.detail-section-title {
-  margin: 0 0 1.2rem;
-  font-size: 1.1rem;
-}
-
-.detail-section-collapsible-header {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding-bottom: 1.2rem;
-  border-bottom: var(--border-subtle);
-  cursor: pointer;
-}
-
-.detail-section-collapsible-header:hover .collapse-chevron,
-.detail-section-collapsible-header:hover .detail-section-title {
-  color: var(--color-accent);
-}
-
-.detail-section-title i {
-  margin-right: 0.5rem;
-  color: var(--color-accent);
-}
-
-.detail-fields {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 1rem;
-}
-
-.detail-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  min-width: 0;
-}
-
-.detail-label {
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  color: var(--color-text-secondary);
-}
-
-.detail-field .mono {
-  word-break: break-all;
-}
-
-.detail-empty {
-  color: var(--color-text-secondary);
-  font-style: italic;
-}
-
-.detail-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.75rem;
-  background: var(--color-accent-soft);
-  border: 1px solid transparent;
-  border-radius: var(--radius-pill);
-  cursor: pointer;
-  color: var(--color-accent-light);
-  font-family: var(--font-primary);
-  font-size: 0.88rem;
-  font-weight: 500;
-  text-decoration: none;
-  white-space: nowrap;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
-}
-
-.detail-link i {
-  font-size: 0.78rem;
-  flex-shrink: 0;
-  opacity: 0.8;
-}
-
-.detail-link:hover {
-  background: var(--color-accent-soft);
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-  filter: brightness(1.15);
-}
-
 .detail-pre--params,
 .detail-empty--params {
   margin-top: 2rem;
-}
-
-.detail-pre {
-  background: var(--color-bg-primary);
-  border-radius: var(--radius-input);
-  padding: 1rem;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: var(--color-text-primary);
-  font-size: 0.9rem;
-  margin: 0;
 }
 
 /* ── Файлы весов ─────────────────────────────────────────────────────────────── */
@@ -628,46 +394,17 @@
 }
 
 /* ── Иконочные кнопки действий ───────────────────────────────────────────────── */
-.btn-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-input);
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  padding: 0.4rem;
-  font-size: 0.9rem;
-  transition: color 0.15s, background 0.15s;
-  flex-shrink: 0;
-}
-
-.btn-icon:hover {
-  color: var(--color-text-primary);
-  background: var(--color-bg-primary);
-}
-
-.btn-icon--danger:hover {
-  color: var(--color-danger, #e05c5c);
-  background: rgba(224, 92, 92, 0.1);
-}
-
-.btn-icon--sm {
-  font-size: 0.75rem;
-  padding: 0.3rem;
-}
-
 .model-version-actions {
   text-align: center;
 }
 
-.model-version-row .btn-icon--sm {
+/* Кнопка удаления версии проявляется при наведении на строку */
+.model-version-row .icon-button.small {
   opacity: 0;
-  transition: opacity 0.15s, color 0.15s, background 0.15s;
+  transition: var(--transition);
 }
 
-.model-version-row:hover .btn-icon--sm {
+.model-version-row:hover .icon-button.small {
   opacity: 1;
 }
 

--- a/frontend/src/pages/Models.tsx
+++ b/frontend/src/pages/Models.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { mlModelsService } from '../services/mlModelsService';
 import { datasetService } from '../services/datasetService';
 import { useNotification } from '../contexts/NotificationContext';
-import { useModelFilters } from '../hooks';
+import { useModelFilters, useDebouncedValue } from '../hooks';
 import { MODELS_PAGE_SIZE } from '../constants';
 import { ModelCard, ModelGroupCard } from '../components/models';
 import Select from '../components/common/Select';
@@ -29,6 +29,8 @@ const Models: React.FC = () => {
 
   // Фильтры и пагинация.
   const { filters, offset, setFilter, setOffset, resetPage } = useModelFilters();
+  // Имя дебаунсим, чтобы не слать запрос на каждое нажатие клавиши.
+  const debouncedName = useDebouncedValue(filters.name);
   const [statuses, setStatuses] = useState<MLModelStatus[]>([]);
   const [datasets, setDatasets] = useState<Dataset[]>([]);
 
@@ -45,7 +47,7 @@ const Models: React.FC = () => {
     setLoading(true);
     try {
       const data = await mlModelsService.getModels({
-        name: filters.name || undefined,
+        name: debouncedName || undefined,
         status: filters.status || undefined,
         dataset_id: filters.dataset || undefined,
         limit: MODELS_PAGE_SIZE,
@@ -58,12 +60,13 @@ const Models: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [filters, offset, showNotification]);
+  }, [debouncedName, filters.status, filters.dataset, offset, showNotification]);
 
   const loadGrouped = useCallback(async () => {
     setLoading(true);
     try {
       const data = await mlModelsService.getGroupedModels({
+        name: debouncedName || undefined,
         status: filters.status || undefined,
         dataset_id: filters.dataset || undefined,
         limit: MODELS_PAGE_SIZE,
@@ -76,7 +79,7 @@ const Models: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [filters, offset, showNotification]);
+  }, [debouncedName, filters.status, filters.dataset, offset, showNotification]);
 
   useEffect(() => {
     if (viewMode === 'flat') {
@@ -98,6 +101,8 @@ const Models: React.FC = () => {
   const canNext = offset + MODELS_PAGE_SIZE < total;
 
   const isEmpty = viewMode === 'flat' ? models.length === 0 : groups.length === 0;
+  // Полноэкранный лоадер — только на первичной загрузке; при обновлении приглушаем текущий список.
+  const initialLoading = loading && isEmpty;
 
   return (
     <div className="page">
@@ -110,17 +115,15 @@ const Models: React.FC = () => {
 
       <div className="models-toolbar">
         <div className="models-filters">
-          {viewMode === 'flat' && (
-            <div className="filter-field">
-              <i className="fas fa-search"></i>
-              <input
-                type="text"
-                placeholder="Поиск по имени"
-                value={filters.name}
-                onChange={(e) => setFilter('name', e.target.value)}
-              />
-            </div>
-          )}
+          <div className="filter-field">
+            <i className="fas fa-search"></i>
+            <input
+              type="text"
+              placeholder="Поиск по имени"
+              value={filters.name}
+              onChange={(e) => setFilter('name', e.target.value)}
+            />
+          </div>
 
           <Select
             icon="fas fa-filter"
@@ -159,7 +162,7 @@ const Models: React.FC = () => {
         </div>
       </div>
 
-      {loading ? (
+      {initialLoading ? (
         <div className="loading-state">
           <i className="fas fa-spinner fa-spin"></i> Загрузка моделей…
         </div>
@@ -169,7 +172,7 @@ const Models: React.FC = () => {
         </div>
       ) : (
         <>
-          <div className="models-grid">
+          <div className={`models-grid${loading ? ' is-refreshing' : ''}`}>
             {viewMode === 'flat'
               ? models.map((model) => <ModelCard key={model.id} model={model} />)
               : groups.map((group) => <ModelGroupCard key={group.name} group={group} onReload={loadGrouped} />)

--- a/frontend/src/pages/Models.tsx
+++ b/frontend/src/pages/Models.tsx
@@ -8,6 +8,7 @@ import { ModelCard, ModelGroupCard } from '../components/models';
 import Select from '../components/common/Select';
 import type { MLModel, MLModelGroup, MLModelStatus } from '../types/mlModels';
 import type { Dataset } from '../types/dataset';
+import { ICONS } from '../constants/icons';
 import './Models.css';
 
 type ViewMode = 'grouped' | 'flat';
@@ -116,7 +117,7 @@ const Models: React.FC = () => {
       <div className="models-toolbar">
         <div className="models-filters">
           <div className="filter-field">
-            <i className="fas fa-search"></i>
+            <i className={`fas ${ICONS.search}`}></i>
             <input
               type="text"
               placeholder="Поиск по имени"
@@ -126,7 +127,7 @@ const Models: React.FC = () => {
           </div>
 
           <Select
-            icon="fas fa-filter"
+            icon={`fas ${ICONS.filter}`}
             ariaLabel="Фильтр по статусу"
             placeholder="Все статусы"
             value={filters.status}
@@ -135,7 +136,7 @@ const Models: React.FC = () => {
           />
 
           <Select
-            icon="fas fa-database"
+            icon={`fas ${ICONS.dataset}`}
             ariaLabel="Фильтр по датасету"
             placeholder="Все датасеты"
             value={filters.dataset}
@@ -150,25 +151,25 @@ const Models: React.FC = () => {
             onClick={() => switchView('grouped')}
             title="Группировка по моделям"
           >
-            <i className="fas fa-layer-group"></i>
+            <i className={`fas ${ICONS.groupedView}`}></i>
           </button>
           <button
             className={`view-toggle-btn${viewMode === 'flat' ? ' active' : ''}`}
             onClick={() => switchView('flat')}
             title="Плоский список"
           >
-            <i className="fas fa-list"></i>
+            <i className={`fas ${ICONS.listView}`}></i>
           </button>
         </div>
       </div>
 
       {initialLoading ? (
         <div className="loading-state">
-          <i className="fas fa-spinner fa-spin"></i> Загрузка моделей…
+          <i className={`fas ${ICONS.loading} fa-spin`}></i> Загрузка моделей…
         </div>
       ) : isEmpty ? (
         <div className="empty-state">
-          <i className="fas fa-box-open"></i> Модели не найдены.
+          <i className={`fas ${ICONS.empty}`}></i> Модели не найдены.
         </div>
       ) : (
         <>
@@ -185,7 +186,7 @@ const Models: React.FC = () => {
               disabled={!canPrev}
               onClick={() => setOffset(Math.max(0, offset - MODELS_PAGE_SIZE))}
             >
-              <i className="fas fa-chevron-left"></i> Назад
+              <i className={`fas ${ICONS.pagePrev}`}></i> Назад
             </button>
             <span className="pagination-info">
               Стр. {page} из {totalPages} · всего {total}
@@ -195,7 +196,7 @@ const Models: React.FC = () => {
               disabled={!canNext}
               onClick={() => setOffset(offset + MODELS_PAGE_SIZE)}
             >
-              Вперёд <i className="fas fa-chevron-right"></i>
+              Вперёд <i className={`fas ${ICONS.pageNext}`}></i>
             </button>
           </div>
         </>

--- a/frontend/src/services/mlModelsService.ts
+++ b/frontend/src/services/mlModelsService.ts
@@ -40,6 +40,7 @@ export const mlModelsService = {
     const url = new URL(`${ML_MODELS_URL}/models/grouped`);
     if (query.dataset_id) url.searchParams.append('dataset_id', query.dataset_id);
     if (query.status) url.searchParams.append('status', query.status);
+    if (query.name) url.searchParams.append('name', query.name);
     if (query.limit != null) url.searchParams.append('limit', String(query.limit));
     if (query.offset != null) url.searchParams.append('offset', String(query.offset));
     const response = await fetch(url.toString());

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -29,6 +29,102 @@
   margin: 0 auto 1.5rem;
 }
 
+/* ── Переключатель вкладок страницы ──────────────────────────────────────────── */
+.page-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+  padding: 0.3rem;
+  background: var(--color-bg-secondary);
+  border-radius: 40px;
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+  border: 1px solid var(--color-border);
+}
+
+.page-tab {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: none;
+  padding: 0.5rem 1.5rem;
+  border-radius: 30px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: none;
+  transition: var(--transition);
+}
+
+.page-tab:hover {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  transform: none;
+  box-shadow: none;
+}
+
+.page-tab.active {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.page-tab.active:hover {
+  background: var(--color-accent-light);
+  color: var(--color-on-accent);
+}
+
+.page-tab i {
+  margin-right: 0.4rem;
+}
+
+/* ── Тулбар фильтров списка ──────────────────────────────────────────────────── */
+.list-toolbar {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.list-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  flex: 1;
+}
+
+.filter-field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: var(--color-bg-secondary);
+  border: var(--border-subtle);
+  border-radius: var(--radius-input);
+  padding: 0.55rem 1rem;
+  flex: 1 1 220px;
+}
+
+.filter-field i {
+  color: var(--color-text-secondary);
+}
+
+.filter-field input,
+.filter-field select {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--color-text-primary);
+  font-family: var(--font-primary);
+  font-size: 0.95rem;
+  width: 100%;
+}
+
+.filter-field select option {
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+}
+
 /* ── Карточка ────────────────────────────────────────────────────────────────── */
 .card {
   background: var(--color-bg-secondary);
@@ -99,13 +195,42 @@ button:disabled,
   padding: 0.3rem;
 }
 
-/* Кнопка «назад» в детальных просмотрах */
-.back-button {
-  margin-bottom: 1.5rem;
+.icon-button--danger:hover:not(:disabled) {
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
 }
 
-.back-button i {
-  margin-right: 0.4rem;
+/* Лёгкая ссылка-возврат в стиле breadcrumb над шапкой детальной страницы.
+   Стрелка сдвигается влево при наведении, фон не подсвечивается. */
+.detail-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: var(--color-text-secondary);
+  font-family: var(--font-primary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.detail-back-link i {
+  transition: transform 0.15s;
+}
+
+.detail-back-link:hover {
+  background: transparent;
+  color: var(--color-accent);
+  transform: none;
+  box-shadow: none;
+}
+
+.detail-back-link:hover i {
+  transform: translateX(-3px);
 }
 
 /* ── Бейджи статусов ─────────────────────────────────────────────────────────── */
@@ -176,6 +301,114 @@ button:disabled,
 .mono {
   font-family: ui-monospace, 'Cascadia Code', 'Fira Code', 'Courier New', monospace;
   font-size: 0.9rem;
+}
+
+/* ── Детальные страницы: секции и поля ───────────────────────────────────────── */
+.detail-section {
+  background: var(--color-bg-secondary);
+  border: var(--border-subtle);
+  border-radius: var(--radius-card);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.detail-section-title {
+  margin: 0 0 1.2rem;
+  font-size: 1.1rem;
+}
+
+.detail-section-collapsible-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding-bottom: 1.2rem;
+  border-bottom: var(--border-subtle);
+  cursor: pointer;
+}
+
+.detail-section-collapsible-header:hover .collapse-chevron,
+.detail-section-collapsible-header:hover .detail-section-title {
+  color: var(--color-accent);
+}
+
+.detail-section-title i {
+  margin-right: 0.5rem;
+  color: var(--color-accent);
+}
+
+.detail-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.detail-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.detail-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--color-text-secondary);
+}
+
+.detail-field .mono {
+  word-break: break-all;
+}
+
+.detail-empty {
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.detail-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  background: var(--color-accent-soft);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  color: var(--color-accent-light);
+  font-family: var(--font-primary);
+  font-size: 0.88rem;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.detail-link i {
+  font-size: 0.78rem;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+.detail-link:hover {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  filter: brightness(1.15);
+}
+
+.detail-pre {
+  background: var(--color-bg-primary);
+  border-radius: var(--radius-input);
+  padding: 1rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text-primary);
+  font-size: 0.9rem;
+  margin: 0;
 }
 
 /* ── Единый индикатор сворачивания (collapse/expand) ─────────────────────────── */

--- a/frontend/src/types/mlModels.ts
+++ b/frontend/src/types/mlModels.ts
@@ -70,5 +70,5 @@ export interface MLModelsGrouped {
   offset: number;
 }
 
-// Параметры запроса grouped endpoint (без name — фильтр идёт по имени группы через name в ModelsQuery).
-export type GroupedModelsQuery = Omit<ModelsQuery, 'name'>;
+// Параметры запроса grouped endpoint: name — частичный поиск по имени группы.
+export type GroupedModelsQuery = ModelsQuery;

--- a/services/agents/app/core/__init__.py
+++ b/services/agents/app/core/__init__.py
@@ -4,6 +4,7 @@ from app.logs import get_logger
 from app.core.crews.dataset_analyst import run_dataset_analyst
 from app.core.crews.reporter import run_reporter
 from app.core.memory import iteration_context
+from app.services.agent_history import agent_history_client
 from .pipeline import (
     train_and_debug, reasoning,
     TrainingInput
@@ -36,6 +37,7 @@ def development_models(
     """
 
     logger.info("Анализа датасета...")
+    agent_history_client.info("Запуск пайплайна разработки модели. Анализ датасета...")
     dataset_analyst_out = run_dataset_analyst(
         dataset_id=dataset_id,
         dataset_version_id=dataset_version_id,
@@ -43,9 +45,11 @@ def development_models(
     )
     if not dataset_analyst_out.readiness_assessment:
         logger.info("🟥 Анализ датасета показал, что данные не готовы к обучению")
+        agent_history_client.error("Анализ датасета показал, что данные не готовы к обучению. Пайплайн остановлен.")
         return None
 
     logger.info("✅ Анализ датасета")
+    agent_history_client.info("Анализ датасета завершён: данные готовы к обучению.")
     version_model=0
 
     for iter in range(1, max_iter+1):
@@ -53,6 +57,7 @@ def development_models(
         version_model+=1
 
         info_start_iter = f"Полный цикл обучения №{iter} из {max_iter}"
+        agent_history_client.info(f"{info_start_iter}. Этап рассуждения агентов.")
         logger.info(
             f"\n{'='*100}"
             f"\n{'Этап рассуждения':^100}"
@@ -73,8 +78,12 @@ def development_models(
         if not ml_engin_out.decision:
             logger.info("🟥 МЛ инженер и исследователь не смогли придти к общему мнению.")
             logger.warning("🟥 Обучение остановлено")
+            agent_history_client.error(
+                "ML-инженер и исследователь не пришли к общему мнению. Обучение остановлено."
+            )
             return None
         logger.info("✅ Конец рассуждений.")
+        agent_history_client.info("Рассуждение завершено: конфигурация обучения согласована.")
 
         logger.info(
             f"\n{'='*100}"
@@ -82,6 +91,7 @@ def development_models(
             f"\n{info_start_iter:^100}"
             f"\n{'='*100}"
         )
+        agent_history_client.info(f"{info_start_iter}. Запуск обучения модели.")
         # Создаём экземпляр модели для запуска тренировок
         training_input=TrainingInput(
             model_name=model_name,
@@ -104,6 +114,7 @@ def development_models(
                 f"\n{'✅ Модель успешно обучена':^100}"
                 f"\n{'='*100}"
             )
+            agent_history_client.info(f"Цикл обучения №{iter} из {max_iter} завершён: модель успешно обучена.")
 
         else:
             logger.info(
@@ -113,6 +124,9 @@ def development_models(
                 f"\n{'🟥 Не удалось обучить модель':^100}"
                 f"\nОписание: {training_res.error}"
                 f"\n{'='*100}"
+            )
+            agent_history_client.warning(
+                f"Цикл обучения №{iter} из {max_iter} провалился: {training_res.error}"
             )
             # Сообщаем следующей итерации о провале обучения, чтобы исследователь и
             # ML инженер не повторили то же решение.
@@ -126,6 +140,7 @@ def development_models(
             )
 
     # Подводим итоги обучений
+    agent_history_client.info("Все циклы обучения завершены. Формирование итогового отчёта...")
     result = run_reporter(
         business_requirements=business_requirements,
         deployment_constraints=deployment_constraints,

--- a/services/ml_models/app/api/routers/ml_models.py
+++ b/services/ml_models/app/api/routers/ml_models.py
@@ -117,6 +117,7 @@ async def get_models_statistics(
 async def get_grouped_models(
     dataset_id: Optional[str] = Query(None, description="Фильтр по ID датасета"),
     model_status: Optional[str] = Query(None, alias="status", description="Фильтр по статусу модели"),
+    name: Optional[str] = Query(None, description="Фильтр по имени модели (частичное совпадение)"),
     limit: Optional[int] = Query(None, ge=1, description="Размер страницы (по именам)"),
     offset: int = Query(0, ge=0, description="Смещение для пагинации"),
     manager: MlModelsManager = Depends(get_ml_models_manager)
@@ -124,6 +125,7 @@ async def get_grouped_models(
     result = manager.get_grouped_models(
         dataset_id=dataset_id,
         status=model_status,
+        name=name,
         limit=limit,
         offset=offset,
     )

--- a/services/ml_models/app/core/train_models_tasks.py
+++ b/services/ml_models/app/core/train_models_tasks.py
@@ -74,8 +74,8 @@ class MlModelsManager:
             conditions.append("s.status = %s")
             params.append(status)
         if name:
-            conditions.append("m.name = %s")
-            params.append(name)
+            conditions.append("m.name ILIKE %s")
+            params.append(f"%{name}%")
 
         if conditions:
             query += "WHERE " + " AND ".join(conditions) + "\n"
@@ -330,8 +330,8 @@ class MlModelsManager:
             conditions.append("s.status = %s")
             params.append(status)
         if name:
-            conditions.append("m.name = %s")
-            params.append(name)
+            conditions.append("m.name ILIKE %s")
+            params.append(f"%{name}%")
 
         if conditions:
             query += "WHERE " + " AND ".join(conditions) + "\n"
@@ -360,6 +360,7 @@ class MlModelsManager:
         self,
         dataset_id: str | None = None,
         status: str | None = None,
+        name: str | None = None,
         limit: int | None = None,
         offset: int = 0
     ) -> Dict[str, Any]:
@@ -380,6 +381,9 @@ class MlModelsManager:
         if status:
             conditions.append("s.status = %s")
             filter_params.append(status)
+        if name:
+            conditions.append("m.name ILIKE %s")
+            filter_params.append(f"%{name}%")
 
         filter_where = ("WHERE " + " AND ".join(conditions) + "\n") if conditions else ""
 


### PR DESCRIPTION
## 📌 Что было сделано?

### Иконки и общие компоненты
- Вынесены UI-иконки в единый реестр (`constants/icons.ts`, `ICONS`); footer и иконки сворачивания переведены на него (`Footer`, `Collapse`)
- Добавлены переиспользуемые common-компоненты: `Combobox`, `ChipListEditor`; обновлён `Select`
- Новый хук `useDebouncedValue`; `useCopyToClipboard` теперь обрабатывает ошибки clipboard

### Агенты / дискуссии
- Страница дискуссии агента переделана в таймлайн-вид (`DiscussionCard`, `DiscussionView`, `MessageBubble`, `DiscussionInfo`)
- Маршрут дискуссии переведён на path-параметр (`AgentDiscussion`, `App`)
- Карточки дискуссий приведены к стилю датасетов (`RunPipelineForm`, `Agents.css`)
- Системные info-сообщения дискуссии теперь эмитятся из `agents/core/__init__.py`

### Датасеты
- Добавлена страница `DatasetDetail`
- Переработаны `DatasetCard`, `DatasetForm`, `SourcesEditor` (+ CSS)

### Модели (ml_models)
- Обновлён `ModelGroupCard`, добавлен фильтр по имени (`Models.tsx`, `mlModelsService`, `types/mlModels`)
- Бэкенд: фильтр по `name` в роутере и `train_models_tasks`

### Прочее
- Footer: убрана ссылка на Telegram, копирайт переведён на MIT
- Удалён мёртвый код, убран setState-in-effect