### PR TITLE
Frontend/feat/models page polish

### DIFF
--- a/frontend/src/components/models/ModelCard.tsx
+++ b/frontend/src/components/models/ModelCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { MLModelVersion } from '../../types/mlModels';
 import { formatDateTime } from '../../utils/format';
 import { ICONS } from '../../constants/icons';
+import { modelStatusLabel, statusBadgeClass } from '../../constants';
 import { Tooltip } from '../common/Tooltip';
 
 interface Props {
@@ -33,7 +34,7 @@ const ModelCard: React.FC<Props> = ({ model }) => {
             <i className={`fas ${ICONS.version}`}></i> v{model.version}
           </Tooltip>
         </div>
-        <span className={`status-badge status-${model.status}`}>{model.status}</span>
+        <span className={statusBadgeClass(model.status)}>{modelStatusLabel(model.status)}</span>
       </div>
 
       <div className="model-meta">

--- a/frontend/src/components/models/ModelGroupCard.tsx
+++ b/frontend/src/components/models/ModelGroupCard.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { MLModel, MLModelVersion } from '../../types/mlModels';
-import { formatDateParts, formatDateTime } from '../../utils/format';
+import { formatDateParts, formatDateTime, pluralRu } from '../../utils/format';
 import { mlModelsService } from '../../services/mlModelsService';
 import { useNotification } from '../../contexts/NotificationContext';
 import ConfirmModal from '../common/ConfirmModal';
 import { Tooltip } from '../common/Tooltip';
 import { ICONS } from '../../constants/icons';
+import { modelStatusLabel, statusBadgeClass } from '../../constants';
 
 interface Props {
   model: MLModel;
@@ -61,7 +62,7 @@ const ModelGroupCard: React.FC<Props> = ({ model, onReload }) => {
             <div className="model-title-group">
               <h2>{model.name}</h2>
               <span className="model-group-count">
-                <i className={`fas ${ICONS.version}`}></i> {model.versions.length} {model.versions.length === 1 ? 'версия' : model.versions.length < 5 ? 'версии' : 'версий'}
+                <i className={`fas ${ICONS.version}`}></i> {model.versions.length} {pluralRu(model.versions.length, ['версия', 'версии', 'версий'])}
               </span>
             </div>
             <Tooltip content="Удалить модель со всеми версиями">
@@ -146,7 +147,7 @@ const ModelGroupCard: React.FC<Props> = ({ model, onReload }) => {
                     <i className={`fas ${ICONS.version}`}></i> v{v.version}
                   </td>
                   <td className="model-version-type">{v.model_type ?? '—'}</td>
-                  <td><span className={`status-badge status-${v.status}`}>{v.status}</span></td>
+                  <td><span className={statusBadgeClass(v.status)}>{modelStatusLabel(v.status)}</span></td>
                   <td className="model-version-date">
                     {(() => { const { date, time } = formatDateParts(v.created_at); return <><span>{date}</span>{time && <span className="model-version-time">{time}</span>}</>; })()}
                   </td>
@@ -186,7 +187,7 @@ const ModelGroupCard: React.FC<Props> = ({ model, onReload }) => {
         title={pending?.kind === 'model' ? 'Удалить модель?' : 'Удалить версию?'}
         message={
           pending?.kind === 'model'
-            ? `Модель «${pending.name}» и все её ${pending.count} ${pending.count === 1 ? 'версия' : pending.count < 5 ? 'версии' : 'версий'} будут удалены безвозвратно.`
+            ? `Модель «${pending.name}» и все её ${pending.count} ${pluralRu(pending.count, ['версия', 'версии', 'версий'])} будут удалены безвозвратно.`
             : pending?.kind === 'version'
             ? `Версия v${pending.version.version} модели «${model.name}» будет удалена безвозвратно.`
             : undefined

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -5,3 +5,23 @@ export const MODELS_PAGE_SIZE = 12;
 
 // Интервал опроса прогресса активной дискуссии (meta и лента сообщений).
 export const POLL_INTERVAL_DISCUSSION_MS = 3000;
+
+// Человекочитаемые статусы версии модели. Источник статуса — только реестр
+// ml_models; справочник значений отдаёт GET /info/models/status.
+export const MODEL_STATUS_LABELS: Record<string, string> = {
+  completed: 'Обучена',
+  training: 'Обучается',
+  in_progress: 'Обучается',
+  draft: 'Не обучена',
+  failed: 'Не обучена',
+  cancelled: 'Не обучена',
+};
+
+// Неизвестный статус показываем как есть, чтобы не скрывать новые значения из БД.
+export const modelStatusLabel = (status: string): string =>
+  MODEL_STATUS_LABELS[status] ?? status;
+
+// CSS-класс бейджа статуса: классы в components.css — через дефис
+// (status-in-progress), а статусы из БД — с подчёркиванием.
+export const statusBadgeClass = (status: string): string =>
+  `status-badge status-${status.replace(/_/g, '-')}`;

--- a/frontend/src/pages/Datasets.css
+++ b/frontend/src/pages/Datasets.css
@@ -247,14 +247,7 @@
   opacity: 0.8;
 }
 
-/* Поле, занимающее всю ширину сетки (классы) */
-.detail-field--full {
-  grid-column: 1 / -1;
-}
-
-.detail-field--full .tag-list {
-  margin-top: 0.1rem;
-}
+/* .detail-field--full — общий примитив, см. styles/components.css */
 
 .versions-section-head {
   display: flex;

--- a/frontend/src/pages/Models.css
+++ b/frontend/src/pages/Models.css
@@ -1,20 +1,5 @@
 /* Стили, специфичные для страниц моделей. Общие примитивы — в styles/components.css. */
 
-/* ── Toolbar (фильтры + переключатель вида) ───────────────────────────────────── */
-.models-toolbar {
-  display: flex;
-  align-items: flex-start;
-  gap: 1rem;
-  margin-bottom: 2rem;
-}
-
-.models-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  flex: 1;
-}
-
 /* ── Переключатель вида ───────────────────────────────────────────────────────── */
 .view-toggle {
   display: flex;

--- a/frontend/src/pages/Models.tsx
+++ b/frontend/src/pages/Models.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { mlModelsService } from '../services/mlModelsService';
 import { datasetService } from '../services/datasetService';
 import { useNotification } from '../contexts/NotificationContext';
 import { useModelFilters, useDebouncedValue } from '../hooks';
-import { MODELS_PAGE_SIZE } from '../constants';
+import { MODELS_PAGE_SIZE, modelStatusLabel } from '../constants';
 import { ModelCard, ModelGroupCard } from '../components/models';
 import Select from '../components/common/Select';
 import { Tooltip } from '../components/common/Tooltip';
@@ -27,12 +27,17 @@ const Models: React.FC = () => {
   const [models, setModels] = useState<MLModel[]>([]);
   const [groupedTotal, setGroupedTotal] = useState(0);
 
-  const [loading, setLoading] = useState(false);
-
   // Фильтры и пагинация.
   const { filters, offset, setFilter, setOffset, resetPage } = useModelFilters();
   // Имя дебаунсим, чтобы не слать запрос на каждое нажатие клавиши.
   const debouncedName = useDebouncedValue(filters.name);
+  // Принудительная перезагрузка списка (после удаления модели/версии).
+  const [reloadKey, setReloadKey] = useState(0);
+  // loading выводится из ключа запроса: пока загруженный ключ отстаёт
+  // от текущего (смена вида/фильтров/страницы), список считается устаревшим.
+  const requestKey = [viewMode, debouncedName, filters.status, filters.dataset, offset, reloadKey].join('|');
+  const [loadedKey, setLoadedKey] = useState<string | null>(null);
+  const loading = loadedKey !== requestKey;
   const [statuses, setStatuses] = useState<MLModelStatus[]>([]);
   const [datasets, setDatasets] = useState<Dataset[]>([]);
 
@@ -45,51 +50,37 @@ const Models: React.FC = () => {
       .catch(() => { /* фильтр по датасету опционален */ });
   }, []);
 
-  const loadFlat = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await mlModelsService.getVersions({
-        name: debouncedName || undefined,
-        status: filters.status || undefined,
-        dataset_id: filters.dataset || undefined,
-        limit: MODELS_PAGE_SIZE,
-        offset,
-      });
-      setVersions(data.versions);
-      setFlatTotal(data.total);
-    } catch (error) {
-      showNotification(error instanceof Error ? error.message : 'Не удалось загрузить модели', 'error');
-    } finally {
-      setLoading(false);
-    }
-  }, [debouncedName, filters.status, filters.dataset, offset, showNotification]);
-
-  const loadGrouped = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await mlModelsService.getModels({
-        name: debouncedName || undefined,
-        status: filters.status || undefined,
-        dataset_id: filters.dataset || undefined,
-        limit: MODELS_PAGE_SIZE,
-        offset,
-      });
-      setModels(data.models);
-      setGroupedTotal(data.total);
-    } catch (error) {
-      showNotification(error instanceof Error ? error.message : 'Не удалось загрузить модели', 'error');
-    } finally {
-      setLoading(false);
-    }
-  }, [debouncedName, filters.status, filters.dataset, offset, showNotification]);
-
   useEffect(() => {
-    if (viewMode === 'flat') {
-      loadFlat();
-    } else {
-      loadGrouped();
-    }
-  }, [viewMode, loadFlat, loadGrouped]);
+    let cancelled = false;
+    const params = {
+      name: debouncedName || undefined,
+      status: filters.status || undefined,
+      dataset_id: filters.dataset || undefined,
+      limit: MODELS_PAGE_SIZE,
+      offset,
+    };
+    const load =
+      viewMode === 'flat'
+        ? mlModelsService.getVersions(params).then((data) => {
+            if (cancelled) return;
+            setVersions(data.versions);
+            setFlatTotal(data.total);
+          })
+        : mlModelsService.getModels(params).then((data) => {
+            if (cancelled) return;
+            setModels(data.models);
+            setGroupedTotal(data.total);
+          });
+    load
+      .catch((error) => {
+        if (cancelled) return;
+        showNotification(error instanceof Error ? error.message : 'Не удалось загрузить модели', 'error');
+      })
+      .finally(() => {
+        if (!cancelled) setLoadedKey(requestKey);
+      });
+    return () => { cancelled = true; };
+  }, [requestKey, viewMode, debouncedName, filters.status, filters.dataset, offset, showNotification]);
 
   const switchView = (mode: ViewMode) => {
     resetPage();
@@ -115,8 +106,8 @@ const Models: React.FC = () => {
         </p>
       </div>
 
-      <div className="models-toolbar">
-        <div className="models-filters">
+      <div className="list-toolbar">
+        <div className="list-filters">
           <div className="filter-field">
             <i className={`fas ${ICONS.search}`}></i>
             <input
@@ -132,7 +123,7 @@ const Models: React.FC = () => {
             ariaLabel="Фильтр по статусу"
             placeholder="Все статусы"
             value={filters.status}
-            options={statuses.map((s) => ({ value: s.status, label: s.status }))}
+            options={statuses.map((s) => ({ value: s.status, label: modelStatusLabel(s.status) }))}
             onChange={(v) => setFilter('status', v)}
           />
 
@@ -181,7 +172,7 @@ const Models: React.FC = () => {
           <div className={`models-grid${loading ? ' is-refreshing' : ''}`}>
             {viewMode === 'flat'
               ? versions.map((version) => <ModelCard key={version.id} model={version} />)
-              : models.map((model) => <ModelGroupCard key={model.id} model={model} onReload={loadGrouped} />)
+              : models.map((model) => <ModelGroupCard key={model.id} model={model} onReload={() => setReloadKey((k) => k + 1)} />)
             }
           </div>
 

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -266,6 +266,11 @@ button:disabled,
   color: var(--color-danger);
 }
 
+.status-cancelled {
+  background: var(--color-surface-faint);
+  color: var(--color-text-secondary);
+}
+
 /* ── Теги / чипы ─────────────────────────────────────────────────────────────── */
 .tag {
   background: var(--color-accent-soft);
@@ -358,6 +363,15 @@ button:disabled,
 
 .detail-field .mono {
   word-break: break-all;
+}
+
+/* Поле, занимающее всю ширину сетки (например, классы) */
+.detail-field--full {
+  grid-column: 1 / -1;
+}
+
+.detail-field--full .tag-list {
+  margin-top: 0.1rem;
 }
 
 .detail-empty {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -23,6 +23,15 @@ export const formatDateTime = (value: string | null | undefined): string => {
   return date.toLocaleString();
 };
 
+// Русская плюрализация: pluralRu(21, ['версия', 'версии', 'версий']) -> 'версия'.
+export const pluralRu = (n: number, [one, few, many]: [string, string, string]): string => {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return few;
+  return many;
+};
+
 // Форматирование длительности в мс/с (>= 1 с показываем в секундах).
 export const formatDuration = (ms: number): string =>
   ms >= 1000 ? `${(ms / 1000).toFixed(2)} с` : `${ms.toFixed(0)} мс`;


### PR DESCRIPTION
## 📌 Что было сделано?

**Статусы моделей**
- Человекочитаемые лейблы статусов вместо сырых значений из БД на карточках, в таблице версий и фильтре (`modelStatusLabel`, `statusBadgeClass`, `MODEL_STATUS_LABELS`)
- Стиль бейджа для отменённого обучения (`status-cancelled`)

**Список моделей**
- Состояние загрузки выводится из ключа запроса — без рассинхрона спиннера при смене вида/фильтров/страницы; перезагрузка после удаления через `reloadKey` (`Models.tsx`)
- Toolbar страницы переведён на общие примитивы (`list-toolbar`, `list-filters`), дубли стилей удалены из `Models.css`

**Общее**
- Утилита русской плюрализации вместо инлайн-тернарников (`pluralRu`)
- Примитив поля на всю ширину сетки перенесён из `Datasets.css` в общий `styles/components.css` (`detail-field--full`)
