### PR TITLE
feat: checkpoint info in metrics and weights-based model comparison

### DIFF
--- a/services/metrics/app/api/routers/model.py
+++ b/services/metrics/app/api/routers/model.py
@@ -15,6 +15,7 @@ from app.api.schemas import (
     ModelsCompareResponse,
     ModelTrainingStatusUpdate,
     ModelTrainingStatusResponse,
+    CheckpointInfo,
     ClassReportAdd,
     ClassReport,
     StatusResponse,
@@ -275,6 +276,32 @@ async def set_training_status(
         raise HTTPException(status_code=500, detail="Ошибка установки статуса обучения")
     broker.publish(model_id)
     return ModelTrainingStatusResponse(model_id=model_id, status=body.status)
+
+@router.post(
+    "/{model_id}/checkpoint",
+    response_model=StatusResponse,
+    summary="Сохранить информацию о чекпоинте",
+    description="Вызывается trainer'ом после обучения: эпоха, веса которой сохранены "
+                "(лучшая по early-stop-метрике, либо финальная — тогда value = null), "
+                "имя early-stop-метрики (чистое, val-выборка) и её значение. "
+                "Повторная запись перезаписывает (идемпотентно); checkpoint входит "
+                "в SSE-снимок метрик",
+    response_description="Статус операции",
+    responses={
+        500: {"description": "Ошибка записи checkpoint в БД"},
+    },
+)
+async def set_checkpoint(
+    model_id: str,
+    body: CheckpointInfo,
+    manager: CVMetricManager = Depends(get_cv_training_metrics_manager),
+    broker: MetricStreamBroker = Depends(get_metric_stream_broker),
+):
+    success = manager.set_checkpoint(model_id, body)
+    if not success:
+        raise HTTPException(status_code=500, detail="Ошибка сохранения checkpoint")
+    broker.publish(model_id)
+    return StatusResponse(status="ok")
 
 @router.post(
     "/{model_id}/class-report",

--- a/services/metrics/app/api/schemas/model.py
+++ b/services/metrics/app/api/schemas/model.py
@@ -56,6 +56,26 @@ class ModelMetricAdds(BaseModel):
         examples=["2026-06-11T10:00:00Z"],
     )
 
+class CheckpointInfo(BaseModel):
+    """Сохранённые веса модели: эпоха чекпоинта и early-stop-метрика выбора лучшей эпохи"""
+    epoch: int = Field(
+        ...,
+        ge=1,
+        description="Эпоха, веса которой сохранены (нумерация с 1)",
+        examples=[13],
+    )
+    metric: str = Field(
+        ...,
+        description="Early-stop-метрика выбора лучшей эпохи (чистое имя, val-выборка)",
+        examples=["loss"],
+    )
+    value: Optional[float] = Field(
+        None,
+        description="Значение метрики на эпохе чекпоинта; None — улучшение не "
+                    "фиксировалось, сохранены веса финальной эпохи",
+        examples=[0.42],
+    )
+
 class ModelMetrics(BaseModel):
     """ID модели и её метрики, разбитые по выборкам"""
     model_id: str = Field(..., description="ID модели", examples=["model-42"])
@@ -63,6 +83,10 @@ class ModelMetrics(BaseModel):
         None,
         description="Статус обучения; None у моделей, обученных до ввода статусов",
         examples=["in_progress"],
+    )
+    checkpoint: Optional[CheckpointInfo] = Field(
+        None,
+        description="Информация о сохранённых весах; None у моделей, обученных до ввода чекпоинтов",
     )
     train: List[ModelMetricData] = Field(default_factory=list, description="Метрики тренировочной выборки")
     val: List[ModelMetricData] = Field(default_factory=list, description="Метрики валидационной выборки")
@@ -179,6 +203,10 @@ class ModelMetricsSummary(BaseModel):
         default_factory=list,
         description="Разрывы train/val по метрикам, присутствующим в обеих выборках",
     )
+    checkpoint: Optional[CheckpointInfo] = Field(
+        None,
+        description="Информация о сохранённых весах; None у моделей, обученных до ввода чекпоинтов",
+    )
 
 class ModelsCompareRequest(BaseModel):
     """Запрос сравнения нескольких моделей"""
@@ -202,16 +230,30 @@ class ModelComparisonEntry(BaseModel):
     best_value: float = Field(..., description="Лучшее значение с учётом направления метрики")
     best_epoch: int = Field(..., description="Эпоха лучшего значения (нумерация с 1)")
     epochs: int = Field(..., description="Число эпох с записанными значениями")
+    weights_value: float = Field(
+        ...,
+        description="Значение на эпохе сохранённых весов (чекпоинта); при отсутствии "
+                    "checkpoint-информации — final_value",
+    )
+    checkpoint_epoch: Optional[int] = Field(
+        None,
+        description="Эпоха сохранённых весов; None — модель без записанного чекпоинта",
+    )
+    checkpoint_value: Optional[float] = Field(
+        None,
+        description="Значение этой метрики на эпохе чекпоинта; None — чекпоинт "
+                    "неизвестен или эпоха вне диапазона значений",
+    )
     delta_best: float = Field(
         ...,
-        description="Отставание best_value от лидера по этой метрике (0 у лидера)",
+        description="Отставание weights_value от лидера по этой метрике (0 у лидера)",
     )
 
 class MetricComparison(BaseModel):
     """Сравнение моделей по одной метрике"""
     metric: str = Field(..., description="Название метрики", examples=["accuracy"])
     higher_is_better: bool = Field(..., description="Направление метрики")
-    best_model_id: Optional[str] = Field(None, description="ID модели-лидера по лучшему значению")
+    best_model_id: Optional[str] = Field(None, description="ID модели-лидера по weights_value")
     models: List[ModelComparisonEntry] = Field(
         default_factory=list,
         description="Показатели каждой модели, у которой есть эта метрика",

--- a/services/metrics/app/core/model.py
+++ b/services/metrics/app/core/model.py
@@ -159,9 +159,11 @@ class CVMetricManager(ManagerBase):
     def _doc_to_model_metrics(model_doc: dict) -> ModelMetrics:
         """Сборка ответа из документа: метрики по выборкам"""
         splits = model_doc.get('splits', {})
+        checkpoint = model_doc.get('checkpoint')
         return ModelMetrics(
             model_id=model_doc['model_id'],
             status=model_doc.get('status'),
+            checkpoint=CheckpointInfo(**checkpoint) if checkpoint else None,
             **{
                 split: [
                     ModelMetricData(
@@ -236,6 +238,27 @@ class CVMetricManager(ManagerBase):
             return True
         except PyMongoError as e:
             logger.error(f"Ошибка установки статуса обучения модели(id:{model_id}): {e}")
+            return False
+
+    def set_checkpoint(
+            self,
+            model_id: str,
+            checkpoint: CheckpointInfo
+    ) -> bool:
+        """Сохранение информации о чекпоинте — эпохе сохранённых весов (идемпотентная перезапись)"""
+        try:
+            self.collection.update_one(
+                {'model_id': model_id},
+                {
+                    '$set': {'checkpoint': checkpoint.model_dump()},
+                    '$setOnInsert': {'splits': {split: [] for split in SPLITS}},
+                },
+                upsert=True,
+            )
+            logger.debug(f"Checkpoint модели(id:{model_id}) сохранён: эпоха {checkpoint.epoch}")
+            return True
+        except PyMongoError as e:
+            logger.error(f"Ошибка сохранения checkpoint модели(id:{model_id}): {e}")
             return False
 
     def set_class_report(

--- a/services/metrics/app/core/stats.py
+++ b/services/metrics/app/core/stats.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, NamedTuple, Optional
 
 from app.api.schemas import (
     ModelMetricData,
@@ -82,6 +82,7 @@ def compute_model_summary(metrics: ModelMetrics) -> ModelMetricsSummary:
     return ModelMetricsSummary(
         model_id=metrics.model_id,
         overfitting=_overfitting_gaps(summaries["train"], summaries["val"]),
+        checkpoint=metrics.checkpoint,
         **summaries,
     )
 
@@ -94,61 +95,89 @@ def compare_models(
     """Сравнение моделей по метрикам выбранной выборки.
 
     Модели без сохранённых метрик попадают в missing; лидер по метрике
-    определяется лучшим best_value с учётом направления метрики.
+    определяется лучшим weights_value — значением на эпохе сохранённых весов
+    (чекпоинт по early-stop-метрике), с фолбэком на final_value у моделей
+    без записанного чекпоинта, — с учётом направления метрики.
     """
     found_ids = {m.model_id for m in all_metrics}
     missing = [model_id for model_id in requested_ids if model_id not in found_ids]
 
-    # Сводки метрик выбранной выборки по каждой модели
-    summaries_by_model = {
+    # Сводки и числовые значения метрик выбранной выборки по каждой модели:
+    # сырые values нужны для среза на эпохе чекпоинта.
+    stats_by_model = {
         model.model_id: {
-            summary.name: summary
+            summary.name: (summary, _numeric(metric.values))
             for metric in getattr(model, split)
             if (summary := summarize_metric(metric)) is not None
         }
         for model in all_metrics
     }
+    checkpoint_by_model = {m.model_id: m.checkpoint for m in all_metrics}
 
     metric_names = sorted({
         name
-        for summaries in summaries_by_model.values()
-        for name in summaries
+        for stats in stats_by_model.values()
+        for name in stats
     })
     if metric_filter is not None:
         allowed = set(metric_filter)
         metric_names = [name for name in metric_names if name in allowed]
 
+    class _Participant(NamedTuple):
+        model_id: str
+        summary: MetricSummary
+        checkpoint_epoch: Optional[int]
+        checkpoint_value: Optional[float]
+        weights_value: float
+
     comparisons = []
     for name in metric_names:
         higher_is_better = is_higher_better(name)
-        participants = [
-            (model_id, summaries[name])
-            for model_id, summaries in summaries_by_model.items()
-            if name in summaries
-        ]
+        participants = []
+        for model_id, stats in stats_by_model.items():
+            if name not in stats:
+                continue
+            summary, values = stats[name]
+            ckpt = checkpoint_by_model.get(model_id)
+            checkpoint_value = (
+                values[ckpt.epoch - 1]
+                if ckpt is not None and 1 <= ckpt.epoch <= len(values)
+                else None
+            )
+            participants.append(_Participant(
+                model_id=model_id,
+                summary=summary,
+                checkpoint_epoch=ckpt.epoch if ckpt is not None else None,
+                # На одноточечном test чекпоинт-среза нет (values уже измерены
+                # на сохранённых весах) — фолбэк на final_value корректен.
+                checkpoint_value=checkpoint_value,
+                weights_value=checkpoint_value if checkpoint_value is not None else summary.final_value,
+            ))
 
         best = (max if higher_is_better else min)(
-            participants, key=lambda pair: pair[1].best_value
+            participants, key=lambda p: p.weights_value
         )
-        best_model_id, best_summary = best
 
         entries = [
             ModelComparisonEntry(
-                model_id=model_id,
-                final_value=summary.final_value,
-                best_value=summary.best_value,
-                best_epoch=summary.best_epoch,
-                epochs=summary.epochs,
-                delta_best=abs(summary.best_value - best_summary.best_value),
+                model_id=p.model_id,
+                final_value=p.summary.final_value,
+                best_value=p.summary.best_value,
+                best_epoch=p.summary.best_epoch,
+                epochs=p.summary.epochs,
+                weights_value=p.weights_value,
+                checkpoint_epoch=p.checkpoint_epoch,
+                checkpoint_value=p.checkpoint_value,
+                delta_best=abs(p.weights_value - best.weights_value),
             )
-            for model_id, summary in participants
+            for p in participants
         ]
         entries.sort(key=lambda entry: entry.delta_best)
 
         comparisons.append(MetricComparison(
             metric=name,
             higher_is_better=higher_is_better,
-            best_model_id=best_model_id,
+            best_model_id=best.model_id,
             models=entries,
         ))
 

--- a/services/trainer/app/core/__init__.py
+++ b/services/trainer/app/core/__init__.py
@@ -1,6 +1,6 @@
 from app.api.schemas import TaskParams
 from app.service.tasker import tasker_service
-from app.service.metrices import MetricesClient
+from app.service.metrices import MetricesClient, send_checkpoint_info
 from app.service.ml_models import upload_file_model_in_ml_models
 from app.logs import get_logger
 
@@ -91,6 +91,14 @@ async def training_model(config: TaskParams, model_id: str):
         await tasker_service.update_status_task(percentages=PROGRESS_TRAINING_START, status_info="Обучение...")
         model = await trainer.train(PROGRESS_TRAINING_START, PROGRESS_TRAINING_END)
         await tasker_service.update_status_task(percentages=PROGRESS_TRAINING_END, status_info="Модель обучена.")
+        # Инфа о сохранённых весах: лучшая эпоха по early-stop-метрике,
+        # либо финальная, если улучшение не фиксировалось (best_value = None)
+        await send_checkpoint_info(
+            model_id=model_id,
+            epoch=trainer.best_epoch or trainer.last_epoch,
+            metric=config.trainer_params.early_stop.metric_name,
+            value=trainer.best_value,
+        )
     finally:
         metric_client.close()
 

--- a/services/trainer/app/core/trainer/train_model.py
+++ b/services/trainer/app/core/trainer/train_model.py
@@ -84,6 +84,13 @@ class Trainer:
         # Чекпоинт лучшей эпохи
         self.checkpoint_path = Path(tempfile.gettempdir()) / "checkpoints" / f"model_{model_id}.pt"
 
+        # Итог обучения: эпоха/значение лучшего чекпоинта (None — улучшение
+        # не фиксировалось, сохранены веса финальной эпохи) и фактически
+        # последняя отученная эпоха (early stop может прервать цикл раньше).
+        self.best_epoch: Optional[int] = None
+        self.best_value: Optional[float] = None
+        self.last_epoch: int = 0
+
         logger.debug("🏁 Инициализация успешно завершена")
 
     def _setup_loss_fn(
@@ -342,12 +349,12 @@ class Trainer:
         progress_value = float(progress_value_start)
         progress_per_epoch = (progress_value_end - progress_value_start) / self.epochs
 
-        # Лучшая эпоха по метрике ранней остановки
-        best_value: Optional[float] = None
+        # Лучшая эпоха по метрике ранней остановки (эпоха/значение — в self,
+        # их после обучения отправляют в metrics; здесь только веса)
         best_state: Optional[Dict[str, Tensor]] = None
-        best_epoch: Optional[int] = None
 
         for epoch in range(1, self.epochs + 1):
+            self.last_epoch = epoch
             # Проверка отмены задачи (на границе эпох)
             if await self._tasker_service.get_task_status() == "cancelled":
                 logger.info("🛑 Задача отменена пользователем, обучение остановлено")
@@ -369,16 +376,16 @@ class Trainer:
 
             # Трекинг лучшей эпохи (веса храним на CPU, чтобы не занимать память GPU)
             current_value = self._metric_service.last_early_stop_value
-            if current_value is not None and self._is_better(current_value, best_value):
-                best_value = current_value
-                best_epoch = epoch
+            if current_value is not None and self._is_better(current_value, self.best_value):
+                self.best_value = current_value
+                self.best_epoch = epoch
                 best_state = {
                     k: v.detach().cpu().clone()
                     for k, v in self.model.state_dict().items()
                 }
                 logger.info(f"🏅 Новая лучшая эпоха: {epoch} (метрика: {current_value:.6f})")
                 await asyncio.to_thread(
-                    self._save_checkpoint, best_state, best_epoch, best_value
+                    self._save_checkpoint, best_state, self.best_epoch, self.best_value
                 )
 
             # Логгирование конца эпохи
@@ -397,7 +404,7 @@ class Trainer:
         # Восстановление весов лучшей эпохи
         if best_state is not None:
             self.model.load_state_dict(best_state)
-            logger.info(f"♻️ Восстановлены веса лучшей эпохи [{best_epoch}] (метрика: {best_value:.6f})")
+            logger.info(f"♻️ Восстановлены веса лучшей эпохи [{self.best_epoch}] (метрика: {self.best_value:.6f})")
 
         logger.info("🦾 Тестирование модели...")
         await asyncio.to_thread(self._test_model)

--- a/services/trainer/app/service/metrices/__init__.py
+++ b/services/trainer/app/service/metrices/__init__.py
@@ -1,3 +1,3 @@
-from .mc import MetricesClient, send_training_status
+from .mc import MetricesClient, send_training_status, send_checkpoint_info
 
-__all__ = ['MetricesClient', 'send_training_status']
+__all__ = ['MetricesClient', 'send_training_status', 'send_checkpoint_info']

--- a/services/trainer/app/service/metrices/mc.py
+++ b/services/trainer/app/service/metrices/mc.py
@@ -43,6 +43,31 @@ async def send_training_status(
         logger.error(f"😡 Не удалось отправить статус обучения модели {model_id}: {e}")
         return False
 
+async def send_checkpoint_info(
+    model_id: str,
+    epoch: int,
+    metric: str,
+    value: float | None,
+) -> bool:
+    """
+    Отправка в сервис метрик информации о сохранённых весах: эпоха чекпоинта
+    (лучшая по early-stop-метрике, либо финальная — тогда value = None),
+    early-stop-метрика (чистое имя, подразумевается val) и её значение.
+
+    Ошибки не пробрасываются: репортинг в metrics не должен ломать обучение.
+    """
+    try:
+        res = await _status_client.post(
+            f"{METRICS_URL}/models/{model_id}/checkpoint",
+            json={"epoch": epoch, "metric": metric, "value": value}
+        )
+        res.raise_for_status()
+        logger.debug(f"✅ Checkpoint модели {model_id} (эпоха {epoch}) отправлен в сервис метрик")
+        return True
+    except httpx.HTTPError as e:
+        logger.error(f"😡 Не удалось отправить checkpoint модели {model_id}: {e}")
+        return False
+
 class MetricesClient:
     """
     Клиент метрик отвечает за работу с метриками.


### PR DESCRIPTION
## 📌 Что было сделано?

**metrics**
- Новый endpoint сохранения информации о чекпоинте (`POST /models/{model_id}/checkpoint`) — эпоха сохранённых весов, early-stop-метрика и её значение; запись идемпотентна (`set_checkpoint`)
- Checkpoint добавлен в схемы ответов (`CheckpointInfo`, `ModelMetrics`, `ModelMetricsSummary`) и попадает в SSE-снимок метрик
- Сравнение моделей теперь идёт по значению на эпохе сохранённых весов, а не по лучшему значению за всё обучение; фолбэк на `final_value` у моделей без чекпоинта (`compare_models`, `weights_value`, `checkpoint_epoch`, `checkpoint_value`)

**trainer**
- `Trainer` запоминает итог обучения: лучшую эпоху, её значение и фактически последнюю эпоху (`best_epoch`, `best_value`, `last_epoch`)
- После обучения trainer отправляет checkpoint в metrics; ошибки репортинга не ломают обучение (`send_checkpoint_info`)