### PR TITLE
Frontend/fix/metrics

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import DatasetDetail from './pages/DatasetDetail';
 import DatasetCompare from './pages/DatasetCompare';
 import Models from './pages/Models';
 import ModelDetail from './pages/ModelDetail';
+import ModelCompare from './pages/ModelCompare';
 import Agents from './pages/Agents';
 import AgentDiscussion from './pages/AgentDiscussion';
 
@@ -41,6 +42,7 @@ function App() {
               <Route path="/datasets/:id" element={<DatasetDetail />} />
               <Route path="/datasets/:id/compare" element={<DatasetCompare />} />
               <Route path="/models" element={<Models />} />
+              <Route path="/models/compare" element={<ModelCompare />} />
               <Route path="/models/:id" element={<ModelDetail />} />
               <Route path="/agents" element={<Agents />} />
               <Route path="/agents/discussion/:discussionId" element={<AgentDiscussion />} />

--- a/frontend/src/components/models/ModelClassReport.tsx
+++ b/frontend/src/components/models/ModelClassReport.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+import { metricsService } from '../../services/metricsService';
+import type { ClassReport } from '../../services/metricsService';
+import { CollapseChevron, getDisclosureProps } from '../common/Collapse';
+import { ICONS } from '../../constants/icons';
+
+interface Props {
+  modelId: string;
+  // Отчёт появляется только после завершения обучения — до этого не запрашиваем.
+  enabled: boolean;
+}
+
+const formatScore = (v: number) => v.toFixed(4);
+
+// Интенсивность фона ячейки по доле от суммы строки confusion matrix.
+const cellBackground = (value: number, rowTotal: number, isDiagonal: boolean) => {
+  if (rowTotal === 0 || value === 0) return undefined;
+  const share = value / rowTotal;
+  const alpha = 0.08 + share * 0.55;
+  // Диагональ (верные предсказания) — синяя, ошибки — красноватые, в духе SPLIT_COLORS.
+  return isDiagonal ? `rgba(94, 138, 177, ${alpha})` : `rgba(177, 94, 107, ${alpha})`;
+};
+
+/**
+ * Отчёт по классам на test-выборке из сервиса metrics: confusion matrix
+ * и per-class precision/recall/f1/support. Появляется после завершения
+ * обучения; если отчёта нет (404, старые модели) — не рендерится.
+ */
+const ModelClassReport: React.FC<Props> = ({ modelId, enabled }) => {
+  const [report, setReport] = useState<ClassReport | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    metricsService
+      .getClassReport(modelId)
+      .then((data) => {
+        if (!cancelled) setReport(data);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [modelId, enabled]);
+
+  if (!report) return null;
+
+  const rowTotals = report.confusion_matrix.map((row) =>
+    row.reduce((sum, v) => sum + v, 0),
+  );
+
+  return (
+    <div className="metrics-report-details">
+      <div
+        className="metrics-report-summary"
+        {...getDisclosureProps(open, () => setOpen((o) => !o))}
+      >
+        <CollapseChevron open={open} />
+        <i className={`fas ${ICONS.classReport}`}></i> Отчёт по классам (test)
+      </div>
+      {open && (
+        <div className="class-report">
+          <div className="class-report-block">
+            <p className="metrics-chart-title">Confusion matrix</p>
+            <div className="class-report-table-wrap">
+              <table className="class-report-table class-report-matrix">
+                <thead>
+                  <tr>
+                    <th className="class-report-corner">факт \ прогноз</th>
+                    {report.labels.map((label) => (
+                      <th key={label}>{label}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.confusion_matrix.map((row, i) => (
+                    <tr key={report.labels[i]}>
+                      <th>{report.labels[i]}</th>
+                      {row.map((value, j) => (
+                        <td
+                          key={report.labels[j]}
+                          style={{ background: cellBackground(value, rowTotals[i], i === j) }}
+                        >
+                          {value}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div className="class-report-block">
+            <p className="metrics-chart-title">Метрики по классам</p>
+            <div className="class-report-table-wrap">
+              <table className="class-report-table">
+                <thead>
+                  <tr>
+                    <th>Класс</th>
+                    <th>Precision</th>
+                    <th>Recall</th>
+                    <th>F1</th>
+                    <th>Support</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.per_class.map((row) => (
+                    <tr key={row.label}>
+                      <th>{row.label}</th>
+                      <td>{formatScore(row.precision)}</td>
+                      <td>{formatScore(row.recall)}</td>
+                      <td>{formatScore(row.f1)}</td>
+                      <td>{row.support}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ModelClassReport;

--- a/frontend/src/components/models/ModelMetricsCharts.tsx
+++ b/frontend/src/components/models/ModelMetricsCharts.tsx
@@ -8,15 +8,14 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import type { ModelMetrics, Split } from '../../services/metricsService';
+import type { ModelMetrics, Split, TrainingStatus } from '../../services/metricsService';
 import { useModelMetricsStream } from '../../hooks';
 import { ICONS } from '../../constants/icons';
+import ModelClassReport from './ModelClassReport';
 
 interface Props {
   modelId: string;
 }
-
-const SPLITS: Split[] = ['train', 'val', 'test'];
 
 const SPLIT_COLORS: Record<Split, string> = {
   train: '#b15e6b',
@@ -26,28 +25,49 @@ const SPLIT_COLORS: Record<Split, string> = {
 const GRID_COLOR = 'rgba(255,255,255,0.06)';
 const AXIS_COLOR = '#b0b8c5';
 
+// Кривые по эпохам: train и val накладываются на один график метрики —
+// так виден разрыв между ними (основной сигнал переобучения), как в W&B/TensorBoard.
+const CURVE_SPLITS: Split[] = ['train', 'val'];
+
 interface MetricChart {
   name: string;
   splits: Split[];
-  // Строки графика: эпоха + значение каждой выборки, у которой она есть.
   rows: Array<{ epoch: number } & Partial<Record<Split, number>>>;
   maxPoints: number;
 }
 
-// Группировка метрик по имени: один график на метрику, линия на выборку.
-const toMetricCharts = (data: ModelMetrics): MetricChart[] => {
+interface ScalarCard {
+  name: string;
+  split: Split;
+  value: number;
+}
+
+// Серии train/val из >1 точки — оверлей-графики; одиночные значения любой выборки
+// и весь test (финальная оценка — одна точка) — скалярные карточки.
+const splitMetricViews = (data: ModelMetrics): { charts: MetricChart[]; scalars: ScalarCard[] } => {
+  const scalars: ScalarCard[] = [];
   const byName = new Map<string, Partial<Record<Split, number[]>>>();
-  for (const split of SPLITS) {
+
+  for (const split of CURVE_SPLITS) {
     for (const metric of data[split]) {
       if (metric.values.length === 0) continue;
+      if (metric.values.length === 1) {
+        scalars.push({ name: metric.name, split, value: metric.values[0] });
+        continue;
+      }
       const series = byName.get(metric.name) ?? {};
       series[split] = metric.values;
       byName.set(metric.name, series);
     }
   }
 
-  return Array.from(byName.entries()).map(([name, series]) => {
-    const splits = SPLITS.filter((split) => series[split] !== undefined);
+  for (const metric of data.test) {
+    if (metric.values.length === 0) continue;
+    scalars.push({ name: metric.name, split: 'test', value: metric.values[metric.values.length - 1] });
+  }
+
+  const charts = Array.from(byName.entries()).map(([name, series]) => {
+    const splits = CURVE_SPLITS.filter((split) => series[split] !== undefined);
     const maxPoints = Math.max(...splits.map((split) => series[split]!.length));
     const rows = Array.from({ length: maxPoints }, (_, i) => {
       const row: MetricChart['rows'][number] = { epoch: i + 1 };
@@ -59,20 +79,39 @@ const toMetricCharts = (data: ModelMetrics): MetricChart[] => {
     });
     return { name, splits, rows, maxPoints };
   });
+
+  return { charts, scalars };
 };
 
 const formatValue = (v: number) =>
   Number.isInteger(v) ? String(v) : v.toFixed(4);
 
-const ModelMetricsCharts: React.FC<Props> = ({ modelId }) => {
-  const { data, loading, error } = useModelMetricsStream(modelId);
+// Бейдж статуса обучения; у старых моделей статуса нет — бейдж не показываем.
+const STATUS_BADGES: Record<TrainingStatus, { icon: string; spin?: boolean; label: string }> = {
+  in_progress: { icon: ICONS.loading, spin: true, label: 'Обучение идёт…' },
+  completed: { icon: ICONS.success, label: 'Обучение завершено' },
+  failed: { icon: ICONS.error, label: 'Ошибка обучения' },
+  cancelled: { icon: ICONS.cancelled, label: 'Обучение отменено' },
+};
 
-  const charts = data ? toMetricCharts(data) : [];
+const TrainingStatusBadge: React.FC<{ status: TrainingStatus }> = ({ status }) => {
+  const badge = STATUS_BADGES[status];
+  return (
+    <span className={`metrics-status-badge metrics-status-badge--${status}`}>
+      <i className={`fas ${badge.icon}${badge.spin ? ' fa-spin' : ''}`}></i> {badge.label}
+    </span>
+  );
+};
+
+const ModelMetricsCharts: React.FC<Props> = ({ modelId }) => {
+  const { data, status: trainingStatus, finished, loading, error } = useModelMetricsStream(modelId);
+
+  const { charts, scalars } = data ? splitMetricViews(data) : { charts: [], scalars: [] };
   // Ошибку показываем только если так и не получили данные (первая загрузка упала).
   const status: 'loading' | 'empty' | 'error' | 'ready' =
     loading ? 'loading'
     : error && data === undefined ? 'error'
-    : charts.length === 0 ? 'empty'
+    : charts.length === 0 && scalars.length === 0 ? 'empty'
     : 'ready';
 
   if (status === 'loading') {
@@ -94,70 +133,99 @@ const ModelMetricsCharts: React.FC<Props> = ({ modelId }) => {
   if (status === 'empty') {
     return (
       <div className="metrics-charts-placeholder">
+        {trainingStatus && <TrainingStatusBadge status={trainingStatus} />}
         <i className={`fas ${ICONS.metrics}`}></i> Данные по эпохам отсутствуют.
       </div>
     );
   }
 
   return (
-    <div className="metrics-charts">
-      {charts.map((chart) => (
-        <div key={chart.name} className="metrics-chart-block">
-          <p className="metrics-chart-title">
-            {chart.name}
-            <span style={{ marginLeft: 12, fontSize: 11 }}>
-              {chart.splits.map((split) => (
-                <span key={split} style={{ color: SPLIT_COLORS[split], marginRight: 8 }}>
-                  ● {split}
-                </span>
-              ))}
-            </span>
-          </p>
-          <ResponsiveContainer width="100%" height={180}>
-            <LineChart data={chart.rows} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} />
-              <XAxis
-                dataKey="epoch"
-                tick={{ fill: AXIS_COLOR, fontSize: 11 }}
-                tickLine={false}
-                axisLine={{ stroke: GRID_COLOR }}
-                label={{ value: 'эпоха', position: 'insideBottomRight', offset: -4, fill: AXIS_COLOR, fontSize: 10 }}
-              />
-              <YAxis
-                tick={{ fill: AXIS_COLOR, fontSize: 11 }}
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={formatValue}
-                width={56}
-              />
-              <Tooltip
-                contentStyle={{
-                  background: 'var(--color-bg-secondary)',
-                  border: '1px solid var(--color-border-soft)',
-                  borderRadius: 12,
-                  boxShadow: 'var(--shadow-md)',
-                  fontSize: 12,
-                  color: 'var(--color-text-primary)',
-                }}
-                formatter={(value, name) => [formatValue(Number(value)), String(name)]}
-                labelFormatter={(label) => `Эпоха ${label}`}
-              />
-              {chart.splits.map((split) => (
-                <Line
-                  key={split}
-                  type="monotone"
-                  dataKey={split}
-                  stroke={SPLIT_COLORS[split]}
-                  strokeWidth={2}
-                  dot={chart.maxPoints <= 40}
-                  activeDot={{ r: 4, fill: SPLIT_COLORS[split] }}
-                />
-              ))}
-            </LineChart>
-          </ResponsiveContainer>
+    <>
+      {trainingStatus && (
+        <div className="metrics-status-row">
+          <TrainingStatusBadge status={trainingStatus} />
         </div>
-      ))}
-    </div>
+      )}
+      {scalars.length > 0 && (
+        <div className="metrics-split-section">
+          <p className="metrics-split-title">Финальные значения</p>
+          <div className="metrics-scalar-cards">
+            {scalars.map(({ name, split, value }) => (
+              <div key={`${split}-${name}`} className="metrics-scalar-card">
+                <span className="metrics-scalar-card-name">
+                  <span style={{ color: SPLIT_COLORS[split] }}>●</span> {split} · {name}
+                </span>
+                <span className="metrics-scalar-card-value">{formatValue(value)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {charts.length > 0 && (
+        <div className="metrics-split-section">
+          <p className="metrics-split-title">Кривые по эпохам</p>
+          <div className="metrics-charts">
+            {charts.map((chart) => (
+              <div key={chart.name} className="metrics-chart-block">
+                <p className="metrics-chart-title">
+                  {chart.name}
+                  <span style={{ marginLeft: 12, fontSize: 11 }}>
+                    {chart.splits.map((split) => (
+                      <span key={split} style={{ color: SPLIT_COLORS[split], marginRight: 8 }}>
+                        ● {split}
+                      </span>
+                    ))}
+                  </span>
+                </p>
+                <ResponsiveContainer width="100%" height={180}>
+                  <LineChart data={chart.rows} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} />
+                    <XAxis
+                      dataKey="epoch"
+                      tick={{ fill: AXIS_COLOR, fontSize: 11 }}
+                      tickLine={false}
+                      axisLine={{ stroke: GRID_COLOR }}
+                      label={{ value: 'эпоха', position: 'insideBottomRight', offset: -4, fill: AXIS_COLOR, fontSize: 10 }}
+                    />
+                    <YAxis
+                      tick={{ fill: AXIS_COLOR, fontSize: 11 }}
+                      tickLine={false}
+                      axisLine={false}
+                      tickFormatter={formatValue}
+                      width={56}
+                    />
+                    <Tooltip
+                      contentStyle={{
+                        background: 'var(--color-bg-secondary)',
+                        border: '1px solid var(--color-border-soft)',
+                        borderRadius: 12,
+                        boxShadow: 'var(--shadow-md)',
+                        fontSize: 12,
+                        color: 'var(--color-text-primary)',
+                      }}
+                      formatter={(value, name) => [formatValue(Number(value)), String(name)]}
+                      labelFormatter={(label) => `Эпоха ${label}`}
+                    />
+                    {chart.splits.map((split) => (
+                      <Line
+                        key={split}
+                        type="monotone"
+                        dataKey={split}
+                        stroke={SPLIT_COLORS[split]}
+                        strokeWidth={2}
+                        dot={chart.maxPoints <= 40}
+                        activeDot={{ r: 4, fill: SPLIT_COLORS[split] }}
+                      />
+                    ))}
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <ModelClassReport modelId={modelId} enabled={finished} />
+    </>
   );
 };
 

--- a/frontend/src/components/models/index.ts
+++ b/frontend/src/components/models/index.ts
@@ -1,3 +1,4 @@
 export { default as ModelCard } from './ModelCard';
 export { default as ModelGroupCard } from './ModelGroupCard';
 export { default as ModelMetricsCharts } from './ModelMetricsCharts';
+export { default as ModelClassReport } from './ModelClassReport';

--- a/frontend/src/constants/icons.ts
+++ b/frontend/src/constants/icons.ts
@@ -40,6 +40,7 @@ export const ICONS = {
   success: 'fa-circle-check',
   warning: 'fa-triangle-exclamation',
   error: 'fa-circle-exclamation',
+  cancelled: 'fa-ban',         // отменённое обучение
   notFound: 'fa-triangle-exclamation',
   question: 'fa-circle-question',
   empty: 'fa-box-open',        // пустой список результатов
@@ -63,6 +64,7 @@ export const ICONS = {
   metrics: 'fa-chart-line',
   datasetStats: 'fa-chart-bar', // статистика splits версии датасета
   report: 'fa-file-lines',
+  classReport: 'fa-table-cells', // отчёт по классам (confusion matrix)
   weights: 'fa-file-arrow-down',
   file: 'fa-file',
 

--- a/frontend/src/hooks/useModelMetricsStream.ts
+++ b/frontend/src/hooks/useModelMetricsStream.ts
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react';
 import { metricsService } from '../services/metricsService';
-import type { ModelMetrics } from '../services/metricsService';
+import type { ModelMetrics, TrainingStatus } from '../services/metricsService';
+
+const FINAL_STATUSES: TrainingStatus[] = ['completed', 'failed', 'cancelled'];
 
 interface UseModelMetricsStreamResult {
   data: ModelMetrics | undefined;
+  status: TrainingStatus | null | undefined;
+  finished: boolean;
   loading: boolean;
   error: boolean;
 }
@@ -12,26 +16,41 @@ interface UseModelMetricsStreamResult {
  * Метрики модели в реальном времени через SSE: полный снимок приходит при
  * подключении и после каждой эпохи. Соединение не закрываем при ошибке —
  * EventSource переподключается сам, а очередной снимок восстанавливает данные.
+ * По событию 'end' (финальный статус обучения) соединение закрываем сами:
+ * сервер поток не завершает, новых снимков уже не будет.
  * Если SSE упал до первого снимка, делаем одноразовый fallback-запрос GET.
  */
 export function useModelMetricsStream(modelId: string): UseModelMetricsStreamResult {
   const [data, setData] = useState<ModelMetrics | undefined>(undefined);
+  const [finished, setFinished] = useState(false);
   const [error, setError] = useState(false);
 
   useEffect(() => {
     setData(undefined);
+    setFinished(false);
     setError(false);
 
     let cancelled = false;
     let gotData = false;
     let fallbackTried = false;
 
+    const applyMetrics = (metrics: ModelMetrics) => {
+      gotData = true;
+      setData(metrics);
+      setError(false);
+      // Статус мог быть финальным уже в первом снимке (просмотр обученной модели).
+      if (metrics.status && FINAL_STATUSES.includes(metrics.status)) setFinished(true);
+    };
+
     const unsubscribe = metricsService.subscribeModelMetrics(modelId, {
       onMetrics: (metrics) => {
         if (cancelled) return;
-        gotData = true;
-        setData(metrics);
-        setError(false);
+        applyMetrics(metrics);
+      },
+      onEnd: () => {
+        if (cancelled) return;
+        setFinished(true);
+        unsubscribe();
       },
       onError: () => {
         if (cancelled || gotData) return;
@@ -42,9 +61,7 @@ export function useModelMetricsStream(modelId: string): UseModelMetricsStreamRes
           .getModelMetrics(modelId)
           .then((metrics) => {
             if (cancelled || gotData || metrics === null) return;
-            gotData = true;
-            setData(metrics);
-            setError(false);
+            applyMetrics(metrics);
           })
           .catch(() => undefined);
       },
@@ -56,5 +73,11 @@ export function useModelMetricsStream(modelId: string): UseModelMetricsStreamRes
     };
   }, [modelId]);
 
-  return { data, loading: data === undefined && !error, error };
+  return {
+    data,
+    status: data?.status,
+    finished,
+    loading: data === undefined && !error,
+    error,
+  };
 }

--- a/frontend/src/pages/ModelCompare.tsx
+++ b/frontend/src/pages/ModelCompare.tsx
@@ -1,0 +1,296 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { mlModelsService } from '../services/mlModelsService';
+import { metricsService } from '../services/metricsService';
+import type { ModelsCompareResponse, Split } from '../services/metricsService';
+import { useNotification } from '../contexts/NotificationContext';
+import { formatDateParts } from '../utils/format';
+import type { MLModelVersion } from '../types/mlModels';
+import Select from '../components/common/Select';
+import { Tooltip } from '../components/common/Tooltip';
+import { ICONS } from '../constants/icons';
+import './Models.css';
+// Стили блока выбора пары (vcmp-*) общие со сравнением версий датасета.
+import './DatasetCompare.css';
+
+const SPLITS: Split[] = ['train', 'val', 'test'];
+// Лимит выборки версий для пикеров; пагинацию здесь не делаем.
+const VERSIONS_LIMIT = 100;
+
+const formatValue = (v: number) =>
+  Number.isInteger(v) ? String(v) : v.toFixed(4);
+
+/**
+ * Страница сравнения двух версий моделей по метрикам обучения
+ * (POST /models/compare сервиса metrics). Выбранные версии живут в query
+ * string (?from=&to=), поэтому ссылкой на сравнение можно делиться.
+ */
+const ModelCompare: React.FC = () => {
+  const navigate = useNavigate();
+  const { showNotification } = useNotification();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [versions, setVersions] = useState<MLModelVersion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [split, setSplit] = useState<Split>('val');
+  // Результат помечен ключом «from|to|split»: ответ для устаревшего выбора игнорируется.
+  const [result, setResult] = useState<
+    { key: string; status: 'ready'; data: ModelsCompareResponse } | { key: string; status: 'error' } | null
+  >(null);
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    mlModelsService.getVersions({ limit: VERSIONS_LIMIT })
+      .then((data) => {
+        if (!cancelled) setVersions(data.versions);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          showNotification(err instanceof Error ? err.message : 'Не удалось загрузить модели', 'error');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [showNotification]);
+
+  const fromParam = searchParams.get('from');
+  const toParam = searchParams.get('to');
+
+  // Дефолты и валидация query-параметров: невалидные id сбрасываются,
+  // пустые заполняются самыми свежими версиями (как в сравнении датасетов).
+  useEffect(() => {
+    if (versions.length < 2) return;
+    const ids = new Set(versions.map((v) => v.id));
+    let from = fromParam && ids.has(fromParam) ? fromParam : null;
+    let to = toParam && ids.has(toParam) ? toParam : null;
+    if ((fromParam && !from) || (toParam && !to)) {
+      showNotification('Модель из ссылки не найдена', 'warning');
+    }
+    if (!to) to = versions.find((v) => v.id !== from)?.id ?? null;
+    if (!from) from = versions.find((v) => v.id !== to)?.id ?? null;
+    if (from && to && (from !== fromParam || to !== toParam)) {
+      setSearchParams({ from, to }, { replace: true });
+    }
+  }, [versions, fromParam, toParam, setSearchParams, showNotification]);
+
+  const versionById = useMemo(() => new Map(versions.map((v) => [v.id, v])), [versions]);
+  const fromVersion = fromParam ? versionById.get(fromParam) : undefined;
+  const toVersion = toParam ? versionById.get(toParam) : undefined;
+  const fromId = fromVersion?.id;
+  const toId = toVersion?.id;
+
+  const compareKey = fromId && toId && fromId !== toId ? `${fromId}|${toId}|${split}` : null;
+
+  useEffect(() => {
+    if (!fromId || !toId || fromId === toId) return;
+    const key = `${fromId}|${toId}|${split}`;
+    let cancelled = false;
+    metricsService.compareModels([fromId, toId], split)
+      .then((data) => {
+        if (!cancelled) setResult({ key, status: 'ready', data });
+      })
+      .catch(() => {
+        if (!cancelled) setResult({ key, status: 'error' });
+      });
+    return () => { cancelled = true; };
+  }, [fromId, toId, split, retryKey]);
+
+  const currentResult = result && result.key === compareKey ? result : null;
+  const comparison = currentResult?.status === 'ready' ? currentResult.data : null;
+  const compareLoading = compareKey !== null && currentResult === null;
+  const compareError = currentResult?.status === 'error';
+
+  const versionOptions = useMemo(
+    () =>
+      versions.map((v) => ({
+        value: v.id,
+        label: `${v.name} · v${v.version} · ${formatDateParts(v.created_at).date}`,
+      })),
+    [versions],
+  );
+
+  const modelLabel = (modelId: string) => {
+    const version = versionById.get(modelId);
+    return version ? `${version.name} · v${version.version}` : modelId;
+  };
+
+  const setVersionParam = (key: 'from' | 'to', value: string) => {
+    const next = new URLSearchParams(searchParams);
+    next.set(key, value);
+    setSearchParams(next, { replace: true });
+  };
+
+  const swapVersions = () => {
+    if (!fromParam || !toParam) return;
+    setSearchParams({ from: toParam, to: fromParam }, { replace: true });
+  };
+
+  if (loading) {
+    return (
+      <div className="page">
+        <div className="loading-state">
+          <i className={`fas ${ICONS.loading} fa-spin`}></i> Загрузка моделей…
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <button className="detail-back-link" onClick={() => navigate('/models')}>
+        <i className={`fas ${ICONS.back}`}></i> К моделям
+      </button>
+
+      <div className="page-header">
+        <h1>Сравнение моделей</h1>
+        <p className="page-description">
+          Сравнение версий моделей по метрикам обучения: финальные и лучшие значения, отставание от лидера.
+        </p>
+      </div>
+
+      {versions.length < 2 ? (
+        <div className="empty-state">
+          <i className={`fas ${ICONS.empty}`}></i> Для сравнения нужно минимум две версии моделей.
+        </div>
+      ) : (
+        <>
+          <section className="detail-section vcmp-picker">
+            <div className="vcmp-picker-field">
+              <span className="vcmp-picker-label">
+                <i className={`fas ${ICONS.model}`}></i> Базовая модель
+              </span>
+              <Select
+                value={fromParam ?? ''}
+                options={versionOptions}
+                onChange={(v) => setVersionParam('from', v)}
+                ariaLabel="Базовая модель"
+              />
+            </div>
+            <Tooltip content="Поменять модели местами">
+              <button
+                className="icon-button vcmp-swap"
+                onClick={swapVersions}
+                aria-label="Поменять модели местами"
+              >
+                <i className={`fas ${ICONS.swap}`}></i>
+              </button>
+            </Tooltip>
+            <div className="vcmp-picker-field">
+              <span className="vcmp-picker-label">
+                <i className={`fas ${ICONS.model}`}></i> Сравниваемая модель
+              </span>
+              <Select
+                value={toParam ?? ''}
+                options={versionOptions}
+                onChange={(v) => setVersionParam('to', v)}
+                ariaLabel="Сравниваемая модель"
+              />
+            </div>
+            <div className="view-toggle mcmp-split-toggle" role="group" aria-label="Выборка для сравнения">
+              {SPLITS.map((s) => (
+                <button
+                  key={s}
+                  className={`view-toggle-btn${split === s ? ' active' : ''}`}
+                  onClick={() => setSplit(s)}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          {fromId && toId && fromId === toId && (
+            <div className="metrics-charts-placeholder">
+              <i className={`fas ${ICONS.info}`}></i> Выберите две разные модели.
+            </div>
+          )}
+
+          {compareLoading && (
+            <div className="metrics-charts-placeholder">
+              <i className={`fas ${ICONS.loading} fa-spin`}></i> Сравнение моделей…
+            </div>
+          )}
+
+          {compareError && (
+            <div className="metrics-charts-placeholder metrics-charts-placeholder--error">
+              <i className={`fas ${ICONS.warning}`}></i> Не удалось сравнить модели.
+              <button
+                className="button secondary small"
+                onClick={() => { setResult(null); setRetryKey((k) => k + 1); }}
+              >
+                Повторить
+              </button>
+            </div>
+          )}
+
+          {comparison && (
+            <>
+              {comparison.missing.length > 0 && (
+                <div className="metrics-charts-placeholder">
+                  <i className={`fas ${ICONS.info}`}></i>
+                  Нет сохранённых метрик: {comparison.missing.map(modelLabel).join(', ')}.
+                </div>
+              )}
+
+              {comparison.metrics.length === 0 && comparison.missing.length === 0 && (
+                <div className="empty-state">
+                  <i className={`fas ${ICONS.empty}`}></i> На выборке {comparison.split} нет общих метрик для сравнения.
+                </div>
+              )}
+
+              {comparison.metrics.map((metric) => (
+                <section key={metric.metric} className="detail-section mcmp-metric-block">
+                  <p className="metrics-chart-title">
+                    {metric.metric}
+                    <Tooltip content={metric.higher_is_better ? 'Больше — лучше' : 'Меньше — лучше'}>
+                      <span className="mcmp-direction">
+                        {metric.higher_is_better ? '↑' : '↓'}
+                      </span>
+                    </Tooltip>
+                  </p>
+                  <div className="class-report-table-wrap">
+                    <table className="class-report-table mcmp-table">
+                      <thead>
+                        <tr>
+                          <th>Модель</th>
+                          <th>Финал</th>
+                          <th>Лучшее</th>
+                          <th>Лучшая эпоха</th>
+                          <th>Эпох</th>
+                          <th>Δ от лидера</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {metric.models.map((entry) => {
+                          const isBest = entry.model_id === metric.best_model_id;
+                          return (
+                            <tr key={entry.model_id} className={isBest ? 'mcmp-row--best' : undefined}>
+                              <th>
+                                {isBest && <i className={`fas ${ICONS.star} mcmp-best-icon`}></i>}
+                                {modelLabel(entry.model_id)}
+                              </th>
+                              <td>{formatValue(entry.final_value)}</td>
+                              <td>{formatValue(entry.best_value)}</td>
+                              <td>{entry.best_epoch}</td>
+                              <td>{entry.epochs}</td>
+                              <td>{isBest ? '—' : formatValue(entry.delta_best)}</td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </section>
+              ))}
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ModelCompare;

--- a/frontend/src/pages/ModelDetail.tsx
+++ b/frontend/src/pages/ModelDetail.tsx
@@ -103,6 +103,12 @@ const ModelDetail: React.FC = () => {
           <h1>{model.name}</h1>
           <span className="model-version"><i className={`fas ${ICONS.version}`}></i> v{model.version}</span>
           <span className={`status-badge status-${model.status}`}>{model.status}</span>
+          <button
+            className="button secondary small"
+            onClick={() => navigate(`/models/compare?from=${model.id}`)}
+          >
+            <i className={`fas ${ICONS.compare}`}></i> Сравнить
+          </button>
         </div>
         <Tooltip content="Нажмите, чтобы скопировать ID">
           <span

--- a/frontend/src/pages/Models.css
+++ b/frontend/src/pages/Models.css
@@ -628,6 +628,42 @@
   font-size: 0.72rem;
 }
 
+/* ========================
+   Model Compare
+   ======================== */
+
+.mcmp-split-toggle {
+  margin-left: auto;
+  align-self: flex-end;
+}
+
+.mcmp-metric-block {
+  margin-bottom: 1rem;
+}
+
+.mcmp-direction {
+  margin-left: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  cursor: help;
+}
+
+.mcmp-table th:first-child {
+  min-width: 220px;
+}
+
+.mcmp-row--best th,
+.mcmp-row--best td {
+  color: var(--color-text-primary);
+  background: color-mix(in srgb, var(--color-success) 8%, transparent);
+}
+
+.mcmp-best-icon {
+  color: var(--color-success);
+  margin-right: 0.4rem;
+  font-size: 0.75rem;
+}
+
 /* Collapsible text report */
 .metrics-report-details {
   margin-top: 0.75rem;

--- a/frontend/src/pages/Models.css
+++ b/frontend/src/pages/Models.css
@@ -469,6 +469,54 @@
   margin-bottom: 1rem;
 }
 
+/* Раздельные секции по выборкам: train / val / test */
+.metrics-split-section {
+  margin-bottom: 1.25rem;
+}
+
+.metrics-split-title {
+  margin: 0 0 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+/* Скалярные карточки для одиночных финальных значений (test) */
+.metrics-scalar-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.metrics-scalar-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 140px;
+  padding: 0.85rem 1rem;
+  background: var(--color-bg-deep);
+  border: var(--border-soft);
+  border-radius: var(--radius-input);
+}
+
+.metrics-scalar-card-name {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+.metrics-scalar-card-value {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
 .metrics-chart-block {
   background: var(--color-bg-deep);
   border: var(--border-soft);
@@ -496,6 +544,88 @@
 
 .metrics-charts-placeholder--error {
   color: var(--color-danger);
+}
+
+/* Training status badge */
+.metrics-status-row {
+  margin-bottom: 0.75rem;
+}
+
+.metrics-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: var(--radius-input);
+  border: var(--border-soft);
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-deep);
+}
+
+.metrics-status-badge--completed {
+  color: var(--color-success);
+}
+
+.metrics-status-badge--failed {
+  color: var(--color-danger);
+}
+
+.metrics-status-badge--cancelled {
+  color: var(--color-text-secondary);
+}
+
+/* Class report: confusion matrix + per-class metrics */
+.class-report {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-top: 0.75rem;
+}
+
+.class-report-block {
+  background: var(--color-bg-deep);
+  border: var(--border-soft);
+  border-radius: var(--radius-input);
+  padding: 0.85rem 0.75rem;
+  min-width: 0;
+}
+
+.class-report-table-wrap {
+  overflow-x: auto;
+}
+
+.class-report-table {
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  color: var(--color-text-primary);
+}
+
+.class-report-table th,
+.class-report-table td {
+  padding: 0.35rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.class-report-table th {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  text-align: left;
+}
+
+.class-report-table thead th {
+  text-align: right;
+}
+
+.class-report-table thead th:first-child {
+  text-align: left;
+}
+
+.class-report-corner {
+  font-weight: 400;
+  font-size: 0.72rem;
 }
 
 /* Collapsible text report */

--- a/frontend/src/services/metricsService.ts
+++ b/frontend/src/services/metricsService.ts
@@ -42,6 +42,30 @@ export interface StreamEndEvent {
   status: TrainingStatus;
 }
 
+export interface CompareModelEntry {
+  model_id: string;
+  final_value: number;
+  best_value: number;
+  best_epoch: number;
+  epochs: number;
+  // Отставание от лидера по best_value (0 у лидера).
+  delta_best: number;
+}
+
+export interface CompareMetric {
+  metric: string;
+  higher_is_better: boolean;
+  best_model_id: string | null;
+  models: CompareModelEntry[];
+}
+
+export interface ModelsCompareResponse {
+  split: Split;
+  metrics: CompareMetric[];
+  // Модели без сохранённых метрик (не ошибка).
+  missing: string[];
+}
+
 interface MetricsStreamHandlers {
   onMetrics: (metrics: ModelMetrics) => void;
   onEnd?: (event: StreamEndEvent) => void;
@@ -53,6 +77,16 @@ export const metricsService = {
     const response = await fetch(`${BASE}/models/${modelId}`);
     if (response.status === 404) return null;
     return handleResponse<ModelMetrics>(response);
+  },
+
+  /** Сравнение моделей (мин. 2) по метрикам выборки; модели без метрик попадают в missing. */
+  async compareModels(modelIds: string[], split: Split = 'val'): Promise<ModelsCompareResponse> {
+    const response = await fetch(`${BASE}/models/compare`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model_ids: modelIds, split }),
+    });
+    return handleResponse<ModelsCompareResponse>(response);
   },
 
   /** Отчёт по классам на test; null — отчёта ещё нет (появляется после обучения). */

--- a/frontend/src/services/metricsService.ts
+++ b/frontend/src/services/metricsService.ts
@@ -4,21 +4,47 @@ const BASE = serviceUrl(import.meta.env.VITE_METRICS, 'localhost:6310');
 
 export type Split = 'train' | 'val' | 'test';
 
+export type TrainingStatus = 'in_progress' | 'completed' | 'failed' | 'cancelled';
+
 export interface MetricData {
   name: string;
   split?: Split;
   values: number[];
+  // Параллелен values (UTC); у старых моделей может быть короче.
+  timestamps?: string[];
 }
 
 export interface ModelMetrics {
   model_id: string;
+  status?: TrainingStatus | null;
   train: MetricData[];
   val: MetricData[];
   test: MetricData[];
 }
 
+export interface PerClassMetrics {
+  label: string;
+  precision: number;
+  recall: number;
+  f1: number;
+  support: number;
+}
+
+export interface ClassReport {
+  model_id: string;
+  labels: string[];
+  confusion_matrix: number[][];
+  per_class: PerClassMetrics[];
+}
+
+export interface StreamEndEvent {
+  model_id: string;
+  status: TrainingStatus;
+}
+
 interface MetricsStreamHandlers {
   onMetrics: (metrics: ModelMetrics) => void;
+  onEnd?: (event: StreamEndEvent) => void;
   onError?: (event: Event) => void;
 }
 
@@ -29,9 +55,18 @@ export const metricsService = {
     return handleResponse<ModelMetrics>(response);
   },
 
+  /** Отчёт по классам на test; null — отчёта ещё нет (появляется после обучения). */
+  async getClassReport(modelId: string): Promise<ClassReport | null> {
+    const response = await fetch(`${BASE}/models/${modelId}/class-report`);
+    if (response.status === 404) return null;
+    return handleResponse<ClassReport>(response);
+  },
+
   /**
    * Подписка на SSE-поток метрик модели: сервер шлёт событие 'metrics'
    * с полным снимком при подключении и после каждой эпохи обучения.
+   * При финальном статусе обучения после снимка приходит событие 'end' —
+   * сервер поток не закрывает, закрыть соединение должен подписчик.
    * При обрыве соединения EventSource переподключается сам.
    * @returns функция отписки (закрывает соединение)
    */
@@ -39,6 +74,9 @@ export const metricsService = {
     const source = new EventSource(`${BASE}/models/${modelId}/stream`);
     source.addEventListener('metrics', (event: MessageEvent) => {
       handlers.onMetrics(JSON.parse(event.data) as ModelMetrics);
+    });
+    source.addEventListener('end', (event: MessageEvent) => {
+      handlers.onEnd?.(JSON.parse(event.data) as StreamEndEvent);
     });
     source.onerror = (event) => handlers.onError?.(event);
     return () => source.close();

--- a/services/trainer/app/api/schemas/metrices.py
+++ b/services/trainer/app/api/schemas/metrices.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 class MetricesParams(BaseModel):
     metrics_list: List[str] = Field(
@@ -21,27 +21,44 @@ class MetricesParams(BaseModel):
     }
 
 class MetricesParamCollections(BaseModel):
-    train: MetricesParams = Field(
+    train_val: MetricesParams = Field(
         ...,
-        description="Метрики для обучения"
-    )
-    val: MetricesParams = Field(
-        ...,
-        description="Метрики для валидации"
+        description="Единый список метрик для train и val: одинаковый набор на обеих "
+                    "выборках, чтобы каждую метрику можно было сравнивать между ними "
+                    "(контроль переобучения)"
     )
     test: MetricesParams = Field(
         ...,
-        description="Метрики для тестирования"
+        description="Метрики для тестирования (могут расширять train/val-набор)"
     )
-    
+
+    @model_validator(mode='before')
+    @classmethod
+    def _merge_legacy_split_lists(cls, data):
+        """Старый формат с раздельными train/val: объединяем списки в train_val."""
+        if not isinstance(data, dict) or 'train_val' in data:
+            return data
+        legacy = [data.get(split) for split in ('train', 'val')]
+        legacy = [params for params in legacy if isinstance(params, dict)]
+        if not legacy:
+            return data
+        merged_list = list(dict.fromkeys(
+            name for params in legacy for name in params.get('metrics_list') or []
+        ))
+        average = next(
+            (params['average'] for params in legacy if params.get('average')),
+            'macro'
+        )
+        train_val = {'average': average}
+        if merged_list:  # пустой список не затирает дефолтный набор метрик
+            train_val['metrics_list'] = merged_list
+        data['train_val'] = train_val
+        return data
+
     model_config = {
         "json_schema_extra": {
             "example": {
-                "train": {
-                    "metrics_list": ['accuracy', 'loss'],
-                    "average": 'macro'
-                },
-                "val": {
+                "train_val": {
                     "metrics_list": ['accuracy', 'precision', 'recall', 'f1'],
                     "average": 'macro'
                 },

--- a/services/trainer/app/api/schemas/tasker.py
+++ b/services/trainer/app/api/schemas/tasker.py
@@ -70,11 +70,7 @@ class TaskParams(BaseModel):
                     "pretrained": True
                 },
                 "metrices_params": {
-                    "train": {
-                        "metrics_list": ["accuracy", "loss"],
-                        "average": "macro"
-                    },
-                    "val": {
+                    "train_val": {
                         "metrics_list": ["accuracy", "precision", "recall", "f1"],
                         "average": "macro"
                     },

--- a/services/trainer/app/core/utils/validate_config.py
+++ b/services/trainer/app/core/utils/validate_config.py
@@ -69,7 +69,7 @@ def validate_task_params(config: Dict[str, Any]) -> List[Dict[str, str]]:
         })
 
     # Метрики
-    for split in ('train', 'val', 'test'):
+    for split in ('train_val', 'test'):
         metrics_params = getattr(params.metrices_params, split)
         for metric_name in metrics_params.metrics_list:
             if metric_name not in METRICS_REGISTRY:

--- a/services/trainer/app/service/metrices/collection.py
+++ b/services/trainer/app/service/metrices/collection.py
@@ -117,15 +117,17 @@ def create_classification_collections(
     Returns:
         Словарь с коллекциями
     """
+    # train и val считают один и тот же набор метрик (train_val) —
+    # каждая метрика сравнима между выборками для контроля переобучения
     return {
         'train': create_classification_metrics(
-            metric_params=metric_param_collections.train,
+            metric_params=metric_param_collections.train_val,
             num_classes=num_classes,
             device=device,
             prefix='train_'
         ),
         'val': create_classification_metrics(
-            metric_params=metric_param_collections.val,
+            metric_params=metric_param_collections.train_val,
             num_classes=num_classes,
             device=device,
             prefix='val_'


### PR DESCRIPTION
## 📌 Что было сделано?

- **Статус обучения** - обработка SSE-события `end`: фронт закрывает EventSource сам (раньше соединение висело после завершения обучения), бейдж статуса на странице модели (`TrainingStatusBadge`, hook `useModelMetricsStream`); типы синхронизированы с API metrics — `status`, `timestamps` (`metricsService`)
- **Class report** - confusion matrix с подсветкой ячеек и таблица per-class precision/recall/f1/support на странице модели; запрашивается после события `end` (`ModelClassReport`, `getClassReport`)
- **Графики метрик** - train+val накладываются на один график метрики для контроля переобучения; test и прочие одиночные значения — скалярными карточками «Финальные значения», а не точкой на кривой (`ModelMetricsCharts`)
- **Сравнение моделей** - страница сравнения двух версий по метрикам обучения: выбор пары в query string, переключатель train/val/test, финальное/лучшее значение, Δ от лидера и подсветка лучшей модели (`ModelCompare`, маршрут `/models/compare`, `compareModels`, кнопка «Сравнить» в `ModelDetail`)
- **Trainer** - единый список метрик для train и val в конфиге обучения (`MetricesParamCollections.train_val`): каждая метрика сравнима между выборками; старые конфиги с раздельными списками читаются через объединение, агенты получают новую схему через `/info/example_config`