### PR TITLE
Отображение процесса обучения на странице модели

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -3,3 +3,4 @@ VITE_AGENT_HISTORY=localhost:6410
 VITE_AGENTS=localhost:6400
 VITE_ML_MODELS=localhost:6300
 VITE_METRICS=localhost:6310
+VITE_TASKER=localhost:6110

--- a/frontend/src/components/models/TrainingTaskProgress.tsx
+++ b/frontend/src/components/models/TrainingTaskProgress.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import { taskerService } from '../../services/taskerService';
+import { useNotification } from '../../contexts/NotificationContext';
+import { usePolling } from '../../hooks/usePolling';
+import ConfirmModal from '../common/ConfirmModal';
+import type { TrainingTask } from '../../types/tasks';
+import { formatDateTime } from '../../utils/format';
+import { ICONS } from '../../constants/icons';
+import { statusBadgeClass, POLL_INTERVAL_TASK_MS } from '../../constants';
+
+// Статусы, в которых задача ещё живая: опрашиваем и даём отменить.
+const ACTIVE_TASK_STATUSES = ['waiting', 'running'];
+
+// Человекочитаемые статусы задачи; для неизвестных — описание из tasker.
+const TASK_STATUS_LABELS: Record<string, string> = {
+  waiting: 'В очереди',
+  running: 'Обучается',
+  completed: 'Завершена',
+  failed: 'Ошибка',
+  cancelled: 'Отменена',
+};
+
+const taskStatusLabel = (task: TrainingTask): string =>
+  TASK_STATUS_LABELS[task.status] ?? task.status_description ?? task.status;
+
+interface TrainingTaskProgressProps {
+  modelId: string;
+}
+
+/**
+ * Виджет хода обучения на странице модели: прогресс задачи из tasker
+ * (проценты, статусная строка) с возможностью отмены. Самодостаточен:
+ * сам опрашивает tasker и не рендерится, если показывать нечего
+ * (задач нет или последняя завершилась успешно — метрики уже ниже).
+ */
+const TrainingTaskProgress: React.FC<TrainingTaskProgressProps> = ({ modelId }) => {
+  const { showNotification } = useNotification();
+  const [pendingCancel, setPendingCancel] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  // Берём последнюю задачу модели: при переобучении задач может быть несколько.
+  const { data: task, refetch } = usePolling<TrainingTask | null>(
+    async () => {
+      const { tasks } = await taskerService.getTasks({ model_id: modelId });
+      if (tasks.length === 0) return null;
+      return [...tasks].sort((a, b) => b.created_at.localeCompare(a.created_at))[0];
+    },
+    {
+      intervalMs: POLL_INTERVAL_TASK_MS,
+      // Финальный статус — опрос больше не нужен; tasker недоступен — не
+      // долбим его, страница модели живёт без виджета.
+      continueWhile: (t) => t !== null && ACTIVE_TASK_STATUSES.includes(t.status),
+      deps: [modelId],
+    },
+  );
+
+  const handleCancel = async () => {
+    if (!task) return;
+    setPendingCancel(false);
+    try {
+      setCancelling(true);
+      await taskerService.cancelTask(task.id);
+      showNotification('Обучение будет остановлено на границе эпохи', 'success');
+      refetch();
+    } catch (error) {
+      showNotification(error instanceof Error ? error.message : 'Не удалось отменить задачу', 'error');
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  // Нечего показывать: задач нет либо последняя завершилась успешно.
+  // Проверка model_id отсекает устаревшие данные прошлой версии: при переключении
+  // версии usePolling отдаёт прежний результат до первого ответа нового опроса.
+  if (!task || task.model_id !== modelId || task.status === 'completed') return null;
+
+  const active = ACTIVE_TASK_STATUSES.includes(task.status);
+  const percent = Math.min(100, Math.max(0, task.percentages));
+
+  return (
+    <section className="detail-section">
+      <h3 className="detail-section-title"><i className={`fas ${ICONS.task}`}></i> Процесс обучения</h3>
+
+      <div className="training-task">
+        <div className="training-task-header">
+          <span className={statusBadgeClass(task.status)}>
+            {active && <><i className={`fas ${ICONS.loading} fa-spin`}></i>{' '}</>}
+            {taskStatusLabel(task)}
+          </span>
+          {task.status_info && <span className="training-task-info">{task.status_info}</span>}
+          {active && (
+            <button
+              className="button danger small training-task-cancel"
+              onClick={() => setPendingCancel(true)}
+              disabled={cancelling}
+            >
+              <i className={`fas ${ICONS.cancelled}`}></i>
+              {cancelling ? 'Отмена…' : 'Отменить обучение'}
+            </button>
+          )}
+        </div>
+
+        {active && (
+          <div className="training-task-progress">
+            <div
+              className="progress-bar"
+              role="progressbar"
+              aria-valuenow={percent}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
+              <div className="progress-bar-fill" style={{ width: `${percent}%` }} />
+            </div>
+            <span className="training-task-percent">{percent}%</span>
+          </div>
+        )}
+
+        {task.status === 'failed' && task.error_message && (
+          <p className="training-task-error">
+            <i className={`fas ${ICONS.error}`}></i> {task.error_message}
+          </p>
+        )}
+
+        <div className="training-task-meta">
+          {task.started_at && <span><i className={`fas ${ICONS.duration}`}></i> Старт: {formatDateTime(task.started_at)}</span>}
+          {task.completed_at && <span>Завершение: {formatDateTime(task.completed_at)}</span>}
+        </div>
+      </div>
+
+      <ConfirmModal
+        open={pendingCancel}
+        danger
+        title="Отменить обучение?"
+        message={`Задача «${task.name}» будет отменена. Воркер остановит обучение на границе эпохи.`}
+        confirmLabel="Отменить обучение"
+        cancelLabel="Назад"
+        onConfirm={handleCancel}
+        onCancel={() => setPendingCancel(false)}
+      />
+    </section>
+  );
+};
+
+export default TrainingTaskProgress;

--- a/frontend/src/components/models/index.ts
+++ b/frontend/src/components/models/index.ts
@@ -8,3 +8,4 @@ export { default as ModelCompareCurves } from './ModelCompareCurves';
 export { default as ModelCompareMetaDiff } from './ModelCompareMetaDiff';
 export { default as ModelCompareClassReport } from './ModelCompareClassReport';
 export { default as CompareDeltaChip } from './CompareDeltaChip';
+export { default as TrainingTaskProgress } from './TrainingTaskProgress';

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -6,6 +6,9 @@ export const MODELS_PAGE_SIZE = 12;
 // Интервал опроса прогресса активной дискуссии (meta и лента сообщений).
 export const POLL_INTERVAL_DISCUSSION_MS = 3000;
 
+// Интервал опроса задачи обучения в tasker (виджет прогресса на странице модели).
+export const POLL_INTERVAL_TASK_MS = 3000;
+
 // Человекочитаемые статусы версии модели. Источник статуса — только реестр
 // ml_models; справочник значений отдаёт GET /info/models/status.
 export const MODEL_STATUS_LABELS: Record<string, string> = {

--- a/frontend/src/pages/ModelDetail.tsx
+++ b/frontend/src/pages/ModelDetail.tsx
@@ -11,7 +11,7 @@ import { CollapseChevron, getDisclosureProps } from '../components/common/Collap
 import ConfirmModal from '../components/common/ConfirmModal';
 import { Tooltip } from '../components/common/Tooltip';
 import Select from '../components/common/Select';
-import { ModelMetricsCharts } from '../components/models';
+import { ModelMetricsCharts, TrainingTaskProgress } from '../components/models';
 import { ICONS } from '../constants/icons';
 import { modelStatusLabel, statusBadgeClass } from '../constants';
 import './Models.css';
@@ -318,6 +318,8 @@ const ModelDetail: React.FC = () => {
       </section>
 
       {model.description && <ModelDescription key={model.id} text={model.description} />}
+
+      <TrainingTaskProgress modelId={model.id} />
 
       <section className="detail-section">
         <h3 className="detail-section-title"><i className={`fas ${ICONS.metrics}`}></i> Метрики</h3>

--- a/frontend/src/services/taskerService.ts
+++ b/frontend/src/services/taskerService.ts
@@ -1,0 +1,32 @@
+import type { TrainingTasks, TasksQuery } from '../types/tasks';
+import { handleResponse, serviceUrl } from './http';
+
+// Базовый URL сервиса задач берётся из VITE_TASKER, по умолчанию localhost:6110.
+const TASKER_URL = serviceUrl(import.meta.env.VITE_TASKER, 'localhost:6110');
+
+/**
+ * Сервис задач обучения: просмотр прогресса и отмена.
+ */
+export const taskerService = {
+  /**
+   * Получить задачи обучения с фильтрами.
+   * GET /tasks?status&model_id
+   */
+  async getTasks(query: TasksQuery = {}): Promise<TrainingTasks> {
+    const url = new URL(`${TASKER_URL}/tasks`);
+    if (query.status) url.searchParams.append('status', query.status);
+    if (query.model_id) url.searchParams.append('model_id', query.model_id);
+    const response = await fetch(url.toString());
+    return handleResponse<TrainingTasks>(response);
+  },
+
+  /**
+   * Отменить задачу (только waiting/running); воркер остановит обучение
+   * на границе эпохи.
+   * POST /tasks/{taskId}/cancel
+   */
+  async cancelTask(taskId: string): Promise<void> {
+    const response = await fetch(`${TASKER_URL}/tasks/${taskId}/cancel`, { method: 'POST' });
+    await handleResponse<unknown>(response);
+  },
+};

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -255,9 +255,15 @@ button:disabled,
 
 .status-training,
 .status-in-progress,
+.status-running,
 .status-active {
   background: var(--color-info-soft);
   color: var(--color-info);
+}
+
+.status-waiting {
+  background: var(--color-surface-faint);
+  color: var(--color-text-secondary);
 }
 
 .status-failed,
@@ -269,6 +275,73 @@ button:disabled,
 .status-cancelled {
   background: var(--color-surface-faint);
   color: var(--color-text-secondary);
+}
+
+/* ── Прогресс задачи обучения ────────────────────────────────────────────────── */
+.progress-bar {
+  flex: 1;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-faint);
+  border: var(--border-subtle);
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: var(--color-info);
+  transition: width 0.6s ease;
+}
+
+.training-task {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.training-task-header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.training-task-info {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.training-task-cancel {
+  margin-left: auto;
+}
+
+.training-task-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.training-task-percent {
+  min-width: 3rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.training-task-error {
+  margin: 0;
+  color: var(--color-danger);
+  font-size: 0.9rem;
+}
+
+.training-task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
 }
 
 /* ── Теги / чипы ─────────────────────────────────────────────────────────────── */

--- a/frontend/src/types/tasks.ts
+++ b/frontend/src/types/tasks.ts
@@ -1,0 +1,31 @@
+// Типы сервиса задач обучения (tasker, порт 6110).
+
+// Статусы задачи: waiting | running | completed | failed | cancelled.
+export type TrainingTaskStatus = string;
+
+export interface TrainingTask {
+  id: string;
+  name: string;
+  model_id: string;
+  discussion_id: string | null;
+  agent_respons_ids: string[];
+  status_id: number;
+  status: TrainingTaskStatus;
+  status_description: string;
+  percentages: number;
+  status_info: string | null;
+  error_message: string | null;
+  created_at: string;
+  started_at: string | null;
+  updated_at: string | null;
+  completed_at: string | null;
+}
+
+export interface TrainingTasks {
+  tasks: TrainingTask[];
+}
+
+export interface TasksQuery {
+  status?: string;
+  model_id?: string;
+}

--- a/services/tasker/app/api/routers/task.py
+++ b/services/tasker/app/api/routers/task.py
@@ -63,12 +63,13 @@ async def create_task(
 )
 async def get_tasks(
     status_filter: str | None = Query(None, alias="status", description="Фильтр по статусу задачи"),
+    model_id: str | None = Query(None, description="Фильтр по ID модели"),
     manager: TrainingTaskManager = Depends(get_training_task_manager)
 ):
-    if status_filter:
-        tasks = manager.get_task_with_status(status_filter)
-    else:
-        tasks = manager.get_tasks()
+    if model_id:
+        valid_uuid(model_id, on_error=True)
+
+    tasks = manager.get_tasks(status=status_filter, model_id=model_id)
 
     return TasksResponse(
         tasks=[

--- a/services/tasker/app/core/train_models_tasks.py
+++ b/services/tasker/app/core/train_models_tasks.py
@@ -153,17 +153,30 @@ class TrainingTaskManager:
             return dict(row) if row is not None else None
 
     def get_tasks(
-            self
+            self,
+            status: str | None = None,
+            model_id: str | None = None
     ) -> List[Dict]:
-        """Получить информацию о задачах"""
+        """Получить информацию о задачах (с опциональными фильтрами)"""
+        conditions = []
+        params: list[Any] = []
+        if status:
+            conditions.append("s.status = %s")
+            params.append(status)
+        if model_id:
+            conditions.append("t.model_id = %s")
+            params.append(model_id)
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         query = f"""
             SELECT {TASK_FIELDS}
             FROM {self._table} t
             LEFT JOIN {self._status_table} s ON t.status_id = s.id
+            {where}
             ORDER BY t.created_at ASC
         """
         with self.db.session() as db:
-            rows = db.fetch_all(query)
+            rows = db.fetch_all(query, tuple(params) if params else None)
             return [dict(row) for row in rows]
 
     def get_status_values(self) -> List[Dict[str, Any]]:
@@ -174,22 +187,6 @@ class TrainingTaskManager:
         """
         with self.db.session() as db:
             rows = db.fetch_all(query)
-            return [dict(row) for row in rows]
-
-    def get_task_with_status(
-        self,
-        status: str
-    ) -> List[Dict]:
-        """Получить задачи c заданным статусом"""
-        query = f"""
-            SELECT {TASK_FIELDS}
-            FROM {self._table} t
-            LEFT JOIN {self._status_table} s ON t.status_id = s.id
-            WHERE s.status = %s
-            ORDER BY t.created_at ASC
-        """
-        with self.db.session() as db:
-            rows = db.fetch_all(query, (status,))
             return [dict(row) for row in rows]
 
     def get_next_task(self) -> Dict[str, Any] | None:


### PR DESCRIPTION
## 📌 Что было сделано?

- **tasker**: фильтр по модели в списке задач (`GET /tasks?model_id=`, валидация UUID; объединённые фильтры в `TrainingTaskManager.get_tasks`, удалён дублирующий `get_task_with_status`)
- **frontend**: клиент сервиса задач (`taskerService`, типы `TrainingTask`, переменная `VITE_TASKER`, константа `POLL_INTERVAL_TASK_MS`)
- **frontend**: виджет хода обучения на странице модели (`TrainingTaskProgress`): progress bar с процентами и статусной строкой, опрос tasker раз в 3 секунды с остановкой на финальном статусе, отмена обучения через `ConfirmModal` (`POST /tasks/{id}/cancel`), вывод ошибки при `failed`
- **frontend**: стили progress bar и бейджи статусов `running`/`waiting` (`components.css`)