### PR TITLE
feat: rework model detail page with metric charts, checkpoint info an…

### DIFF
--- a/frontend/src/components/common/Tooltip.css
+++ b/frontend/src/components/common/Tooltip.css
@@ -57,3 +57,19 @@
   top: -5px;
   transform: rotate(225deg);
 }
+
+/* Иконка-подсказка «?» рядом с заголовками и терминами */
+.info-hint {
+  display: inline-flex;
+  margin-left: 0.35rem;
+  color: var(--color-text-secondary);
+  font-size: 0.72rem;
+  opacity: 0.7;
+  cursor: help;
+}
+
+.info-hint:hover,
+.info-hint:focus-visible {
+  opacity: 1;
+  color: var(--color-text-primary);
+}

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useId, useLayoutEffect, useRef, useState } from 'reac
 // Escape для скрытия. Пузырёк рендерится порталом в body (position: fixed),
 // поэтому не обрезается overflow-контейнерами модалок и таблиц.
 import { createPortal } from 'react-dom';
+import { ICONS } from '../../constants/icons';
 import './Tooltip.css';
 
 const SHOW_DELAY_MS = 250;
@@ -26,6 +27,25 @@ interface BubblePos {
   placement: Placement;
   arrowLeft: number;
 }
+
+/**
+ * Иконка-подсказка «?» с тултипом — пояснение термина рядом с заголовком
+ * или ячейкой. Фокусируема с клавиатуры (tabIndex), клик не всплывает,
+ * чтобы не дёргать collapse-заголовки, внутри которых она может стоять.
+ */
+export const InfoHint: React.FC<{ text: string }> = ({ text }) => (
+  <Tooltip content={text}>
+    <span
+      className="info-hint"
+      tabIndex={0}
+      role="note"
+      aria-label={text}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <i className={`fas ${ICONS.question}`} aria-hidden="true"></i>
+    </span>
+  </Tooltip>
+);
 
 export const Tooltip: React.FC<TooltipProps> = ({
   content,

--- a/frontend/src/components/models/ModelClassReport.tsx
+++ b/frontend/src/components/models/ModelClassReport.tsx
@@ -2,7 +2,25 @@ import React, { useEffect, useState } from 'react';
 import { metricsService } from '../../services/metricsService';
 import type { ClassReport } from '../../services/metricsService';
 import { CollapseChevron, getDisclosureProps } from '../common/Collapse';
+import { Tooltip, InfoHint } from '../common/Tooltip';
 import { ICONS } from '../../constants/icons';
+import { getMetricMeta, getMetricQuality } from '../../constants/metrics';
+
+// Подсказки для обычного пользователя: что значит каждая таблица и колонка.
+const HINTS = {
+  report:
+    'Показывает, какие классы модель распознаёт хорошо, а какие путает между собой.',
+  matrix:
+    'Строка — каким класс был на самом деле, столбец — что предсказала модель. Синяя диагональ — верные ответы, красные ячейки — ошибки; чем ярче цвет, тем больше доля таких ответов.',
+  toggleCounts: 'Показывать число примеров.',
+  togglePercent: 'Показывать долю от всех примеров фактического класса (строки).',
+  support: 'Сколько примеров этого класса было в test-выборке.',
+  macroAvg:
+    'Среднее по всем классам, каждый класс учитывается одинаково — независимо от числа его примеров.',
+  accuracy: 'Доля верных предсказаний по всей test-выборке.',
+  perClass:
+    'Качество модели отдельно для каждого класса. Значения подсвечены цветом: зелёный — хорошо, жёлтый — средне, красный — слабо.',
+} as const;
 
 interface Props {
   modelId: string;
@@ -10,7 +28,11 @@ interface Props {
   enabled: boolean;
 }
 
+type MatrixView = 'counts' | 'percent';
+
 const formatScore = (v: number) => v.toFixed(4);
+const formatShare = (value: number, rowTotal: number) =>
+  rowTotal === 0 ? '—' : `${((value / rowTotal) * 100).toFixed(1)}%`;
 
 // Интенсивность фона ячейки по доле от суммы строки confusion matrix.
 const cellBackground = (value: number, rowTotal: number, isDiagonal: boolean) => {
@@ -21,14 +43,26 @@ const cellBackground = (value: number, rowTotal: number, isDiagonal: boolean) =>
   return isDiagonal ? `rgba(94, 138, 177, ${alpha})` : `rgba(177, 94, 107, ${alpha})`;
 };
 
+// Значение precision/recall/f1/accuracy с окраской по порогам качества метрики.
+const ScoreCell: React.FC<{ metric: string; value: number }> = ({ metric, value }) => {
+  const quality = getMetricQuality(getMetricMeta(metric), value);
+  return (
+    <span className={quality ? `class-report-score--${quality}` : undefined}>
+      {formatScore(value)}
+    </span>
+  );
+};
+
 /**
  * Отчёт по классам на test-выборке из сервиса metrics: confusion matrix
- * и per-class precision/recall/f1/support. Появляется после завершения
+ * (counts / нормализация по строке) и per-class precision/recall/f1/support
+ * с итоговыми строками macro avg и accuracy. Появляется после завершения
  * обучения; если отчёта нет (404, старые модели) — не рендерится.
  */
 const ModelClassReport: React.FC<Props> = ({ modelId, enabled }) => {
   const [report, setReport] = useState<ClassReport | null>(null);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
+  const [matrixView, setMatrixView] = useState<MatrixView>('counts');
 
   useEffect(() => {
     if (!enabled) return;
@@ -50,6 +84,18 @@ const ModelClassReport: React.FC<Props> = ({ modelId, enabled }) => {
     row.reduce((sum, v) => sum + v, 0),
   );
 
+  // Итоги в духе sklearn classification_report: macro avg и accuracy.
+  const classCount = report.per_class.length;
+  const macro = {
+    precision: report.per_class.reduce((s, r) => s + r.precision, 0) / (classCount || 1),
+    recall: report.per_class.reduce((s, r) => s + r.recall, 0) / (classCount || 1),
+    f1: report.per_class.reduce((s, r) => s + r.f1, 0) / (classCount || 1),
+    support: report.per_class.reduce((s, r) => s + r.support, 0),
+  };
+  const total = rowTotals.reduce((s, v) => s + v, 0);
+  const correct = report.confusion_matrix.reduce((s, row, i) => s + (row[i] ?? 0), 0);
+  const accuracy = total > 0 ? correct / total : undefined;
+
   return (
     <div className="metrics-report-details">
       <div
@@ -58,11 +104,37 @@ const ModelClassReport: React.FC<Props> = ({ modelId, enabled }) => {
       >
         <CollapseChevron open={open} />
         <i className={`fas ${ICONS.classReport}`}></i> Отчёт по классам (test)
+        <InfoHint text={HINTS.report} />
       </div>
       {open && (
         <div className="class-report">
           <div className="class-report-block">
-            <p className="metrics-chart-title">Confusion matrix</p>
+            <div className="class-report-block-head">
+              <p className="metrics-chart-title">
+                Confusion matrix
+                <InfoHint text={HINTS.matrix} />
+              </p>
+              <div
+                className="view-toggle view-toggle--compact"
+                role="group"
+                aria-label="Формат значений матрицы"
+              >
+                {(['counts', 'percent'] as const).map((view) => (
+                  <Tooltip
+                    key={view}
+                    content={view === 'counts' ? HINTS.toggleCounts : HINTS.togglePercent}
+                  >
+                    <button
+                      type="button"
+                      className={`view-toggle-btn${matrixView === view ? ' active' : ''}`}
+                      onClick={() => setMatrixView(view)}
+                    >
+                      {view === 'counts' ? 'N' : '%'}
+                    </button>
+                  </Tooltip>
+                ))}
+              </div>
+            </div>
             <div className="class-report-table-wrap">
               <table className="class-report-table class-report-matrix">
                 <thead>
@@ -82,7 +154,11 @@ const ModelClassReport: React.FC<Props> = ({ modelId, enabled }) => {
                           key={report.labels[j]}
                           style={{ background: cellBackground(value, rowTotals[i], i === j) }}
                         >
-                          {value}
+                          <Tooltip
+                            content={`факт ${report.labels[i]}, прогноз ${report.labels[j]}: ${value} (${formatShare(value, rowTotals[i])})`}
+                          >
+                            {matrixView === 'counts' ? value : formatShare(value, rowTotals[i])}
+                          </Tooltip>
                         </td>
                       ))}
                     </tr>
@@ -92,29 +168,64 @@ const ModelClassReport: React.FC<Props> = ({ modelId, enabled }) => {
             </div>
           </div>
           <div className="class-report-block">
-            <p className="metrics-chart-title">Метрики по классам</p>
+            <div className="class-report-block-head">
+              <p className="metrics-chart-title">
+                Метрики по классам
+                <InfoHint text={HINTS.perClass} />
+              </p>
+            </div>
             <div className="class-report-table-wrap">
               <table className="class-report-table">
                 <thead>
                   <tr>
                     <th>Класс</th>
-                    <th>Precision</th>
-                    <th>Recall</th>
-                    <th>F1</th>
-                    <th>Support</th>
+                    <th>
+                      <Tooltip content={getMetricMeta('precision')?.description}>Precision</Tooltip>
+                    </th>
+                    <th>
+                      <Tooltip content={getMetricMeta('recall')?.description}>Recall</Tooltip>
+                    </th>
+                    <th>
+                      <Tooltip content={getMetricMeta('f1')?.description}>F1</Tooltip>
+                    </th>
+                    <th>
+                      <Tooltip content={HINTS.support}>Support</Tooltip>
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
                   {report.per_class.map((row) => (
                     <tr key={row.label}>
                       <th>{row.label}</th>
-                      <td>{formatScore(row.precision)}</td>
-                      <td>{formatScore(row.recall)}</td>
-                      <td>{formatScore(row.f1)}</td>
+                      <td><ScoreCell metric="precision" value={row.precision} /></td>
+                      <td><ScoreCell metric="recall" value={row.recall} /></td>
+                      <td><ScoreCell metric="f1" value={row.f1} /></td>
                       <td>{row.support}</td>
                     </tr>
                   ))}
                 </tbody>
+                <tfoot>
+                  <tr>
+                    <th>
+                      <Tooltip content={HINTS.macroAvg}>macro avg</Tooltip>
+                    </th>
+                    <td><ScoreCell metric="precision" value={macro.precision} /></td>
+                    <td><ScoreCell metric="recall" value={macro.recall} /></td>
+                    <td><ScoreCell metric="f1" value={macro.f1} /></td>
+                    <td>{macro.support}</td>
+                  </tr>
+                  {accuracy !== undefined && (
+                    <tr>
+                      <th>
+                        <Tooltip content={HINTS.accuracy}>accuracy</Tooltip>
+                      </th>
+                      <td></td>
+                      <td></td>
+                      <td><ScoreCell metric="accuracy" value={accuracy} /></td>
+                      <td>{total}</td>
+                    </tr>
+                  )}
+                </tfoot>
               </table>
             </div>
           </div>

--- a/frontend/src/components/models/ModelMetricsCharts.tsx
+++ b/frontend/src/components/models/ModelMetricsCharts.tsx
@@ -1,20 +1,22 @@
-import React from 'react';
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from 'recharts';
-import type { ModelMetrics, Split, TrainingStatus } from '../../services/metricsService';
-import { useModelMetricsStream } from '../../hooks';
+import React, { useMemo, useState } from 'react';
+import type { ModelMetrics, Split } from '../../services/metricsService';
+import type { UseModelMetricsStreamResult } from '../../hooks';
 import { ICONS } from '../../constants/icons';
+import { getMetricMeta, getMetricQuality, SPLIT_DESCRIPTIONS } from '../../constants/metrics';
+import { formatMetricValue } from '../../utils/format';
+import { Tooltip as AppTooltip, InfoHint } from '../common/Tooltip';
+import { CollapseChevron, getDisclosureProps } from '../common/Collapse';
 import ModelClassReport from './ModelClassReport';
+import { CurveChartGrid, CurveZoomOverlay } from './curveChart';
+import { yDomain } from './curveChartData';
+import type { CheckpointMark, CurveGridItem, CurveSeries, EpochChart } from './curveChartData';
 
 interface Props {
   modelId: string;
+  /** Текстовый отчёт об обучении (model.metrics_report) — рендерится в блоке test. */
+  metricsReport?: string | null;
+  /** SSE-стрим метрик: живёт в ModelDetail, чтобы статус обучения был и в шапке. */
+  stream: UseModelMetricsStreamResult;
 }
 
 const SPLIT_COLORS: Record<Split, string> = {
@@ -22,18 +24,17 @@ const SPLIT_COLORS: Record<Split, string> = {
   val: '#5e8ab1',
   test: '#8a93a3',
 };
-const GRID_COLOR = 'rgba(255,255,255,0.06)';
-const AXIS_COLOR = '#b0b8c5';
+
+// Пунктир эпохи сохранённых весов: нейтральный серый, чтобы не спорить
+// с цветами выборок train/val.
+const CKPT_COLOR = '#8a93a3';
 
 // Кривые по эпохам: train и val накладываются на один график метрики —
 // так виден разрыв между ними (основной сигнал переобучения), как в W&B/TensorBoard.
 const CURVE_SPLITS: Split[] = ['train', 'val'];
 
-interface MetricChart {
-  name: string;
+interface MetricChart extends EpochChart {
   splits: Split[];
-  rows: Array<{ epoch: number } & Partial<Record<Split, number>>>;
-  maxPoints: number;
 }
 
 interface ScalarCard {
@@ -42,17 +43,20 @@ interface ScalarCard {
   value: number;
 }
 
-// Серии train/val из >1 точки — оверлей-графики; одиночные значения любой выборки
+// Серии train/val из >1 точки — оверлей-графики; одиночные значения train/val
 // и весь test (финальная оценка — одна точка) — скалярные карточки.
-const splitMetricViews = (data: ModelMetrics): { charts: MetricChart[]; scalars: ScalarCard[] } => {
-  const scalars: ScalarCard[] = [];
+// test-карточки — отдельный массив: они уходят в блок «Итоговая оценка (test)».
+const splitMetricViews = (
+  data: ModelMetrics,
+): { charts: MetricChart[]; testScalars: ScalarCard[]; trainValScalars: ScalarCard[] } => {
+  const trainValScalars: ScalarCard[] = [];
   const byName = new Map<string, Partial<Record<Split, number[]>>>();
 
   for (const split of CURVE_SPLITS) {
     for (const metric of data[split]) {
       if (metric.values.length === 0) continue;
       if (metric.values.length === 1) {
-        scalars.push({ name: metric.name, split, value: metric.values[0] });
+        trainValScalars.push({ name: metric.name, split, value: metric.values[0] });
         continue;
       }
       const series = byName.get(metric.name) ?? {};
@@ -61,58 +65,126 @@ const splitMetricViews = (data: ModelMetrics): { charts: MetricChart[]; scalars:
     }
   }
 
+  const testScalars: ScalarCard[] = [];
   for (const metric of data.test) {
     if (metric.values.length === 0) continue;
-    scalars.push({ name: metric.name, split: 'test', value: metric.values[metric.values.length - 1] });
+    testScalars.push({ name: metric.name, split: 'test', value: metric.values[metric.values.length - 1] });
   }
+
+  const splitOrder: Record<Split, number> = { test: 0, val: 1, train: 2 };
+  trainValScalars.sort((a, b) => splitOrder[a.split] - splitOrder[b.split]);
 
   const charts = Array.from(byName.entries()).map(([name, series]) => {
     const splits = CURVE_SPLITS.filter((split) => series[split] !== undefined);
     const maxPoints = Math.max(...splits.map((split) => series[split]!.length));
     const rows = Array.from({ length: maxPoints }, (_, i) => {
-      const row: MetricChart['rows'][number] = { epoch: i + 1 };
+      const row: EpochChart['rows'][number] = { epoch: i + 1 };
       for (const split of splits) {
         const value = series[split]![i];
         if (value !== undefined) row[split] = value;
       }
       return row;
     });
-    return { name, splits, rows, maxPoints };
+    return { name, splits, rows, maxPoints, domain: yDomain(rows, splits) };
   });
 
-  return { charts, scalars };
+  return { charts, testScalars, trainValScalars };
 };
 
-const formatValue = (v: number) =>
-  Number.isInteger(v) ? String(v) : v.toFixed(4);
-
-// Бейдж статуса обучения; у старых моделей статуса нет — бейдж не показываем.
-const STATUS_BADGES: Record<TrainingStatus, { icon: string; spin?: boolean; label: string }> = {
-  in_progress: { icon: ICONS.loading, spin: true, label: 'Обучение идёт…' },
-  completed: { icon: ICONS.success, label: 'Обучение завершено' },
-  failed: { icon: ICONS.error, label: 'Ошибка обучения' },
-  cancelled: { icon: ICONS.cancelled, label: 'Обучение отменено' },
-};
-
-const TrainingStatusBadge: React.FC<{ status: TrainingStatus }> = ({ status }) => {
-  const badge = STATUS_BADGES[status];
+// Карточка финального значения метрики; общая для блоков test и train/val.
+// В блоке test заголовок секции уже называет выборку, поэтому бейдж split скрыт.
+const ScalarCardView: React.FC<ScalarCard & { showSplit?: boolean }> = ({ name, split, value, showSplit = true }) => {
+  const meta = getMetricMeta(name);
+  const quality = getMetricQuality(meta, value);
   return (
-    <span className={`metrics-status-badge metrics-status-badge--${status}`}>
-      <i className={`fas ${badge.icon}${badge.spin ? ' fa-spin' : ''}`}></i> {badge.label}
-    </span>
+    <div
+      className={`metrics-scalar-card${quality ? ` metrics-scalar-card--${quality}` : ''}`}
+      style={{ '--split-color': SPLIT_COLORS[split] } as React.CSSProperties}
+    >
+      <span className="metrics-scalar-card-head">
+        <AppTooltip content={meta?.description}>
+          <span className="metrics-scalar-card-name">
+            {meta && <i className={`fas ${meta.icon}`} aria-hidden="true"></i>} {name}
+          </span>
+        </AppTooltip>
+        {showSplit && (
+          <AppTooltip content={SPLIT_DESCRIPTIONS[split]}>
+            <span className="metrics-scalar-card-split">{split}</span>
+          </AppTooltip>
+        )}
+      </span>
+      <span className="metrics-scalar-card-value">{formatMetricValue(value)}</span>
+    </div>
   );
 };
 
-const ModelMetricsCharts: React.FC<Props> = ({ modelId }) => {
-  const { data, status: trainingStatus, finished, loading, error } = useModelMetricsStream(modelId);
+const ModelMetricsCharts: React.FC<Props> = ({ modelId, metricsReport, stream }) => {
+  const { data, finished, loading, error } = stream;
+  const [reportOpen, setReportOpen] = useState(false);
 
-  const { charts, scalars } = data ? splitMetricViews(data) : { charts: [], scalars: [] };
+  // Сборка графиков — самая дорогая часть страницы (recharts): мемоизируем,
+  // чтобы не пересчитывать при рендерах, не меняющих данные метрик.
+  const { charts, testScalars, trainValScalars } = useMemo(
+    () => (data ? splitMetricViews(data) : { charts: [], testScalars: [], trainValScalars: [] }),
+    [data],
+  );
+
+  // «Сохранённые веса»: эпоха чекпоинта по early-stop-метрике. Общее число
+  // эпох выводим из длины кривых train/val; у старых моделей чекпоинта нет.
+  const checkpoint = data?.checkpoint;
+  const totalEpochs = data
+    ? Math.max(0, ...[...data.train, ...data.val].map((m) => m.values.length))
+    : 0;
+
+  // Серии и чекпоинты графиков для общей сетки/оверлея. Чекпоинт у модели
+  // один (нейтральный серый пунктир); в сводке оверлея он показывается
+  // в карточке val (early-stop считается на валидации), иначе — в первой.
+  const gridItems: CurveGridItem[] = useMemo(
+    () =>
+      charts.map((chart) => {
+        const ckptSplit = chart.splits.includes('val') ? 'val' : chart.splits[0];
+        const series: CurveSeries[] = chart.splits.map((split) => ({
+          key: split,
+          label: split,
+          color: SPLIT_COLORS[split],
+          hint: SPLIT_DESCRIPTIONS[split],
+          checkpointEpoch: split === ckptSplit ? checkpoint?.epoch : undefined,
+        }));
+        const checkpoints: CheckpointMark[] =
+          checkpoint && checkpoint.epoch <= chart.maxPoints
+            ? [{ epoch: checkpoint.epoch, color: CKPT_COLOR }]
+            : [];
+        return { chart, series, checkpoints };
+      }),
+    [charts, checkpoint],
+  );
+
+  // Увеличенный график в оверлее: имя метрики или null.
+  const [zoomedName, setZoomedName] = useState<string | null>(null);
+  const zoomedItem = gridItems.find((item) => item.chart.name === zoomedName) ?? null;
+
   // Ошибку показываем только если так и не получили данные (первая загрузка упала).
   const status: 'loading' | 'empty' | 'error' | 'ready' =
     loading ? 'loading'
     : error && data === undefined ? 'error'
-    : charts.length === 0 && scalars.length === 0 ? 'empty'
+    : charts.length === 0 && testScalars.length === 0 && trainValScalars.length === 0 ? 'empty'
     : 'ready';
+
+  // Текстовый отчёт об обучении: часть итоговой оценки, но показываем и когда
+  // числовых метрик нет (старые модели) — после плейсхолдера.
+  const textReport = metricsReport ? (
+    <div className="metrics-report-details">
+      <div
+        className="metrics-report-summary"
+        {...getDisclosureProps(reportOpen, () => setReportOpen((o) => !o))}
+      >
+        <CollapseChevron open={reportOpen} />
+        <i className={`fas ${ICONS.report}`}></i> Текстовый отчёт
+        <InfoHint text="Полный отчёт в текстовом виде, сформированный при обучении модели." />
+      </div>
+      {reportOpen && <pre className="detail-pre metrics-report-pre">{metricsReport}</pre>}
+    </div>
+  ) : null;
 
   if (status === 'loading') {
     return (
@@ -124,107 +196,85 @@ const ModelMetricsCharts: React.FC<Props> = ({ modelId }) => {
 
   if (status === 'error') {
     return (
-      <div className="metrics-charts-placeholder metrics-charts-placeholder--error">
-        <i className={`fas ${ICONS.warning}`}></i> Не удалось загрузить данные из сервиса метрик.
-      </div>
+      <>
+        <div className="metrics-charts-placeholder metrics-charts-placeholder--error">
+          <i className={`fas ${ICONS.warning}`}></i> Не удалось загрузить данные из сервиса метрик.
+        </div>
+        {textReport}
+      </>
     );
   }
 
   if (status === 'empty') {
     return (
-      <div className="metrics-charts-placeholder">
-        {trainingStatus && <TrainingStatusBadge status={trainingStatus} />}
-        <i className={`fas ${ICONS.metrics}`}></i> Данные по эпохам отсутствуют.
-      </div>
+      <>
+        <div className="metrics-charts-placeholder">
+          <i className={`fas ${ICONS.metrics}`}></i> Данные по эпохам отсутствуют.
+        </div>
+        {textReport}
+      </>
     );
   }
 
   return (
     <>
-      {trainingStatus && (
-        <div className="metrics-status-row">
-          <TrainingStatusBadge status={trainingStatus} />
-        </div>
-      )}
-      {scalars.length > 0 && (
+      {/* finished: отчёт по классам возможен только после завершения обучения. */}
+      {(testScalars.length > 0 || textReport || finished) && (
         <div className="metrics-split-section">
-          <p className="metrics-split-title">Финальные значения</p>
-          <div className="metrics-scalar-cards">
-            {scalars.map(({ name, split, value }) => (
-              <div key={`${split}-${name}`} className="metrics-scalar-card">
-                <span className="metrics-scalar-card-name">
-                  <span style={{ color: SPLIT_COLORS[split] }}>●</span> {split} · {name}
-                </span>
-                <span className="metrics-scalar-card-value">{formatValue(value)}</span>
-              </div>
-            ))}
-          </div>
+          <p className="metrics-split-title">
+            Итоговая оценка (test)
+            <InfoHint text="Финальное качество модели на test-выборке — данных, которые она не видела при обучении. Это главный показатель того, как модель поведёт себя на новых данных." />
+          </p>
+          {checkpoint && (
+            <p className="metrics-checkpoint-note">
+              <i className={`fas ${ICONS.weights}`} aria-hidden="true"></i>
+              Сохранены веса эпохи {checkpoint.epoch}
+              {totalEpochs ? ` из ${totalEpochs}` : ''} — лучшая по val_{checkpoint.metric}
+              {checkpoint.value != null ? ` (${formatMetricValue(checkpoint.value)})` : ''}
+              <InfoHint text="Trainer сохраняет веса лучшей эпохи по early-stop-метрике и восстанавливает их перед тестированием — test-метрики соответствуют именно этим весам. На графиках эта эпоха отмечена пунктирной вертикалью." />
+            </p>
+          )}
+          {testScalars.length > 0 && (
+            <div className="metrics-scalar-cards">
+              {testScalars.map((card) => (
+                <ScalarCardView key={`${card.split}-${card.name}`} {...card} showSplit={false} />
+              ))}
+            </div>
+          )}
+          <ModelClassReport modelId={modelId} enabled={finished} />
+          {textReport}
         </div>
       )}
-      {charts.length > 0 && (
+      {(charts.length > 0 || trainValScalars.length > 0) && (
         <div className="metrics-split-section">
-          <p className="metrics-split-title">Кривые по эпохам</p>
-          <div className="metrics-charts">
-            {charts.map((chart) => (
-              <div key={chart.name} className="metrics-chart-block">
-                <p className="metrics-chart-title">
-                  {chart.name}
-                  <span style={{ marginLeft: 12, fontSize: 11 }}>
-                    {chart.splits.map((split) => (
-                      <span key={split} style={{ color: SPLIT_COLORS[split], marginRight: 8 }}>
-                        ● {split}
-                      </span>
-                    ))}
-                  </span>
-                </p>
-                <ResponsiveContainer width="100%" height={180}>
-                  <LineChart data={chart.rows} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} />
-                    <XAxis
-                      dataKey="epoch"
-                      tick={{ fill: AXIS_COLOR, fontSize: 11 }}
-                      tickLine={false}
-                      axisLine={{ stroke: GRID_COLOR }}
-                      label={{ value: 'эпоха', position: 'insideBottomRight', offset: -4, fill: AXIS_COLOR, fontSize: 10 }}
-                    />
-                    <YAxis
-                      tick={{ fill: AXIS_COLOR, fontSize: 11 }}
-                      tickLine={false}
-                      axisLine={false}
-                      tickFormatter={formatValue}
-                      width={56}
-                    />
-                    <Tooltip
-                      contentStyle={{
-                        background: 'var(--color-bg-secondary)',
-                        border: '1px solid var(--color-border-soft)',
-                        borderRadius: 12,
-                        boxShadow: 'var(--shadow-md)',
-                        fontSize: 12,
-                        color: 'var(--color-text-primary)',
-                      }}
-                      formatter={(value, name) => [formatValue(Number(value)), String(name)]}
-                      labelFormatter={(label) => `Эпоха ${label}`}
-                    />
-                    {chart.splits.map((split) => (
-                      <Line
-                        key={split}
-                        type="monotone"
-                        dataKey={split}
-                        stroke={SPLIT_COLORS[split]}
-                        strokeWidth={2}
-                        dot={chart.maxPoints <= 40}
-                        activeDot={{ r: 4, fill: SPLIT_COLORS[split] }}
-                      />
-                    ))}
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
-            ))}
-          </div>
+          <p className="metrics-split-title">
+            Динамика обучения (train / val)
+            <InfoHint text="Как метрики менялись по эпохам на обучающей (train) и валидационной (val) выборках. Если val заметно хуже train — модель переобучилась: заучила примеры вместо закономерностей. Пунктирная вертикаль — эпоха сохранённых весов; кнопкой справа график разворачивается с приближением диапазона эпох." />
+          </p>
+          {/* Порядок графиков пользовательский — общий для всех моделей. */}
+          <CurveChartGrid
+            items={gridItems}
+            storageKey="model-metrics-curves-order"
+            onZoom={setZoomedName}
+          />
+          {trainValScalars.length > 0 && (
+            <div className="metrics-scalar-cards">
+              {trainValScalars.map((card) => (
+                <ScalarCardView key={`${card.split}-${card.name}`} {...card} />
+              ))}
+            </div>
+          )}
         </div>
       )}
-      <ModelClassReport modelId={modelId} enabled={finished} />
+      {zoomedItem && (
+        <CurveZoomOverlay
+          title={zoomedItem.chart.name}
+          chart={zoomedItem.chart}
+          series={zoomedItem.series}
+          checkpoints={zoomedItem.checkpoints}
+          onClose={() => setZoomedName(null)}
+        />
+      )}
     </>
   );
 };

--- a/frontend/src/components/models/curveChart.tsx
+++ b/frontend/src/components/models/curveChart.tsx
@@ -1,0 +1,378 @@
+import React, { useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ReferenceDot,
+  ResponsiveContainer,
+  Brush,
+} from 'recharts';
+import { ICONS } from '../../constants/icons';
+import { getMetricMeta, getMetricQuality } from '../../constants/metrics';
+import { formatMetricValue } from '../../utils/format';
+import { Tooltip as UiTooltip } from '../common/Tooltip';
+import { useDragReorder } from '../../hooks';
+import { curveStats } from './curveChartData';
+import type { CheckpointMark, CurveGridItem, CurveSeries, EpochChart } from './curveChartData';
+
+/**
+ * Общие компоненты графиков train/val-кривых по эпохам: сетка с drag-reorder
+ * и кнопкой увеличения, сам график (recharts) и zoom-оверлей со сводкой.
+ * Используются страницей модели (серии — выборки train/val) и страницей
+ * сравнения (серии — модели); различия параметризованы CurveSeries
+ * (типы и расчётные хелперы — в curveChartData.ts).
+ */
+
+// Тики оси Y после паддинга домена — дробные; 4 знака перегружают ось,
+// поэтому округляем до 3 значащих цифр.
+const formatTick = (v: number) => String(Number(v.toPrecision(3)));
+
+/**
+ * Легенда графика: цветные маркеры серий с пояснением в тултипе (hint).
+ * С onHoverSeries (оверлей) наведение на серию подсвечивает её кривую.
+ */
+const ChartLegend: React.FC<{
+  series: CurveSeries[];
+  onHoverSeries?: (key: string | null) => void;
+}> = ({ series, onHoverSeries }) => (
+  <span className="mcmp-curve-legend">
+    {series.map((s) => (
+      <UiTooltip key={s.key} content={s.hint}>
+        <span
+          style={{ color: s.color }}
+          onMouseEnter={onHoverSeries && (() => onHoverSeries(s.key))}
+          onMouseLeave={onHoverSeries && (() => onHoverSeries(null))}
+        >
+          ● {s.label}
+        </span>
+      </UiTooltip>
+    ))}
+  </span>
+);
+
+/**
+ * Tooltip увеличенного графика: строки серий отсортированы по значению,
+ * у каждой — маркер цвета серии (дефолтный recharts-tooltip их не различает).
+ */
+const CurveTooltip: React.FC<{
+  series: CurveSeries[];
+  active?: boolean;
+  label?: number;
+  payload?: Array<{ dataKey?: string | number; value?: number | string }>;
+}> = ({ series, active, label, payload }) => {
+  if (!active || !payload?.length) return null;
+  const byKey = new Map(series.map((s) => [s.key, s]));
+  const rows = payload
+    .map((item) => ({ series: byKey.get(String(item.dataKey)), value: Number(item.value) }))
+    .filter((row): row is { series: CurveSeries; value: number } =>
+      row.series !== undefined && Number.isFinite(row.value),
+    )
+    .sort((a, b) => b.value - a.value);
+  return (
+    <div className="mcmp-tooltip">
+      <p className="mcmp-tooltip-label">Эпоха {label}</p>
+      {rows.map(({ series: s, value }) => (
+        <p key={s.key} className="mcmp-tooltip-row">
+          <span className="mcmp-side-dot" style={{ background: s.color }} />
+          <span className="mcmp-tooltip-name">{s.label}</span>
+          <b>{formatMetricValue(value)}</b>
+        </p>
+      ))}
+    </div>
+  );
+};
+
+/**
+ * Отрисовка одного графика кривых; используется и в сетке,
+ * и в увеличенном оверлее (там выше порог точек и высота контейнера).
+ */
+export const CurveChartView: React.FC<{
+  chart: EpochChart;
+  /** Серии графика — только те, у которых есть значения в rows. */
+  series: CurveSeries[];
+  /** Пунктирные вертикали эпох сохранённых весов (уже отфильтрованы по эпохам). */
+  checkpoints: CheckpointMark[];
+  height: number | `${number}%`;
+  /** До скольких эпох рисовать точки на линиях. */
+  dotLimit: number;
+  /** Увеличенный вид: brush для приближения диапазона эпох, крупнее оси и линии. */
+  large?: boolean;
+  /** Ключ выделенной серии (hover по легенде): остальные кривые приглушаются. */
+  highlightKey?: string | null;
+}> = ({ chart, series, checkpoints, height, dotLimit, large, highlightKey }) => {
+  // Цвета сетки/осей — через CSS-класс (mcmp-chart-themed), чтобы следовали теме.
+  const dim = (key: string) => (highlightKey == null || highlightKey === key ? 1 : 0.18);
+  const meta = getMetricMeta(chart.name);
+  return (
+    <ResponsiveContainer width="100%" height={height} className="mcmp-chart-themed">
+      <LineChart data={chart.rows} margin={{ top: 4, right: 16, left: 0, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={!large} />
+        {/* Пунктирная вертикаль — эпоха, веса которой сохранены у модели. */}
+        {checkpoints.map((ckpt, index) => (
+          <ReferenceLine
+            key={`ckpt-${ckpt.seriesKey ?? index}`}
+            x={ckpt.epoch}
+            stroke={ckpt.color}
+            strokeDasharray="4 4"
+            strokeOpacity={0.7 * (ckpt.seriesKey ? dim(ckpt.seriesKey) : 1)}
+          />
+        ))}
+        <XAxis
+          dataKey="epoch"
+          tick={{ fontSize: large ? 12 : 11 }}
+          tickLine={false}
+          // В увеличенном виде подпись налезала бы на полосу brush — там ось
+          // поясняется подсказкой под графиком.
+          label={
+            large
+              ? undefined
+              : { value: 'эпоха', position: 'insideBottomRight', offset: -4, fontSize: 10 }
+          }
+        />
+        <YAxis
+          domain={chart.domain}
+          tick={{ fontSize: large ? 12 : 11 }}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={formatTick}
+          width={56}
+        />
+        {large ? (
+          <Tooltip content={<CurveTooltip series={series} />} />
+        ) : (
+          <Tooltip
+            contentStyle={{
+              background: 'var(--color-bg-secondary)',
+              border: '1px solid var(--color-border-soft)',
+              borderRadius: 12,
+              boxShadow: 'var(--shadow-md)',
+              fontSize: 12,
+              color: 'var(--color-text-primary)',
+            }}
+            formatter={(value, name) => [
+              formatMetricValue(Number(value)),
+              series.find((s) => s.key === String(name))?.label ?? String(name),
+            ]}
+            labelFormatter={(label) => `Эпоха ${label}`}
+          />
+        )}
+        {series.map((s) => (
+          <Line
+            key={s.key}
+            type="monotone"
+            dataKey={s.key}
+            stroke={s.color}
+            strokeWidth={large ? 2.5 : 2}
+            strokeOpacity={dim(s.key)}
+            dot={chart.maxPoints <= dotLimit}
+            activeDot={{ r: large ? 5 : 4, fill: s.color }}
+            isAnimationActive={!large}
+          />
+        ))}
+        {/* Маркер лучшей эпохи каждой кривой — та же точка, что в сводке оверлея. */}
+        {large &&
+          series.map((s) => {
+            const { best } = curveStats(chart.rows, s.key, !!meta?.lowerIsBetter);
+            if (!best) return null;
+            return (
+              <ReferenceDot
+                key={`best-${s.key}`}
+                x={best.epoch}
+                y={best.value}
+                r={4.5}
+                fill={s.color}
+                stroke="none"
+                opacity={dim(s.key)}
+              />
+            );
+          })}
+        {/* Brush — приближение диапазона эпох перетаскиванием краёв полосы. */}
+        {large && (
+          <Brush
+            dataKey="epoch"
+            height={32}
+            travellerWidth={9}
+            traveller={({ x, y, width, height: h }) => (
+              <rect x={x} y={y} width={width} height={h} rx={3} className="mcmp-brush-traveller" />
+            )}
+          />
+        )}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+};
+
+/**
+ * Сетка графиков с пользовательским порядком (drag and drop за ручку
+ * в заголовке; порядок хранится в localStorage по storageKey) и кнопкой
+ * разворота графика в zoom-оверлей.
+ */
+export const CurveChartGrid: React.FC<{
+  items: CurveGridItem[];
+  storageKey: string;
+  onZoom: (name: string) => void;
+}> = ({ items, storageKey, onZoom }) => {
+  const chartNames = React.useMemo(() => items.map((item) => item.chart.name), [items]);
+  const reorder = useDragReorder(chartNames, storageKey);
+  const orderedItems = reorder.orderedKeys.map(
+    (name) => items.find((item) => item.chart.name === name)!,
+  );
+
+  return (
+    <div className="metrics-charts">
+      {orderedItems.map(({ chart, series, checkpoints }) => (
+        <div
+          key={chart.name}
+          className={`metrics-chart-block${
+            reorder.draggedKey === chart.name ? ' mcmp-chart--dragging' : ''
+          }`}
+          {...reorder.itemProps(chart.name)}
+        >
+          <p className="metrics-chart-title mcmp-chart-title">
+            <span
+              className="mcmp-chart-grip"
+              title="Перетащите, чтобы изменить порядок графиков"
+              {...reorder.handleProps(chart.name)}
+            >
+              <i className={`fas ${ICONS.dragHandle}`} aria-hidden="true"></i>
+            </span>
+            {chart.name}
+            <ChartLegend series={series} />
+            <UiTooltip content="Развернуть график" className="mcmp-chart-zoom">
+              <button
+                className="icon-button small"
+                onClick={() => onZoom(chart.name)}
+                aria-label={`Развернуть график ${chart.name}`}
+              >
+                <i className={`fas ${ICONS.enlarge}`}></i>
+              </button>
+            </UiTooltip>
+          </p>
+          <CurveChartView
+            chart={chart}
+            series={series}
+            checkpoints={checkpoints}
+            height={180}
+            dotLimit={40}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+/**
+ * Увеличенный график в модальном оверлее: сводка по сериям (лучшее значение
+ * с эпохой, финал, эпоха весов), brush для приближения диапазона эпох,
+ * hover по легенде подсвечивает кривую. Закрывается по Escape и клику мимо;
+ * скролл страницы на время оверлея блокируется.
+ */
+export const CurveZoomOverlay: React.FC<{
+  /** Заголовок (имя метрики, при необходимости — с выборкой). */
+  title: string;
+  chart: EpochChart;
+  series: CurveSeries[];
+  checkpoints: CheckpointMark[];
+  onClose: () => void;
+}> = ({ title, chart, series, checkpoints, onClose }) => {
+  // Hover по легенде — подсветка одной кривой. State живёт в оверлее
+  // и исчезает вместе с ним — сброс при закрытии не нужен.
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const meta = getMetricMeta(chart.name);
+
+  // Закрытие по Escape и блокировка скролла страницы, пока оверлей открыт.
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  return (
+    <div className="mcmp-zoom-overlay" onClick={onClose}>
+      <div
+        className="mcmp-zoom-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`График ${title}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="mcmp-zoom-head">
+          <p className="metrics-chart-title mcmp-chart-title">
+            {title}
+            <ChartLegend series={series} onHoverSeries={setHoveredKey} />
+          </p>
+          <UiTooltip content="Закрыть">
+            <button className="icon-button" onClick={onClose} aria-label="Закрыть">
+              <i className={`fas ${ICONS.close}`}></i>
+            </button>
+          </UiTooltip>
+        </header>
+        {/* Сводка по кривым: лучшее значение с эпохой, финал, эпоха весов. */}
+        <div className="mcmp-zoom-stats">
+          {series.map((s) => {
+            const { best, final } = curveStats(chart.rows, s.key, !!meta?.lowerIsBetter);
+            if (!best || !final) return null;
+            const bestQuality = getMetricQuality(meta, best.value);
+            const showCkpt = s.checkpointEpoch != null && s.checkpointEpoch <= chart.maxPoints;
+            return (
+              <div key={s.key} className="mcmp-zoom-stat" style={{ borderLeftColor: s.color }}>
+                <p className="mcmp-zoom-stat-label">
+                  <span className="mcmp-side-dot" style={{ background: s.color }} />
+                  {s.label}
+                </p>
+                <div className="mcmp-zoom-stat-values">
+                  <span className="mcmp-zoom-stat-item">
+                    <span className="mcmp-zoom-stat-key">
+                      {meta?.lowerIsBetter ? 'минимум' : 'максимум'}
+                    </span>
+                    <b className={bestQuality ? `class-report-score--${bestQuality}` : undefined}>
+                      {formatMetricValue(best.value)}
+                    </b>
+                    <span className="mcmp-zoom-stat-sub">эпоха {best.epoch}</span>
+                  </span>
+                  <span className="mcmp-zoom-stat-item">
+                    <span className="mcmp-zoom-stat-key">финал</span>
+                    <b>{formatMetricValue(final.value)}</b>
+                    <span className="mcmp-zoom-stat-sub">эпоха {final.epoch}</span>
+                  </span>
+                  {showCkpt && (
+                    <span className="mcmp-zoom-stat-item">
+                      <span className="mcmp-zoom-stat-key">веса</span>
+                      <b>эпоха {s.checkpointEpoch}</b>
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="mcmp-zoom-chart">
+          <CurveChartView
+            chart={chart}
+            series={series}
+            checkpoints={checkpoints}
+            height="100%"
+            dotLimit={80}
+            large
+            highlightKey={hoveredKey}
+          />
+        </div>
+        <p className="mcmp-zoom-note">
+          * Потяните края полосы под графиком, чтобы приблизить диапазон эпох; пунктирная
+          вертикаль — эпоха сохранённых весов модели.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/models/curveChartData.ts
+++ b/frontend/src/components/models/curveChartData.ts
@@ -1,0 +1,75 @@
+// Типы и расчётные хелперы графиков кривых по эпохам — отдельно от
+// компонентов (curveChart.tsx), чтобы не ломать react fast refresh.
+
+/** Серия графика: одна кривая с подписью и закреплённым цветом. */
+export interface CurveSeries {
+  /** Ключ значения в строках rows. */
+  key: string;
+  label: string;
+  color: string;
+  /** Пояснение серии (тултип в легенде). */
+  hint?: string;
+  /**
+   * Эпоха сохранённых весов, относящаяся к этой серии, — для сводки
+   * zoom-оверлея («веса: эпоха N»). Вертикаль на графике — checkpoints.
+   */
+  checkpointEpoch?: number | null;
+}
+
+/** Пунктирная вертикаль эпохи сохранённых весов. */
+export interface CheckpointMark {
+  epoch: number;
+  color: string;
+  /** Серия, к которой относится чекпоинт, — приглушается вместе с ней. */
+  seriesKey?: string;
+}
+
+export type EpochRow = { epoch: number } & Partial<Record<string, number>>;
+
+/** Данные одного графика: метрика и значения серий по эпохам. */
+export interface EpochChart {
+  /** Имя метрики (loss, accuracy, …) — заголовок и ключ порядка. */
+  name: string;
+  rows: EpochRow[];
+  maxPoints: number;
+  domain: [number, number];
+}
+
+/** Один график сетки с его сериями и чекпоинтами. */
+export interface CurveGridItem {
+  chart: EpochChart;
+  series: CurveSeries[];
+  checkpoints: CheckpointMark[];
+}
+
+// Ось Y от нуля «прижимает» кривые вроде accuracy (0.90–0.95) к потолку графика,
+// поэтому домен считаем по фактическому диапазону данных с запасом 8% сверху и снизу.
+export const yDomain = (rows: EpochRow[], keys: string[]): [number, number] => {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const row of rows) {
+    for (const key of keys) {
+      const value = row[key];
+      if (value === undefined) continue;
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+  }
+  const padding = (max - min || Math.abs(max) || 1) * 0.08;
+  return [min - padding, max + padding];
+};
+
+/** Лучшее (по направлению метрики) и финальное значение одной кривой. */
+export const curveStats = (rows: EpochRow[], key: string, lowerIsBetter: boolean) => {
+  let best: { value: number; epoch: number } | null = null;
+  let final: { value: number; epoch: number } | null = null;
+  for (const row of rows) {
+    const value = row[key];
+    if (value === undefined) continue;
+    final = { value, epoch: row.epoch };
+    if (!best || (lowerIsBetter ? value < best.value : value > best.value)) {
+      best = { value, epoch: row.epoch };
+    }
+  }
+  return { best, final };
+};

--- a/frontend/src/constants/icons.ts
+++ b/frontend/src/constants/icons.ts
@@ -31,6 +31,8 @@ export const ICONS = {
   menuClose: 'fa-xmark',       // закрыть мобильное меню (бургер в открытом состоянии)
   compare: 'fa-code-compare',  // сравнение версий датасета
   swap: 'fa-right-left',       // поменять местами базовую и сравниваемую версии
+  dragHandle: 'fa-grip-vertical', // ручка перетаскивания (смена порядка графиков)
+  enlarge: 'fa-up-right-and-down-left-from-center', // развернуть график в большой оверлей
   arrowRight: 'fa-arrow-right', // направление сравнения «базовая → сравниваемая»
   minus: 'fa-minus',           // удалённые элементы в diff (пара к add)
 
@@ -86,6 +88,16 @@ export const ICONS = {
   duration: 'fa-clock',
   iteration: 'fa-rotate',
   history: 'fa-clock-rotate-left',
+
+  // --- метрики обучения (карточки финальных значений) ---
+  metricAccuracy: 'fa-bullseye',
+  metricPrecision: 'fa-crosshairs',
+  metricRecall: 'fa-magnifying-glass',
+  metricF1: 'fa-scale-balanced',
+  metricAuroc: 'fa-chart-area',
+  metricSpecificity: 'fa-filter',
+  metricKappa: 'fa-handshake',
+  metricLoss: 'fa-arrow-trend-down',
 
   // --- файлы (FileUploader) ---
   upload: 'fa-cloud-arrow-up',

--- a/frontend/src/constants/metrics.ts
+++ b/frontend/src/constants/metrics.ts
@@ -1,0 +1,80 @@
+// Реестр метрик обучения: описание (тултип), иконка и пороги качества.
+// Набор имён фиксирован трейнером (services/trainer METRICS_REGISTRY + loss);
+// неизвестные имена деградируют мягко: без тултипа/иконки, нейтральная окраска.
+
+import { ICONS } from './icons';
+
+export type MetricQuality = 'good' | 'fair' | 'poor';
+
+export interface MetricMeta {
+  description: string;
+  icon: string;
+  /** Пороги «значение ≥ x» для good/fair; нет — у метрики нет абсолютной шкалы (loss). */
+  thresholds?: { good: number; fair: number };
+  /** Меньше — лучше (loss); по умолчанию метрики растут к лучшему. */
+  lowerIsBetter?: boolean;
+}
+
+const METRIC_META: Record<string, MetricMeta> = {
+  accuracy: {
+    description: 'Доля верных предсказаний среди всех примеров.',
+    icon: ICONS.metricAccuracy,
+    thresholds: { good: 0.85, fair: 0.6 },
+  },
+  precision: {
+    description: 'Доля верных среди предсказанных положительных (macro по классам).',
+    icon: ICONS.metricPrecision,
+    thresholds: { good: 0.85, fair: 0.6 },
+  },
+  recall: {
+    description: 'Полнота: доля найденных объектов каждого класса (macro).',
+    icon: ICONS.metricRecall,
+    thresholds: { good: 0.85, fair: 0.6 },
+  },
+  f1: {
+    description: 'Гармоническое среднее precision и recall (macro).',
+    icon: ICONS.metricF1,
+    thresholds: { good: 0.85, fair: 0.6 },
+  },
+  auroc: {
+    description: 'Площадь под ROC-кривой; 0.5 — случайный классификатор.',
+    icon: ICONS.metricAuroc,
+    thresholds: { good: 0.9, fair: 0.7 },
+  },
+  specificity: {
+    description: 'Доля верно отвергнутых отрицательных примеров.',
+    icon: ICONS.metricSpecificity,
+    thresholds: { good: 0.85, fair: 0.6 },
+  },
+  kappa: {
+    description: 'Каппа Коэна: согласие с истиной с поправкой на случайное угадывание.',
+    icon: ICONS.metricKappa,
+    // Шкала Ландиса–Коха: ≥0.6 — substantial, 0.4–0.6 — moderate.
+    thresholds: { good: 0.6, fair: 0.4 },
+  },
+  loss: {
+    description: 'Значение функции потерь — чем ниже, тем лучше; абсолютной шкалы качества нет.',
+    icon: ICONS.metricLoss,
+    lowerIsBetter: true,
+  },
+};
+
+// Пояснения выборок (split) для подсказок в UI.
+export const SPLIT_DESCRIPTIONS: Record<string, string> = {
+  train: 'Обучающая выборка: на этих данных модель училась.',
+  val: 'Валидационная выборка: контроль качества во время обучения, в само обучение не входит.',
+  test: 'Test-выборка: отложенные данные для финальной оценки — модель не видела их при обучении.',
+};
+
+export const getMetricMeta = (name: string): MetricMeta | undefined =>
+  METRIC_META[name.trim().toLowerCase()];
+
+export const getMetricQuality = (
+  meta: MetricMeta | undefined,
+  value: number,
+): MetricQuality | undefined => {
+  if (!meta?.thresholds) return undefined;
+  if (value >= meta.thresholds.good) return 'good';
+  if (value >= meta.thresholds.fair) return 'fair';
+  return 'poor';
+};

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,6 +1,8 @@
 export { useCopyToClipboard } from './useCopyToClipboard';
 export { usePolling } from './usePolling';
 export { useModelMetricsStream } from './useModelMetricsStream';
+export type { UseModelMetricsStreamResult } from './useModelMetricsStream';
 export { useDebouncedValue } from './useDebouncedValue';
+export { useDragReorder } from './useDragReorder';
 export { useModelFilters } from './useModelFilters';
 export type { ModelFilters } from './useModelFilters';

--- a/frontend/src/hooks/useDragReorder.ts
+++ b/frontend/src/hooks/useDragReorder.ts
@@ -1,0 +1,82 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+/**
+ * Перетаскивание элементов сетки/списка для смены их порядка (HTML5 DnD).
+ *
+ * Перетаскивание начинается только с «ручки» (handleProps) — содержимое
+ * элемента (hover-тултипы графиков, выделение текста) остаётся рабочим.
+ * Порядок применяется на лету при наведении на другой элемент; при заданном
+ * storageKey сохраняется в localStorage. Ключи, которых нет в сохранённом
+ * порядке (новые метрики), добавляются в конец в исходном порядке.
+ */
+export function useDragReorder(keys: string[], storageKey?: string) {
+  const [order, setOrder] = useState<string[]>(() => {
+    if (!storageKey) return [];
+    try {
+      const raw = localStorage.getItem(storageKey);
+      return raw ? (JSON.parse(raw) as string[]) : [];
+    } catch {
+      return [];
+    }
+  });
+  // Элемент «взведён» нажатием на ручку: только он получает draggable,
+  // иначе перетаскивание стартовало бы с любой точки блока.
+  const [armedKey, setArmedKey] = useState<string | null>(null);
+  const [draggedKey, setDraggedKey] = useState<string | null>(null);
+
+  const orderedKeys = useMemo(() => {
+    const known = order.filter((k) => keys.includes(k));
+    return [...known, ...keys.filter((k) => !known.includes(k))];
+  }, [order, keys]);
+
+  useEffect(() => {
+    if (!storageKey || order.length === 0) return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(order));
+    } catch {
+      // localStorage недоступен (приватный режим) — порядок живёт до перезагрузки.
+    }
+  }, [order, storageKey]);
+
+  // Отпустил ручку без перетаскивания — снимаем draggable с блока.
+  useEffect(() => {
+    if (armedKey === null) return;
+    const disarm = () => setArmedKey(null);
+    window.addEventListener('mouseup', disarm);
+    return () => window.removeEventListener('mouseup', disarm);
+  }, [armedKey]);
+
+  const moveTo = (targetKey: string) => {
+    if (!draggedKey || draggedKey === targetKey) return;
+    const next = orderedKeys.filter((k) => k !== draggedKey);
+    next.splice(next.indexOf(targetKey), 0, draggedKey);
+    if (next.every((k, i) => k === orderedKeys[i])) return;
+    setOrder(next);
+  };
+
+  const handleProps = (key: string) => ({
+    onMouseDown: () => setArmedKey(key),
+  });
+
+  const itemProps = (key: string) => ({
+    draggable: armedKey === key,
+    onDragStart: (e: React.DragEvent) => {
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', key);
+      setDraggedKey(key);
+    },
+    onDragOver: (e: React.DragEvent) => {
+      if (draggedKey === null) return; // чужой drag (файл, текст) — игнорируем
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      moveTo(key);
+    },
+    onDrop: (e: React.DragEvent) => e.preventDefault(),
+    onDragEnd: () => {
+      setDraggedKey(null);
+      setArmedKey(null);
+    },
+  });
+
+  return { orderedKeys, draggedKey, handleProps, itemProps };
+}

--- a/frontend/src/hooks/useModelMetricsStream.ts
+++ b/frontend/src/hooks/useModelMetricsStream.ts
@@ -4,9 +4,13 @@ import type { ModelMetrics, TrainingStatus } from '../services/metricsService';
 
 const FINAL_STATUSES: TrainingStatus[] = ['completed', 'failed', 'cancelled'];
 
-interface UseModelMetricsStreamResult {
+export interface UseModelMetricsStreamResult {
   data: ModelMetrics | undefined;
-  status: TrainingStatus | null | undefined;
+  /**
+   * Стрим дошёл до финального статуса обучения. Это сигнал «новых снимков
+   * не будет», а не статус модели — «обучена/не обучена» знает только
+   * реестр ml_models.
+   */
   finished: boolean;
   loading: boolean;
   error: boolean;
@@ -25,10 +29,19 @@ export function useModelMetricsStream(modelId: string): UseModelMetricsStreamRes
   const [finished, setFinished] = useState(false);
   const [error, setError] = useState(false);
 
-  useEffect(() => {
+  // Сброс при смене модели — синхронно в рендере (паттерн «storing information
+  // from previous renders» из доков React), чтобы между сменой id и подпиской
+  // не отдавались данные прошлой модели.
+  const [prevModelId, setPrevModelId] = useState(modelId);
+  if (prevModelId !== modelId) {
+    setPrevModelId(modelId);
     setData(undefined);
     setFinished(false);
     setError(false);
+  }
+
+  useEffect(() => {
+    if (!modelId) return;
 
     let cancelled = false;
     let gotData = false;
@@ -60,7 +73,13 @@ export function useModelMetricsStream(modelId: string): UseModelMetricsStreamRes
         metricsService
           .getModelMetrics(modelId)
           .then((metrics) => {
-            if (cancelled || gotData || metrics === null) return;
+            if (cancelled || gotData) return;
+            if (metrics === null) {
+              // 404 — метрик у модели нет: это «пусто», а не ошибка сервиса.
+              setData({ model_id: modelId, train: [], val: [], test: [] });
+              setError(false);
+              return;
+            }
             applyMetrics(metrics);
           })
           .catch(() => undefined);
@@ -75,7 +94,6 @@ export function useModelMetricsStream(modelId: string): UseModelMetricsStreamRes
 
   return {
     data,
-    status: data?.status,
     finished,
     loading: data === undefined && !error,
     error,

--- a/frontend/src/pages/DatasetDetail.tsx
+++ b/frontend/src/pages/DatasetDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { datasetService } from '../services/datasetService';
 import { useNotification } from '../contexts/NotificationContext';
 import { useCopyToClipboard } from '../hooks';
@@ -23,6 +23,7 @@ const EMPTY_VERSION = () => ({
 const DatasetDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { showNotification } = useNotification();
   const copyToClipboard = useCopyToClipboard();
 
@@ -30,7 +31,8 @@ const DatasetDetail: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [showVersionForm, setShowVersionForm] = useState(false);
-  const [versionFilter, setVersionFilter] = useState('');
+  // Фильтр версий можно предзаполнить через ?version=<имя> (переход со страницы модели).
+  const [versionFilter, setVersionFilter] = useState(() => searchParams.get('version') ?? '');
   const [newVersion, setNewVersion] = useState(EMPTY_VERSION);
   // Версия, для которой открыта модалка с полной статистикой.
   const [statsVersion, setStatsVersion] = useState<Version | null>(null);

--- a/frontend/src/pages/ModelDetail.tsx
+++ b/frontend/src/pages/ModelDetail.tsx
@@ -1,17 +1,68 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { mlModelsService } from '../services/mlModelsService';
 import { datasetService } from '../services/datasetService';
 import { useNotification } from '../contexts/NotificationContext';
 import type { MLModelVersion, MLModelFile } from '../types/mlModels';
 import type { Dataset } from '../types/dataset';
-import { formatBytes, formatDateTime } from '../utils/format';
-import { useCopyToClipboard } from '../hooks';
+import { formatBytes, formatDateTime, formatDateParts } from '../utils/format';
+import { useCopyToClipboard, useModelMetricsStream } from '../hooks';
 import { CollapseChevron, getDisclosureProps } from '../components/common/Collapse';
+import ConfirmModal from '../components/common/ConfirmModal';
 import { Tooltip } from '../components/common/Tooltip';
+import Select from '../components/common/Select';
 import { ModelMetricsCharts } from '../components/models';
 import { ICONS } from '../constants/icons';
+import { modelStatusLabel, statusBadgeClass } from '../constants';
 import './Models.css';
+
+// Финальные статусы реестра: после них перечитывать версию уже незачем.
+const FINAL_REGISTRY_STATUSES = ['completed', 'failed', 'cancelled'];
+
+/**
+ * Описание модели: длинный текст сворачивается до clamp; кнопка-переключатель
+ * появляется, только если текст реально не помещается. Монтируется
+ * с key={model.id} — при смене версии состояние сбрасывается ремоунтом.
+ */
+const ModelDescription: React.FC<{ text: string }> = ({ text }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const ref = useRef<HTMLParagraphElement>(null);
+
+  // Переполнение проверяем через ResizeObserver: пересчитывается и при
+  // изменении ширины окна, когда clamp начинает/перестаёт резать текст.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      setOverflows(el.scrollHeight > el.clientHeight + 1);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section className="detail-section">
+      <h3 className="detail-section-title"><i className={`fas ${ICONS.description}`}></i> Описание</h3>
+      <p
+        ref={ref}
+        className={`model-detail-description${expanded ? '' : ' model-detail-description--clamped'}`}
+      >
+        {text}
+      </p>
+      {(overflows || expanded) && (
+        <button
+          type="button"
+          className="model-detail-description-toggle"
+          onClick={() => setExpanded(v => !v)}
+        >
+          <i className={`fas ${expanded ? ICONS.collapse : ICONS.expand}`}></i>
+          {expanded ? 'Свернуть' : 'Показать полностью'}
+        </button>
+      )}
+    </section>
+  );
+};
 
 const ModelDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -19,17 +70,27 @@ const ModelDetail: React.FC = () => {
   const { showNotification } = useNotification();
 
   const [model, setModel] = useState<MLModelVersion | null>(null);
+  // Все версии родительской модели — для переключателя в шапке.
+  const [versions, setVersions] = useState<MLModelVersion[]>([]);
   const [files, setFiles] = useState<MLModelFile[]>([]);
   const [dataset, setDataset] = useState<Dataset | null>(null);
-  const [loading, setLoading] = useState(true);
+  // loading выводится из id: пока загруженный id отстаёт от текущего
+  // (первый заход, переключение версии), показываем лоадер.
+  const [loadedId, setLoadedId] = useState<string | null>(null);
+  const loading = !!id && loadedId !== id;
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const [paramsOpen, setParamsOpen] = useState(false);
-  const [reportOpen, setReportOpen] = useState(false);
+
+  // SSE-стрим метрик живёт здесь: графикам нужны данные, а шапке — сигнал
+  // о завершении обучения. Одно соединение на страницу.
+  const metricsStream = useModelMetricsStream(id ?? '');
+  // Подтверждение удаления версии модели (модалка).
+  const [pendingDelete, setPendingDelete] = useState(false);
+  const [busy, setBusy] = useState(false);
 
   useEffect(() => {
     if (!id) return;
     let cancelled = false;
-    setLoading(true);
 
     Promise.all([
       mlModelsService.getVersion(id),
@@ -42,19 +103,58 @@ const ModelDetail: React.FC = () => {
         datasetService.getDataset(modelData.dataset_id)
           .then((ds) => { if (!cancelled) setDataset(ds); })
           .catch(() => {});
+        // Список версий не критичен для страницы: при ошибке остаёмся с бейджем.
+        mlModelsService.getVersions({ model_id: modelData.model_id })
+          .then((res) => { if (!cancelled) setVersions(res.versions); })
+          .catch(() => {});
       })
       .catch((error) => {
         if (cancelled) return;
         showNotification(error instanceof Error ? error.message : 'Не удалось загрузить модель', 'error');
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setLoadedId(id);
       });
 
     return () => { cancelled = true; };
   }, [id, showNotification]);
 
+  // Статус «обучена / не обучена» — только из реестра ml_models: metrics видит
+  // лишь ход обучения. Завершение стрима — сигнал перечитать версию из реестра,
+  // чтобы бейдж обновился без перезагрузки страницы. Статус читаем через ref:
+  // зависимость от model зациклила бы запросы, если реестр отстаёт от стрима.
+  // Ref обновляется эффектом без deps, объявленным до эффекта перечитывания, —
+  // к моменту его запуска статус всегда свежий.
+  const modelStatusRef = useRef<string | null>(null);
+  useEffect(() => {
+    modelStatusRef.current = model?.status ?? null;
+  });
+  useEffect(() => {
+    if (!id || !metricsStream.finished) return;
+    const status = modelStatusRef.current;
+    if (!status || FINAL_REGISTRY_STATUSES.includes(status)) return;
+    let cancelled = false;
+    mlModelsService.getVersion(id)
+      .then((fresh) => { if (!cancelled) setModel(fresh); })
+      .catch(() => { /* реестр недоступен — остаёмся со старым снимком */ });
+    return () => { cancelled = true; };
+  }, [id, metricsStream.finished]);
+
   const handleCopyId = useCopyToClipboard();
+
+  const handleDeleteVersion = async () => {
+    if (!model) return;
+    setPendingDelete(false);
+    try {
+      setBusy(true);
+      await mlModelsService.deleteVersion(model.id);
+      showNotification('Версия модели удалена', 'success');
+      navigate('/models');
+    } catch (error) {
+      showNotification(error instanceof Error ? error.message : 'Не удалось удалить версию', 'error');
+      setBusy(false);
+    }
+  };
 
   const handleDownload = async (file: MLModelFile) => {
     setDownloadingId(file.id);
@@ -91,6 +191,14 @@ const ModelDetail: React.FC = () => {
   }
 
   const trainParams = Object.keys(model.train_params ?? {}).length > 0;
+  const datasetVersionName = dataset?.versions.find(v => v.id === model.dataset_version_id)?.name;
+
+  const versionOptions = [...versions]
+    .sort((a, b) => b.version - a.version)
+    .map((v) => ({
+      value: v.id,
+      label: `v${v.version} · ${formatDateParts(v.created_at).date} · ${modelStatusLabel(v.status)}`,
+    }));
 
   return (
     <div className="page model-detail">
@@ -98,91 +206,122 @@ const ModelDetail: React.FC = () => {
         <i className={`fas ${ICONS.back}`}></i> К списку моделей
       </button>
 
-      <div className="model-detail-header">
-        <div className="model-detail-title">
-          <h1>{model.name}</h1>
-          <span className="model-version"><i className={`fas ${ICONS.version}`}></i> v{model.version}</span>
-          <span className={`status-badge status-${model.status}`}>{model.status}</span>
+      <header className="model-detail-header">
+        <div className="model-detail-heading">
+          <div className="model-detail-title">
+            <h1>{model.name}</h1>
+            {versionOptions.length > 1 ? (
+              <div className="model-detail-version-select">
+                <Select
+                  icon={`fas ${ICONS.version}`}
+                  ariaLabel="Версия модели"
+                  value={model.id}
+                  options={versionOptions}
+                  onChange={(versionId) => {
+                    if (versionId !== model.id) navigate(`/models/${versionId}`);
+                  }}
+                />
+              </div>
+            ) : (
+              <span className="model-version"><i className={`fas ${ICONS.version}`}></i> v{model.version}</span>
+            )}
+            <span className={statusBadgeClass(model.status)}>
+              {(model.status === 'in_progress' || model.status === 'training') && (
+                <><i className={`fas ${ICONS.loading} fa-spin`}></i>{' '}</>
+              )}
+              {modelStatusLabel(model.status)}
+            </span>
+          </div>
+          <Tooltip content="Нажмите, чтобы скопировать ID">
+            <span
+              className="model-detail-id"
+              onClick={() => handleCopyId(model.id)}
+            >
+              <i className={`fas ${ICONS.id}`}></i>{model.id}
+              <i className={`fas ${ICONS.copy} model-detail-id-copy-icon`}></i>
+            </span>
+          </Tooltip>
+        </div>
+        <div className="model-detail-actions">
           <button
             className="button secondary small"
-            onClick={() => navigate(`/models/compare?from=${model.id}`)}
+            onClick={() => navigate(`/models/compare?ids=${model.id}`)}
           >
             <i className={`fas ${ICONS.compare}`}></i> Сравнить
           </button>
-        </div>
-        <Tooltip content="Нажмите, чтобы скопировать ID">
-          <span
-            className="model-detail-id"
-            onClick={() => handleCopyId(model.id)}
+          <button
+            className="button danger model-detail-delete"
+            onClick={() => setPendingDelete(true)}
+            disabled={busy}
           >
-            <i className={`fas ${ICONS.id}`}></i>{model.id}
-            <i className={`fas ${ICONS.copy} model-detail-id-copy-icon`}></i>
-          </span>
-        </Tooltip>
-        {model.description && <p className="model-detail-description">{model.description}</p>}
-      </div>
+            <i className={`fas ${ICONS.delete}`}></i> Удалить версию
+          </button>
+        </div>
+      </header>
 
       <section className="detail-section">
         <h3 className="detail-section-title"><i className={`fas ${ICONS.info}`}></i> Общая информация</h3>
         <div className="detail-fields">
-          <div className="detail-field"><span className="detail-label">Тип</span><span>{model.model_type || '—'}</span></div>
-          <div className="detail-field"><span className="detail-label">Framework</span><span>{model.framework ?? '—'}{model.framework_version ? ` ${model.framework_version}` : ''}</span></div>
-          <div className="detail-field"><span className="detail-label">Создана</span><span>{formatDateTime(model.created_at)}</span></div>
           <div className="detail-field">
-            <span className="detail-label">Датасет</span>
+            <span className="detail-label"><i className={`fas ${ICONS.tag}`}></i> Тип</span>
+            <span>{model.model_type || '—'}</span>
+          </div>
+          <div className="detail-field">
+            <span className="detail-label"><i className={`fas ${ICONS.dateCreated}`}></i> Создана</span>
+            <span>{formatDateTime(model.created_at)}</span>
+          </div>
+          <div className="detail-field">
+            <span className="detail-label"><i className={`fas ${ICONS.framework}`}></i> Framework</span>
+            <span>{model.framework ?? '—'}{model.framework_version ? ` ${model.framework_version}` : ''}</span>
+          </div>
+          <div className="detail-field">
+            <span className="detail-label"><i className={`fas ${ICONS.dataset}`}></i> Датасет</span>
             <Tooltip content={model.dataset_id}>
               <button
                 className="detail-link"
-                onClick={() => navigate('/datasets')}
+                onClick={() => navigate(`/datasets/${model.dataset_id}`)}
               >
-                <i className={`fas ${ICONS.dataset}`}></i>
+                <i className={`fas ${ICONS.external}`}></i>
                 {dataset ? dataset.name : model.dataset_id}
               </button>
             </Tooltip>
           </div>
           <div className="detail-field">
-            <span className="detail-label">Версия датасета</span>
+            <span className="detail-label"><i className={`fas ${ICONS.version}`}></i> Версия датасета</span>
             <Tooltip content={model.dataset_version_id}>
               <button
                 className="detail-link"
-                onClick={() => navigate('/datasets')}
+                onClick={() => navigate(
+                  datasetVersionName
+                    ? `/datasets/${model.dataset_id}?version=${encodeURIComponent(datasetVersionName)}`
+                    : `/datasets/${model.dataset_id}`,
+                )}
               >
-                <i className={`fas ${ICONS.version}`}></i>
-                {dataset?.versions.find(v => v.id === model.dataset_version_id)?.name ?? model.dataset_version_id}
+                <i className={`fas ${ICONS.external}`}></i>
+                {datasetVersionName ?? model.dataset_version_id}
               </button>
             </Tooltip>
+          </div>
+          <div className="detail-field detail-field--full">
+            <span className="detail-label"><i className={`fas ${ICONS.classes}`}></i> Классы ({model.classes.length})</span>
+            {model.classes.length > 0 ? (
+              <div className="tag-list">
+                {model.classes.map((cls) => (
+                  <span key={cls} className="tag">{cls}</span>
+                ))}
+              </div>
+            ) : (
+              <span className="detail-empty">Классы не указаны.</span>
+            )}
           </div>
         </div>
       </section>
 
-      <section className="detail-section">
-        <h3 className="detail-section-title"><i className={`fas ${ICONS.classes}`}></i> Классы ({model.classes.length})</h3>
-        {model.classes.length > 0 ? (
-          <div className="tag-list">
-            {model.classes.map((cls) => (
-              <span key={cls} className="tag">{cls}</span>
-            ))}
-          </div>
-        ) : (
-          <p className="detail-empty">Классы не указаны.</p>
-        )}
-      </section>
+      {model.description && <ModelDescription key={model.id} text={model.description} />}
 
       <section className="detail-section">
         <h3 className="detail-section-title"><i className={`fas ${ICONS.metrics}`}></i> Метрики</h3>
-        <ModelMetricsCharts modelId={model.id} />
-        {model.metrics_report && (
-          <div className="metrics-report-details">
-            <div
-              className="metrics-report-summary"
-              {...getDisclosureProps(reportOpen, () => setReportOpen(o => !o))}
-            >
-              <CollapseChevron open={reportOpen} />
-              <i className={`fas ${ICONS.report}`}></i> Текстовый отчёт
-            </div>
-            {reportOpen && <pre className="detail-pre metrics-report-pre">{model.metrics_report}</pre>}
-          </div>
-        )}
+        <ModelMetricsCharts modelId={model.id} metricsReport={model.metrics_report} stream={metricsStream} />
       </section>
 
       <section className="detail-section">
@@ -236,6 +375,17 @@ const ModelDetail: React.FC = () => {
           <p className="detail-empty">У модели нет файлов весов.</p>
         )}
       </section>
+
+      <ConfirmModal
+        open={pendingDelete}
+        danger
+        title="Удалить версию модели?"
+        message={`Версия v${model.version} модели «${model.name}» будет удалена безвозвратно вместе с файлами весов.`}
+        confirmLabel="Удалить"
+        cancelLabel="Отмена"
+        onConfirm={handleDeleteVersion}
+        onCancel={() => setPendingDelete(false)}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/Models.css
+++ b/frontend/src/pages/Models.css
@@ -31,7 +31,16 @@
   color: #fff;
 }
 
-/* .filter-field — общий примитив, см. styles/components.css */
+/* Компактный вариант — для маленьких заголовков блоков (confusion matrix и т.п.) */
+.view-toggle--compact {
+  padding: 0.15rem;
+  gap: 0.15rem;
+}
+
+.view-toggle--compact .view-toggle-btn {
+  padding: 0.2rem 0.55rem;
+  font-size: 0.78rem;
+}
 
 /* ── Сетка карточек ──────────────────────────────────────────────────────────── */
 .models-grid {
@@ -118,8 +127,53 @@
 }
 
 /* ── Детальный просмотр ──────────────────────────────────────────────────────── */
+/* Шапка: заголовок и ID слева, действия справа, разделитель снизу
+   (как .dataset-detail-header на странице датасета). */
 .model-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
   margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: var(--border-subtle);
+}
+
+.model-detail-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.model-detail-heading .tooltip-trigger {
+  align-self: flex-start;
+  max-width: 100%;
+}
+
+.model-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-shrink: 0;
+}
+
+/* На узких экранах действия уходят под заголовок */
+@media (max-width: 640px) {
+  .model-detail-header {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .model-detail-actions {
+    align-self: flex-start;
+  }
+}
+
+/* Ссылки на датасет в «Общей информации» обёрнуты в Tooltip:
+   не даём обёртке растянуться на всю колонку. */
+.model-detail .detail-field .tooltip-trigger {
+  align-self: flex-start;
+  max-width: 100%;
 }
 
 .model-detail-title {
@@ -127,6 +181,22 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 0.8rem;
+}
+
+/* Select растягивается под фильтры — в шапке ему нужна компактная ширина. */
+.model-detail-version-select {
+  width: 240px;
+  max-width: 100%;
+}
+
+.model-detail-version-select .select {
+  flex: none;
+  width: 100%;
+}
+
+.model-detail-version-select .select-trigger {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
 }
 
 .model-detail-title h1 {
@@ -169,8 +239,44 @@
 }
 
 .model-detail-description {
-  margin-top: 0.5rem;
+  margin: 0;
   color: var(--color-text-secondary);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Очень длинное описание сворачиваем до нескольких строк */
+.model-detail-description--clamped {
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.model-detail-description-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+  padding: 0.25rem 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-family: var(--font-primary);
+  font-size: 0.85rem;
+  transition: color 0.15s;
+}
+
+.model-detail-description-toggle:hover {
+  color: var(--color-accent);
+}
+
+.model-detail-description-toggle i {
+  font-size: 0.7rem;
 }
 
 .detail-pre--params,
@@ -468,6 +574,20 @@
   color: var(--color-text-secondary);
 }
 
+/* Строка о сохранённых весах: эпоха чекпоинта по early-stop-метрике */
+.metrics-checkpoint-note {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.metrics-checkpoint-note i {
+  color: var(--color-accent);
+}
+
 /* Скалярные карточки для одиночных финальных значений (test) */
 .metrics-scalar-cards {
   display: flex;
@@ -477,14 +597,46 @@
 }
 
 .metrics-scalar-card {
+  position: relative;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
-  min-width: 140px;
-  padding: 0.85rem 1rem;
+  gap: 0.35rem;
+  min-width: 150px;
+  padding: 0.9rem 1.1rem;
   background: var(--color-bg-deep);
   border: var(--border-soft);
   border-radius: var(--radius-input);
+  transition: var(--transition);
+}
+
+/* Акцентная полоска слева: цвет качества метрики, иначе цвет сплита
+   (--split-color задаётся инлайн, --quality-color — модификаторами ниже) */
+.metrics-scalar-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--quality-color, var(--split-color));
+}
+
+/* Окраска по качеству результата метрики (пороги — constants/metrics.ts) */
+.metrics-scalar-card--good { --quality-color: var(--color-success); }
+.metrics-scalar-card--fair { --quality-color: var(--color-warning); }
+.metrics-scalar-card--poor { --quality-color: var(--color-danger); }
+
+.metrics-scalar-card:hover {
+  border-color: var(--color-border-strong);
+  transform: translateY(-1px);
+}
+
+.metrics-scalar-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
 }
 
 .metrics-scalar-card-name {
@@ -495,10 +647,27 @@
   color: var(--color-text-secondary);
 }
 
-.metrics-scalar-card-value {
-  font-size: 1.35rem;
+.metrics-scalar-card-name i {
+  font-size: 0.7rem;
+  opacity: 0.8;
+  margin-right: 0.15rem;
+}
+
+.metrics-scalar-card-split {
+  font-size: 0.62rem;
   font-weight: 600;
-  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-pill);
+  color: var(--split-color);
+  background: color-mix(in srgb, var(--split-color) 16%, transparent);
+}
+
+.metrics-scalar-card-value {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--quality-color, var(--color-text-primary));
   font-variant-numeric: tabular-nums;
 }
 
@@ -531,33 +700,262 @@
   color: var(--color-danger);
 }
 
-/* Training status badge */
-.metrics-status-row {
-  margin-bottom: 0.75rem;
+/* ========================
+   Общие элементы графиков (mcmp-*)
+   Родом со страницы сравнения, теперь общие для ModelMetricsCharts
+   (ModelDetail) и ModelCompareCurves: темизация recharts, легенда,
+   drag-ручка, увеличенный график в оверлее.
+   ======================== */
+
+/* Точка цвета серии (модель/выборка): маркер в тултипах, сводках и легендах. */
+.mcmp-side-dot {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  margin-right: 0.45rem;
+  vertical-align: baseline;
+  flex-shrink: 0;
 }
 
-.metrics-status-badge {
-  display: inline-flex;
+/* Темизация recharts: SVG-атрибуты не резолвят var(), поэтому цвета сетки и
+   осей задаются CSS-правилами — каскад перебивает presentation-атрибуты. */
+.mcmp-chart-themed .recharts-cartesian-grid line {
+  stroke: var(--color-border-soft);
+}
+
+.mcmp-chart-themed .recharts-cartesian-axis-line {
+  stroke: var(--color-border-soft);
+}
+
+.mcmp-chart-themed .recharts-cartesian-axis-tick-value,
+.mcmp-chart-themed .recharts-label {
+  fill: var(--color-text-secondary);
+}
+
+/* Brush увеличенного графика: фон/выделение в токенах темы. */
+.mcmp-chart-themed .recharts-brush > rect:first-of-type {
+  fill: var(--color-surface-faint);
+  stroke: var(--color-border-soft);
+}
+
+.mcmp-chart-themed .recharts-brush-slide {
+  fill: var(--color-accent-soft);
+  fill-opacity: 1;
+}
+
+/* Встроенные SVG-числа эпох у ползунков вылезают за край графика —
+   выбранный диапазон показывается подсказкой под графиком. */
+.mcmp-chart-themed .recharts-brush-texts {
+  display: none;
+}
+
+.mcmp-brush-traveller {
+  fill: var(--color-text-secondary);
+}
+
+.mcmp-curve-legend {
+  margin-left: 12px;
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.mcmp-curve-legend > span {
+  margin-right: 8px;
+  cursor: help;
+}
+
+/* Заголовок графика: имя, легенда и кнопка «развернуть» справа. */
+.mcmp-chart-title {
+  display: flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.25rem 0.65rem;
+  flex-wrap: wrap;
+  gap: 0.1rem 0;
+}
+
+.mcmp-chart-zoom {
+  margin-left: auto;
+}
+
+/* Ручка перетаскивания графика: drag начинается только с неё, чтобы не
+   мешать hover-тултипам recharts внутри блока. */
+.mcmp-chart-grip {
+  margin-right: 0.55rem;
+  color: var(--color-text-secondary);
+  opacity: 0.5;
+  cursor: grab;
+}
+
+.mcmp-chart-grip:hover {
+  opacity: 1;
+}
+
+.mcmp-chart-grip:active {
+  cursor: grabbing;
+}
+
+/* Перетаскиваемый блок: полупрозрачный с акцентной рамкой — видно, что и
+   куда встанет (порядок применяется на лету при наведении). */
+.mcmp-chart--dragging {
+  opacity: 0.45;
+  outline: 1px dashed var(--color-accent);
+  outline-offset: 2px;
   border-radius: var(--radius-input);
+}
+
+/* ---------- Увеличенный график (оверлей) ---------- */
+
+/* Паттерн overlay/pop-in — как у VersionStatsModal/ConfirmModal. */
+.mcmp-zoom-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1.5rem;
+  animation: mcmp-zoom-fade 0.15s ease;
+}
+
+.mcmp-zoom-modal {
+  background: var(--color-bg-secondary);
   border: var(--border-soft);
-  font-size: 0.8rem;
+  border-radius: 20px;
+  box-shadow: var(--shadow-md);
+  width: min(1280px, 100%);
+  padding: 1.1rem 1.35rem 1.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  animation: mcmp-zoom-pop 0.18s ease;
+}
+
+.mcmp-zoom-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.mcmp-zoom-head .metrics-chart-title {
+  flex: 1;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+/* Высота увеличенного графика: почти вся высота окна, но с потолком,
+   чтобы на больших мониторах кривые не растягивались до нечитаемости. */
+.mcmp-zoom-chart {
+  height: min(68vh, 640px);
+}
+
+/* Сводка по кривым в оверлее: карточка на серию — лучшее значение (с эпохой),
+   финал и эпоха сохранённых весов. Сетка, чтобы на широком экране карточки
+   стояли ровными колонками, а не текли строкой. */
+.mcmp-zoom-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.6rem;
+  font-size: 0.78rem;
   color: var(--color-text-secondary);
-  background: var(--color-bg-deep);
+  font-variant-numeric: tabular-nums;
 }
 
-.metrics-status-badge--completed {
-  color: var(--color-success);
+.mcmp-zoom-stat {
+  background: var(--color-surface-faint);
+  border: var(--border-subtle);
+  border-left: 3px solid; /* цвет серии — inline style */
+  border-radius: var(--radius-input);
+  padding: 0.5rem 0.85rem 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
 }
 
-.metrics-status-badge--failed {
-  color: var(--color-danger);
+.mcmp-zoom-stat-label {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text-primary);
 }
 
-.metrics-status-badge--cancelled {
+/* Значения карточки: мини-колонки «подпись над числом». */
+.mcmp-zoom-stat-values {
+  display: flex;
+  gap: 1.4rem;
+}
+
+.mcmp-zoom-stat-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.mcmp-zoom-stat-key {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.8;
+}
+
+.mcmp-zoom-stat-sub {
+  font-size: 0.7rem;
+  opacity: 0.8;
+}
+
+.mcmp-zoom-stat b {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-text-primary);
+}
+
+/* Tooltip увеличенного графика: маркеры цвета серий, значения по убыванию. */
+.mcmp-tooltip {
+  background: var(--color-bg-secondary);
+  border: var(--border-soft);
+  border-radius: var(--radius-input);
+  box-shadow: var(--shadow-md);
+  padding: 0.5rem 0.7rem;
+  font-size: 0.78rem;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.mcmp-tooltip-label {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.mcmp-tooltip-row {
+  margin: 0.15rem 0 0;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.mcmp-tooltip-name {
   color: var(--color-text-secondary);
+  margin-right: 0.3rem;
+}
+
+/* Подсказка под графиком: как пользоваться brush'ем. */
+.mcmp-zoom-note {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--color-text-secondary);
+  opacity: 0.85;
+}
+
+@keyframes mcmp-zoom-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes mcmp-zoom-pop {
+  from { opacity: 0; transform: scale(0.97); }
+  to { opacity: 1; transform: scale(1); }
 }
 
 /* Class report: confusion matrix + per-class metrics */
@@ -611,6 +1009,42 @@
 .class-report-corner {
   font-weight: 400;
   font-size: 0.72rem;
+}
+
+/* Шапка блока таблицы: заголовок слева, toggle counts/% справа */
+.class-report-block-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.class-report-block-head .metrics-chart-title {
+  margin: 0;
+}
+
+/* Итоговые строки (macro avg, accuracy) — как footer classification_report */
+.class-report-table tfoot tr:first-child th,
+.class-report-table tfoot tr:first-child td {
+  border-top: 2px solid rgba(255, 255, 255, 0.14);
+}
+
+.class-report-table tfoot th {
+  color: var(--color-text-primary);
+}
+
+/* Окраска значений по порогам качества метрики (см. constants/metrics.ts) */
+.class-report-score--good {
+  color: var(--color-success);
+}
+
+.class-report-score--fair {
+  color: var(--color-warning);
+}
+
+.class-report-score--poor {
+  color: var(--color-danger);
 }
 
 /* ========================

--- a/frontend/src/services/metricsService.ts
+++ b/frontend/src/services/metricsService.ts
@@ -14,9 +14,21 @@ export interface MetricData {
   timestamps?: string[];
 }
 
+export interface CheckpointInfo {
+  // Эпоха, веса которой сохранены (нумерация с 1).
+  epoch: number;
+  // Early-stop-метрика выбора лучшей эпохи (чистое имя, val-выборка).
+  metric: string;
+  // Значение метрики на эпохе чекпоинта; null — улучшение не фиксировалось,
+  // сохранены веса финальной эпохи.
+  value: number | null;
+}
+
 export interface ModelMetrics {
   model_id: string;
   status?: TrainingStatus | null;
+  // null у моделей, обученных до ввода чекпоинтов.
+  checkpoint?: CheckpointInfo | null;
   train: MetricData[];
   val: MetricData[];
   test: MetricData[];

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -32,6 +32,10 @@ export const pluralRu = (n: number, [one, few, many]: [string, string, string]):
   return many;
 };
 
+// Значение метрики обучения: целые — как есть, дробные — 4 знака.
+export const formatMetricValue = (v: number): string =>
+  Number.isInteger(v) ? String(v) : v.toFixed(4);
+
 // Форматирование длительности в мс/с (>= 1 с показываем в секундах).
 export const formatDuration = (ms: number): string =>
   ms >= 1000 ? `${(ms / 1000).toFixed(2)} с` : `${ms.toFixed(0)} мс`;


### PR DESCRIPTION
## 📌 Что было сделано?

**Страница модели**
- Новая шапка: переключатель версий, статус из реестра, действия, сворачиваемое длинное описание (`ModelDetail.tsx`, `model-detail-header`, `ModelDescription`)
- Статус «обучена/не обучена» берётся только из реестра ml_models; завершение SSE-стрима — сигнал перечитать версию без перезагрузки страницы
- Ссылка на датасет ведёт с предзаполненным фильтром версии (`DatasetDetail`, `?version=`)

**Графики метрик**
- Переиспользуемые компоненты кривых обучения: сетка графиков, метка чекпоинта, увеличение в оверлей с brush-зумом и сводкой по сериям (`curveChart.tsx`, `curveChartData.ts`, `CurveZoomOverlay`)
- Перетаскивание графиков для смены порядка (`useDragReorder`, `dragHandle`)
- Скалярные карточки финальных значений с иконками и окраской по качеству метрики (`metrics-scalar-card`, `constants/metrics.ts`)
- Строка о сохранённых весах: эпоха чекпоинта по early-stop-метрике (`metrics-checkpoint-note`, `CheckpointInfo` в `metricsService`)

**Class report**
- Подсказки для каждой таблицы и колонки (`InfoHint` в `Tooltip.tsx`), переключатель counts/% у confusion matrix, окраска значений по порогам качества

**Хуки**
- `useModelMetricsStream`: сброс данных при смене модели синхронно в рендере, 404 трактуется как «метрик нет», а не ошибка; убран дублирующий `status`
