### PR TITLE
fix: handle cancelled task status and missing timeout in agents tasker client

### DIFF
--- a/services/agents/app/core/pipeline/train.py
+++ b/services/agents/app/core/pipeline/train.py
@@ -84,12 +84,18 @@ def training(
         logger.info("✅ Модель обучена")
         models_context.add_model(version_id)
     else:
+        # При cancelled error_message пустой — причина лежит в status_info
+        error = task["error_message"] or task.get("status_info")
         logger.info(
             "🟥 Модель не была обучена."
-            f"\nПроизошла ошибка в процесе обучения. Причина: {task['error_message']}"
+            f"\nПроизошла ошибка в процесе обучения. Причина: {error}"
+        )
+        return TrainingOut(
+            is_completed_successfully=False,
+            error=error
         )
 
     return TrainingOut(
-        is_completed_successfully=is_complete,
+        is_completed_successfully=True,
         error=task["error_message"]
     )

--- a/services/agents/app/services/tasker/client.py
+++ b/services/agents/app/services/tasker/client.py
@@ -57,6 +57,7 @@ class TaskerClient():
         try:
             response = self.session.get(
                 f"{self.URL}/tasks/{task_id}",
+                timeout=30
             )
             response.raise_for_status()
             task = response.json()
@@ -79,8 +80,8 @@ class TaskerClient():
             task_status = task.get("status", "failed")
             if task_status == "completed":
                 return True, task
-            elif task_status == "failed":
-                logger.error(f"Задача `{task_id}` завершена с ошибкой")
+            elif task_status in ("failed", "cancelled"):
+                logger.error(f"Задача `{task_id}` завершена со статусом `{task_status}`")
                 return False, task
             
             time.sleep(2)


### PR DESCRIPTION
## 📌 Что было сделано?

- **agents / tasker client** (`TaskerClient.waiting_completed`): добавлена обработка статуса `cancelled` — раньше при отмене задачи пайплайн опрашивал tasker бесконечно, выход из цикла был только на `completed`/`failed`
- **agents / tasker client** (`TaskerClient.get_task`): добавлен `timeout=30` для GET-запроса — без него запрос мог зависнуть навсегда при недоступности tasker
- **agents / pipeline** (`training`, `train.py`): при неуспешном завершении задачи причина берётся из `error_message` с fallback на `status_info` — при `cancelled` поле `error_message` пустое и в ответ уходило `None`