### PR TITLE
Agents: new trainer tools (augmentations, config validation)

### DIFF
--- a/services/agents/app/core/crews/ml_debuger/tools.py
+++ b/services/agents/app/core/crews/ml_debuger/tools.py
@@ -9,7 +9,9 @@ from app.services.trainer import (
     GetDeviceInfoTool,
     GetOptimizersTool,
     GetSchedulersTool,
-    GetMetricsForTrainerTool
+    GetMetricsForTrainerTool,
+    GetAugmentationsTool,
+    ValidateTrainingConfigTool
 )
 
 _tool_instances = [
@@ -19,6 +21,8 @@ _tool_instances = [
     GetOptimizersTool(),
     GetSchedulersTool(),
     GetMetricsForTrainerTool(),
+    GetAugmentationsTool(),
+    ValidateTrainingConfigTool(),
     GetDatasetDetailsTool(),
     ListAllDatasetsTool()
 ]

--- a/services/agents/app/core/crews/ml_engeneer/tools.py
+++ b/services/agents/app/core/crews/ml_engeneer/tools.py
@@ -9,7 +9,9 @@ from app.services.trainer import (
     GetDeviceInfoTool,
     GetOptimizersTool,
     GetSchedulersTool,
-    GetMetricsForTrainerTool
+    GetMetricsForTrainerTool,
+    GetAugmentationsTool,
+    ValidateTrainingConfigTool
 )
 
 _tool_instances = [
@@ -19,6 +21,8 @@ _tool_instances = [
     GetOptimizersTool(),
     GetSchedulersTool(),
     GetMetricsForTrainerTool(),
+    GetAugmentationsTool(),
+    ValidateTrainingConfigTool(),
     GetDatasetDetailsTool(),
     ListAllDatasetsTool()
 ]

--- a/services/agents/app/services/trainer/__init__.py
+++ b/services/agents/app/services/trainer/__init__.py
@@ -4,7 +4,9 @@ from .tools import (
     GetDeviceInfoTool,
     GetOptimizersTool,
     GetSchedulersTool,
-    GetMetricsForTrainerTool
+    GetMetricsForTrainerTool,
+    GetAugmentationsTool,
+    ValidateTrainingConfigTool
 )
 
 __all__ = [
@@ -13,5 +15,7 @@ __all__ = [
     'GetDeviceInfoTool',
     'GetOptimizersTool',
     'GetSchedulersTool',
-    'GetMetricsForTrainerTool'
+    'GetMetricsForTrainerTool',
+    'GetAugmentationsTool',
+    'ValidateTrainingConfigTool'
 ]

--- a/services/agents/app/services/trainer/tools.py
+++ b/services/agents/app/services/trainer/tools.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import Dict, Any
 from crewai.tools import BaseTool
 
-from ..utils import tool_response, get_json
+from ..utils import tool_response, get_json, post_json, parse_in_json
 from app.config import config_url
 from app.logs import get_logger
 
@@ -210,9 +210,77 @@ class GetMetricsForTrainerTool(BaseTool):
     """
 
     @tool_response(TRAINER_URL)
-    def _run(self) -> str: 
+    def _run(self) -> str:
         url = f"{TRAINER_URL}/info/metrics"
         return get_json(url) # type: ignore[return-value]  Декоратор преобразет ответ в str
 
     async def _arun(self) -> str:
         return await asyncio.to_thread(self._run)
+
+
+class GetAugmentationsTool(BaseTool):
+    """Инструмент для получения списка доступных методов аугментации"""
+
+    name: str = "GetAugmentations"
+    description: str = """
+    НАЗНАЧЕНИЕ: Получить список всех доступных методов аугментации данных.
+
+    КОГДА ИСПОЛЬЗОВАТЬ:
+    - При настройке трансформаций данных в конфигурации обучения
+    - Когда датасет небольшой и нужно увеличить разнообразие данных
+    - Для изучения доступных аугментаций перед составлением конфигурации
+
+    ВХОДНЫЕ ДАННЫЕ:
+    - Нет входных параметров
+
+    ВОЗВРАЩАЕТ:
+    - список доступных аугментаций
+
+    ВАЖНЫЕ ЗАМЕЧАНИЯ:
+    - Названия аугментаций чувствительны к регистру (используй точно как в ответе)
+    - В конфигурации можно использовать только аугментации из этого списка
+    - Аугментации основаны на трансформациях torchvision
+    """
+
+    @tool_response(TRAINER_URL)
+    def _run(self) -> str:
+        url = f"{TRAINER_URL}/info/augmentations"
+        return get_json(url) # type: ignore[return-value]  Декоратор преобразет ответ в str
+
+    async def _arun(self) -> str:
+        return await asyncio.to_thread(self._run)
+
+
+class ValidateTrainingConfigTool(BaseTool):
+    """Инструмент для валидации конфигурации обучения без запуска"""
+
+    name: str = "ValidateTrainingConfig"
+    description: str = """
+    НАЗНАЧЕНИЕ: Проверить конфигурацию обучения без запуска тренировки.
+
+    КОГДА ИСПОЛЬЗОВАТЬ:
+    - ОБЯЗАТЕЛЬНО перед тем, как отдать финальную конфигурацию обучения
+    - После исправления конфигурации, чтобы убедиться, что ошибка устранена
+    - При сомнениях в корректности названий модели, оптимизатора, планировщика или метрик
+
+    ВХОДНЫЕ ДАННЫЕ:
+    - config (str): Конфигурация обучения в виде JSON-строки.
+      Структура — как в GetExampleTrainingConfig.
+
+    ВОЗВРАЩАЕТ:
+    - dict с полями: valid (bool) и errors (список найденных проблем)
+
+    ВАЖНЫЕ ЗАМЕЧАНИЯ:
+    - Проверяет соответствие схеме, существование модели, функции потерь,
+      оптимизатора, планировщика, метрик, трансформаций и доступность устройства
+    - Если valid=False — исправь конфигурацию по списку errors и проверь снова
+    - Валидация ничего не запускает и не изменяет
+    """
+
+    @tool_response(TRAINER_URL)
+    def _run(self, config: str) -> str:
+        url = f"{TRAINER_URL}/config/validate"
+        return post_json(url, parse_in_json(config)) # type: ignore[return-value]  Декоратор преобразет ответ в str
+
+    async def _arun(self, config: str) -> str:
+        return await asyncio.to_thread(self._run, config)

--- a/services/agents/app/services/utils/__init__.py
+++ b/services/agents/app/services/utils/__init__.py
@@ -1,7 +1,7 @@
-from .get import handle_errors, get_json, tool_response
+from .get import handle_errors, get_json, post_json, tool_response
 from .json import parse_in_json
 
 __all__ = [
-    'handle_errors', 'get_json', 'tool_response',
+    'handle_errors', 'get_json', 'post_json', 'tool_response',
     'parse_in_json'
 ]

--- a/services/agents/app/services/utils/get.py
+++ b/services/agents/app/services/utils/get.py
@@ -51,6 +51,15 @@ def get_json(url: str, params: dict | None = None) -> dict:
     return resp.json()
 
 
+def post_json(url: str, data: dict | None = None) -> dict:
+    resp = requests.post(
+        url,
+        json=data
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
 def tool_response(domain: str):
     """
     Декоратор для инструментов агентов: ловит ошибки и ВСЕГДА возвращает


### PR DESCRIPTION
## 📌 Что было сделано?

- **agents / trainer tools** (`GetAugmentationsTool`, `ValidateTrainingConfigTool`): добавлены два новых инструмента — получение списка доступных аугментаций (`/info/augmentations`) и валидация конфигурации обучения без запуска тренировки (`/config/validate`)
- **agents / utils** (`post_json`): добавлен хелпер для POST-запросов с JSON-телом, экспортирован из `services/utils`
- **agents / crews** (`ml_engeneer`, `ml_debuger`): новые инструменты подключены в наборы tools обоих crew