### PR TITLE
Trainer/feat/weights predownload

### DIFF
--- a/.env
+++ b/.env
@@ -33,6 +33,10 @@ TASKER_POSTGRES_PASSWORD=060720
 # - port:62xx 
 
 TRAINER_SERVICE_PORT=6200
+## Таймаут (сек) на скачивание весов pretrained-моделей с Hugging Face Hub
+HF_HUB_DOWNLOAD_TIMEOUT=30
+## Токен Hugging Face — нужен только для gated-моделей
+# HF_TOKEN=
 
 # =================================================
 # Порты сервисов отвечающих за работу с ML моделями

--- a/db/hf_cache/.gitignore
+++ b/db/hf_cache/.gitignore
@@ -1,0 +1,3 @@
+*
+!README.md
+!.gitignore

--- a/db/hf_cache/README.md
+++ b/db/hf_cache/README.md
@@ -1,0 +1,9 @@
+# hf_cache
+
+Кэш весов pretrained-моделей для сервиса trainer (bind-mount в `/app/hf_cache`).
+
+- `huggingface/` - кэш `huggingface_hub` (`HF_HOME`), сюда timm качает веса с HF Hub.
+- `torch/` - кэш `torch.hub` (`TORCH_HOME`) для legacy-моделей timm.
+
+Содержимое не коммитится (см. `.gitignore`): веса качаются один раз и переживают пересоздание
+контейнера. Каталог создаётся контейнером под root - застрявшие `*.incomplete` чистить через контейнер.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,7 +66,10 @@ services:
 
   trainer:
     volumes:
-      # ./db/datasets_storage:/app/datasets наследуется из базового файла
+      # Compose не мержит списки volumes — override заменяет их целиком, поэтому
+      # маунты из базового файла (datasets, hf_cache) перечислены здесь явно.
+      - ./db/datasets_storage:/app/datasets
+      - ./db/hf_cache:/app/hf_cache
       - ./services/trainer:/app
 
   # =============================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,7 @@ services:
               capabilities: [gpu]
     volumes:
       - ./db/datasets_storage:/app/datasets
+      - ./db/hf_cache:/app/hf_cache        # кэш весов pretrained-моделей (HF Hub + torch.hub)
     ports:
       - "${TRAINER_SERVICE_PORT}:${TRAINER_SERVICE_PORT}"
     environment:
@@ -185,6 +186,13 @@ services:
       - TASKER_DOMAIN=tasker:${TASKER_PORT}
       - METRICS_DOMAIN=metrics:${METRICS_SERVICE_PORT}
       - ML_MODELS_DOMAIN=ml_models:${ML_MODELS_SERVICE_PORT}
+      - HF_HOME=/app/hf_cache/huggingface
+      - TORCH_HOME=/app/hf_cache/torch
+      - HF_HUB_DOWNLOAD_TIMEOUT=${HF_HUB_DOWNLOAD_TIMEOUT:-30}
+      - HF_TOKEN=${HF_TOKEN:-}
+      # Xet-бэкенд (hf_xet) виснет без маршрута к cas-server.xethub.hf.co —
+      # форсим классический HTTP-путь, он уважает HF_HUB_DOWNLOAD_TIMEOUT и докачку.
+      - HF_HUB_DISABLE_XET=1
     depends_on:
       metrics:
         condition: service_healthy

--- a/services/trainer/README.md
+++ b/services/trainer/README.md
@@ -71,13 +71,17 @@ CMD ["python", "main.py"]
 
 Загружаются через `dotenv` из `.env`. Источник - [app/config/__init__.py](app/config/__init__.py).
 
-| Переменная              | Назначение                                  | По умолчанию       |
-|-------------------------|---------------------------------------------|--------------------|
-| `HF_TOKEN`              | токен Hugging Face для pretrained-весов timm | - (warning в логах) |
-| `TASKER_DOMAIN`         | host:port сервиса tasker                    | `localhost:6110`   |
-| `ML_MODELS_DOMAIN`      | host:port сервиса ml_models                 | `localhost:6300`   |
-| `METRICS_DOMAIN`        | host:port сервиса metrics                   | `localhost:6310`   |
-| `TRAINER_SERVICE_PORT`  | порт HTTP API trainer                       | `6200`             |
+| Переменная                 | Назначение                                  | По умолчанию       |
+|----------------------------|---------------------------------------------|--------------------|
+| `HF_TOKEN`                 | токен Hugging Face для pretrained-весов timm (нужен для gated-моделей) | - (warning в логах) |
+| `HF_HOME`                  | кэш весов huggingface_hub (в Docker - bind-mount `./db/hf_cache`) | `~/.cache/huggingface` |
+| `TORCH_HOME`               | кэш весов torch.hub (legacy-модели timm)    | `~/.cache/torch`   |
+| `HF_HUB_DOWNLOAD_TIMEOUT`  | таймаут (сек) на скачивание весов с HF Hub  | `30`               |
+| `HF_HUB_DISABLE_XET`       | `1` - отключить Xet-бэкенд (см. «Загрузка pretrained-весов») | `1` (в compose)    |
+| `TASKER_DOMAIN`            | host:port сервиса tasker                    | `localhost:6110`   |
+| `ML_MODELS_DOMAIN`         | host:port сервиса ml_models                 | `localhost:6300`   |
+| `METRICS_DOMAIN`           | host:port сервиса metrics                   | `localhost:6310`   |
+| `TRAINER_SERVICE_PORT`     | порт HTTP API trainer                       | `6200`             |
 
 ## HTTP API
 
@@ -148,7 +152,7 @@ optimizer / scheduler / метрик / трансформаций + доступ
 
 | Прогресс | Этап |
 |----------|------|
-| 0–19     | подготовка: `setup_device` → `create_dataloaders` (ImageFolder train/val/test) → `get_model` (timm) → `MetricesClient` → сборка `Trainer` |
+| 0–19     | подготовка: `setup_device` → `create_dataloaders` (ImageFolder train/val/test) → **pre-download весов** (если `pretrained`, этап 6–8) → `get_model` (timm) → `MetricesClient` → сборка `Trainer` |
 | 20–80    | `Trainer.train()` - цикл эпох: forward/backward, AMP (GPU), grad clipping, шаг scheduler, метрики, early stop, чекпоинт лучшей эпохи |
 | -        | восстановление лучших весов из чекпоинта → прогон на test → `send_checkpoint_info` в metrics |
 | 81–95    | экспорт в ONNX (`save_model_to_onnx`, классы в metadata) → upload в ml_models → удаление чекпоинта |
@@ -156,6 +160,31 @@ optimizer / scheduler / метрик / трансформаций + доступ
 
 Класс `Trainer` - [app/core/trainer/train_model.py](app/core/trainer/train_model.py).
 Синхронная часть обучения выполняется в `asyncio.to_thread`, чтобы воркер мог проверять отмену.
+
+## Загрузка pretrained-весов
+
+При `model_params.pretrained = true` веса скачиваются с Hugging Face Hub. Скачивание вынесено в
+**отдельный этап pre-download** (прогресс 6–8) ДО `get_model`
+([app/core/models/downloader.py](app/core/models/downloader.py)::`predownload_weights`), после чего
+`timm.create_model(pretrained=True)` берёт веса из кэша мгновенно. Зачем так:
+
+- **Видимый прогресс.** Раньше между «Загрузка модели...» и «модель загружена» была тишина, и было
+  непонятно, идёт ли скачивание или всё зависло. Теперь `_LoggingTqdm` пишет в логи строки вида
+  `Скачивание весов: 49% (6.1/12.3 МБ)`, а в `status_info` задачи идёт «Скачивание весов модели...».
+- **Кэш на volume.** `HF_HOME` / `TORCH_HOME` указывают в bind-mount `./db/hf_cache`. Без него веса
+  качались в эфемерный слой контейнера и скачивались **заново при каждом пересоздании**; теперь модель
+  качается один раз и переживает рестарты.
+- **Отключённый Xet (`HF_HUB_DISABLE_XET=1`).** По умолчанию `huggingface_hub` качает через Xet-бэкенд
+  (`hf_xet`, ходит на `cas-server.xethub.hf.co`). В нашем окружении этот хост недоступен, и скачивание
+  **виснет без обрыва** (это и был «бесконечный цикл») - при этом обычный `huggingface.co` доступен.
+  Флаг форсит классический HTTP-путь, который уважает `HF_HUB_DOWNLOAD_TIMEOUT` и умеет докачку (resume)
+  после read-timeout. Если на другой машине Xet работает - флаг можно убрать (Xet быстрее).
+- **Fallback.** Модель не на HF Hub (legacy torch.hub) → pre-download пропускается, `get_model` качает
+  её сам в `TORCH_HOME`. Сетевая ошибка/таймаут → исключение пробрасывается, задача уходит в `failed`
+  (через воркер), а не висит вечно.
+
+Тест: [tests/test_predownload.py](tests/test_predownload.py) (запуск в контейнере
+`python -m tests.test_predownload`, модель переопределяется через env `HF_TEST_MODEL`).
 
 ## Жизненный цикл задачи и модели
 
@@ -210,7 +239,11 @@ optimizer / scheduler / метрик / трансформаций + доступ
 ## Отладка
 
 - **Логи**: `app/logs/app_json.log`, уровень `DEBUG` ([app/logs/config.py](app/logs/config.py)).
-- **Нет `HF_TOKEN`** → warning в логах, pretrained-веса timm могут не скачаться.
+- **Нет `HF_TOKEN`** → warning в логах, pretrained-веса timm могут не скачаться (gated-модели).
+- **Скачивание весов «зависло»** → почти всегда Xet-бэкенд: проверь, что выставлен `HF_HUB_DISABLE_XET=1`
+  (см. «Загрузка pretrained-весов»). В логах ищи `Скачивание весов: N%` - если их нет и висит на
+  «Скачивание весов модели...», значит соединение не идёт. Кэш в `db/hf_cache` создаётся под root -
+  чистить застрявшие `*.incomplete` через контейнер, не с хоста.
 - **Сервис недоступен на старте** → `check_services` пометит его `unhealthy` в `/info/health`.
 - **Нет папки датасета** (`datasets/{dataset_id}/{version_id}/...`) → ошибка при `create_dataloaders`;
   путь сейчас относительный - запускать из корня сервиса.
@@ -231,7 +264,7 @@ app/
 │   ├── __init__.py    training_model() - оркестратор
 │   ├── worker.py      to_work() - воркер-цикл
 │   ├── trainer/       класс Trainer (цикл эпох, AMP, early stop, чекпоинт)
-│   ├── models/        get_model (timm)
+│   ├── models/        get_model (timm), predownload_weights (downloader.py - кэш/прогресс весов)
 │   ├── datas/         create_dataloaders, ALLOWED_TRANSFORMS
 │   └── utils/         setup_device, validate_task_params, save_model_to_onnx
 ├── service/           HTTP-клиенты: tasker / ml_models / metrices

--- a/services/trainer/app/core/__init__.py
+++ b/services/trainer/app/core/__init__.py
@@ -6,7 +6,7 @@ from app.logs import get_logger
 
 from .utils.save_model import save_model_to_onnx
 from .datas import create_dataloaders
-from .models import get_model
+from .models import get_model, predownload_weights
 from .trainer import Trainer
 from .utils import setup_device
 
@@ -18,7 +18,9 @@ PROGRESS_DEVICE_CHECK = 1
 PROGRESS_DEVICE_READY = 2
 PROGRESS_DATA_LOADING = 3
 PROGRESS_DATA_READY = 5
-PROGRESS_MODEL_LOADING = 6
+PROGRESS_WEIGHTS_DOWNLOAD = 6
+PROGRESS_WEIGHTS_READY = 8
+PROGRESS_MODEL_LOADING = 9
 PROGRESS_MODEL_READY = 10
 PROGRESS_METRICS_SETUP = 11
 PROGRESS_METRICS_READY = 12
@@ -48,7 +50,16 @@ async def training_model(config: TaskParams, model_id: str):
     train_loader, val_loader, test_loader, classes = create_dataloaders(config.data_loader_params)
     await tasker_service.update_status_task(percentages=PROGRESS_DATA_READY, status_info="Данные загружены.")
 
-    # Загружаем модель
+    # Предзагрузка весов pretrained-модели в кэш (отдельный этап с видимым прогрессом)
+    if config.model_params.pretrained:
+        await predownload_weights(
+            model_name=config.model_params.type,
+            tasker_service=tasker_service,
+            progress_start=PROGRESS_WEIGHTS_DOWNLOAD,
+            progress_end=PROGRESS_WEIGHTS_READY,
+        )
+
+    # Загружаем модель (веса берутся из кэша мгновенно)
     await tasker_service.update_status_task(percentages=PROGRESS_MODEL_LOADING, status_info="Загрузка модели...")
     model = get_model(
         config.model_params,

--- a/services/trainer/app/core/models/__init__.py
+++ b/services/trainer/app/core/models/__init__.py
@@ -1,3 +1,4 @@
 from .factory import get_model, get_models_type_name
+from .downloader import predownload_weights
 
-__all__ = ['get_model', 'get_models_type_name']
+__all__ = ['get_model', 'get_models_type_name', 'predownload_weights']

--- a/services/trainer/app/core/models/downloader.py
+++ b/services/trainer/app/core/models/downloader.py
@@ -1,0 +1,121 @@
+import asyncio
+import inspect
+import time
+from typing import Tuple
+
+import timm
+from huggingface_hub import snapshot_download
+from tqdm import tqdm as _std_tqdm
+
+from app.logs import get_logger
+
+logger = get_logger(__name__)
+
+
+class _LoggingTqdm(_std_tqdm):
+    """tqdm, который вместо прогресс-бара пишет прогресс в логгер сервиса.
+
+    В non-TTY контейнере обычный прогресс-бар теряется, поэтому пишем % и МБ
+    в логи с throttling: не чаще раза в _MIN_INTERVAL секунд или каждые _MIN_STEP %.
+    """
+
+    _MIN_INTERVAL = 2.0   # секунд между лог-сообщениями
+    _MIN_STEP = 10        # процентов
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._last_log_t = 0.0
+        self._last_log_pct = -100
+
+    def update(self, n=1):
+        super().update(n)
+        if not self.total:
+            return
+        pct = int(self.n / self.total * 100)
+        now = time.monotonic()
+        if (
+            now - self._last_log_t >= self._MIN_INTERVAL
+            or pct - self._last_log_pct >= self._MIN_STEP
+            or pct >= 100
+        ):
+            mb = self.n / 1024 / 1024
+            total_mb = self.total / 1024 / 1024
+            logger.info(f"Скачивание весов: {pct}% ({mb:.1f}/{total_mb:.1f} МБ)")
+            self._last_log_t = now
+            self._last_log_pct = pct
+
+
+def resolve_hf_repo(model_name: str) -> Tuple[str | None, str | None]:
+    """Возвращает (hf_hub_id, hf_hub_filename) для timm-модели.
+
+    Если модель не размещена на HF Hub (legacy torch.hub) или конфиг недоступен —
+    возвращает (None, None): это сигнал пропустить pre-download.
+    """
+    try:
+        cfg = timm.get_pretrained_cfg(model_name)
+    except Exception as e:
+        logger.warning(f"Не удалось получить pretrained_cfg для {model_name}: {e!r}")
+        return None, None
+
+    hf_hub_id = getattr(cfg, "hf_hub_id", None)
+    hf_hub_filename = getattr(cfg, "hf_hub_filename", None)
+    if not hf_hub_id:
+        return None, None
+    return hf_hub_id, hf_hub_filename
+
+
+def _do_download(hf_hub_id: str, hf_hub_filename: str | None) -> None:
+    """Блокирующая загрузка весов в кэш HF. Прогресс пишется через _LoggingTqdm."""
+    kwargs = {"repo_id": hf_hub_id}
+    if hf_hub_filename:
+        # тянем только нужный файл весов и json-конфиги, без README/картинок
+        kwargs["allow_patterns"] = [hf_hub_filename, "*.json"]
+    if "tqdm_class" in inspect.signature(snapshot_download).parameters:
+        kwargs["tqdm_class"] = _LoggingTqdm
+    snapshot_download(**kwargs)
+
+
+async def predownload_weights(
+    model_name: str,
+    tasker_service,
+    progress_start: int,
+    progress_end: int,
+) -> bool:
+    """Предзагрузка весов pretrained-модели в кэш HF ДО timm.create_model.
+
+    Отдельный этап с видимым прогрессом: после него timm.create_model(pretrained=True)
+    возьмёт веса из кэша мгновенно.
+
+    Returns:
+        True  — веса скачаны/уже в кэше;
+        False — модель не на HF Hub, pre-download пропущен (fallback на torch.hub в get_model).
+
+    При сетевой ошибке/таймауте исключение пробрасывается наверх — статус `failed`
+    поставит воркер (report_task_failed).
+    """
+    hf_hub_id, hf_hub_filename = resolve_hf_repo(model_name)
+    if hf_hub_id is None:
+        logger.info(
+            f"Модель {model_name} не размещена на HF Hub (legacy/torch.hub) — pre-download пропущен."
+        )
+        return False
+
+    await tasker_service.update_status_task(
+        percentages=progress_start,
+        status_info="Скачивание весов модели...",
+    )
+    logger.info(f"Предзагрузка весов {model_name} из HF Hub: {hf_hub_id}")
+
+    loop = asyncio.get_running_loop()
+    try:
+        await loop.run_in_executor(None, _do_download, hf_hub_id, hf_hub_filename)
+    except Exception as e:
+        logger.error(f"Ошибка предзагрузки весов {model_name}: {e!r}")
+        raise
+
+    await tasker_service.update_status_task(
+        percentages=progress_end,
+        status_info="Веса модели скачаны.",
+    )
+    logger.info(f"✅ Веса {model_name} в кэше")
+    return True

--- a/services/trainer/tests/test_predownload.py
+++ b/services/trainer/tests/test_predownload.py
@@ -1,0 +1,113 @@
+"""Интеграционные тесты предзагрузки весов pretrained-моделей.
+
+Проверяют модуль app.core.models.downloader: разрешение HF-репозитория по имени
+timm-модели, скачивание весов в кэш с обновлением статуса задачи и идемпотентность
+повторного вызова (взятие из кэша).
+
+ВНИМАНИЕ: тесты ходят в сеть (Hugging Face Hub) и пишут в кэш HF_HOME — это
+интеграционные тесты, не unit. Запускать внутри контейнера trainer, где есть timm и
+смонтирован кэш ./db/hf_cache.
+
+Запуск напрямую (рекомендуется для trainer, pytest в зависимостях нет):
+
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml \
+        run --rm --no-deps -e PYTHONUNBUFFERED=1 trainer python -m tests.test_predownload
+
+Каждая функция test_* синхронная (внутри гоняет async через asyncio.run), поэтому
+совместима и с pytest, если он появится в проекте, без pytest-asyncio.
+"""
+import asyncio
+import os
+import sys
+
+from app.core.models import predownload_weights
+from app.core.models.downloader import resolve_hf_repo
+
+# Публичная timm-модель на HF Hub. Переопределяется через env HF_TEST_MODEL
+# (для быстрой проверки удобно взять лёгкую, напр. mobilenetv3_small_050.lamb_in1k).
+HF_MODEL = os.getenv("HF_TEST_MODEL", "resnet50")
+# Заведомо несуществующее имя — проверка fallback-ветки.
+UNKNOWN_MODEL = "no_such_model_xyz_123"
+
+
+class _RecordingTasker:
+    """Заглушка tasker_service: записывает обновления статуса вместо HTTP-запросов."""
+
+    def __init__(self):
+        self.updates = []
+
+    async def update_status_task(self, status="running", status_info=None,
+                                 percentages=None, error=None, task_id=None):
+        self.updates.append({"status_info": status_info, "percentages": percentages})
+        return True
+
+
+def test_resolve_hf_repo_known():
+    """HF-hosted модель → возвращается непустой hf_hub_id."""
+    hf_hub_id, _ = resolve_hf_repo(HF_MODEL)
+    assert hf_hub_id, f"ожидался hf_hub_id для {HF_MODEL}, получено {hf_hub_id!r}"
+    assert hf_hub_id.startswith("timm/"), f"неожиданный репозиторий: {hf_hub_id!r}"
+
+
+def test_resolve_hf_repo_unknown():
+    """Несуществующая модель → (None, None), pre-download будет пропущен."""
+    assert resolve_hf_repo(UNKNOWN_MODEL) == (None, None)
+
+
+def test_predownload_downloads_and_caches():
+    """predownload_weights скачивает веса, шлёт статусы и кладёт файл в кэш."""
+    async def _run():
+        tasker = _RecordingTasker()
+        result = await predownload_weights(HF_MODEL, tasker, progress_start=6, progress_end=8)
+
+        assert result is True, "ожидался True (модель на HF Hub)"
+        # начальный и финальный статусы выставлены
+        pcts = [u["percentages"] for u in tasker.updates]
+        assert 6 in pcts and 8 in pcts, f"ожидались статусы 6 и 8, получено {pcts}"
+        # файл реально в кэше (имя каталога: models--<org>--<repo>)
+        hf_hub_id, _ = resolve_hf_repo(HF_MODEL)
+        expected = "models--" + hf_hub_id.replace("/", "--")
+        hub = os.path.join(os.getenv("HF_HOME", ""), "hub")
+        assert expected in os.listdir(hub), \
+            f"в кэше {hub} нет {expected}: {os.listdir(hub)}"
+
+    asyncio.run(_run())
+
+
+def test_predownload_idempotent():
+    """Повторный вызов на заполненном кэше снова возвращает True (берёт из кэша)."""
+    async def _run():
+        tasker = _RecordingTasker()
+        result = await predownload_weights(HF_MODEL, tasker, progress_start=6, progress_end=8)
+        assert result is True
+
+    asyncio.run(_run())
+
+
+# --- runner для прямого запуска без pytest -----------------------------------
+
+def _main() -> int:
+    print(f"HF_HOME = {os.getenv('HF_HOME')}")
+    print(f"HF_HUB_DOWNLOAD_TIMEOUT = {os.getenv('HF_HUB_DOWNLOAD_TIMEOUT')}\n")
+
+    tests = [
+        test_resolve_hf_repo_known,
+        test_resolve_hf_repo_unknown,
+        test_predownload_downloads_and_caches,
+        test_predownload_idempotent,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e!r}")
+
+    print(f"\nИтого: {len(tests) - failed}/{len(tests)} прошло")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
## 📌 Что было сделано?

Загрузка pretrained-весов timm в сервисе trainer уходила в «бесконечный цикл»: скачивание висело без обратной связи, было непонятно, идёт ли процесс. Диагностика показала, что виснет Xet-бэкенд huggingface_hub (`hf_xet` ходит на `cas-server.xethub.hf.co`, недоступный в окружении), при этом обычный `huggingface.co` доступен. Плюс кэш весов не был примонтирован, и модель скачивалась заново при каждом пересоздании контейнера.

### Инфраструктура (`docker-compose.yml`, `docker-compose.dev.yml`, `.env`)
- Примонтирован кэш весов как bind-mount `./db/hf_cache` (`HF_HOME`, `TORCH_HOME`) - модель качается один раз и переживает рестарты.
- `HF_HUB_DISABLE_XET=1` - форсит классический HTTP-путь вместо зависающего Xet (он уважает таймаут и докачку через resume).
- `HF_HUB_DOWNLOAD_TIMEOUT=30` - потолок по времени, чтобы соединение не висело вечно.
- В dev-override volumes у `trainer` перечислены явно (Compose не мержит списки).

### Логика загрузки (`downloader.py`, `core/__init__.py`, `models/__init__.py`)
- Отдельный этап pre-download (`predownload_weights`) перед `get_model`, со своей шкалой прогресса (`PROGRESS_WEIGHTS_DOWNLOAD=6` → `PROGRESS_WEIGHTS_READY=8`).
- Видимый прогресс: `_LoggingTqdm` пишет в логи `Скачивание весов: N% (.. МБ)`, а в `status_info` задачи идёт «Скачивание весов модели...».
- `resolve_hf_repo` достаёт `hf_hub_id` из timm; для legacy-моделей (torch.hub) pre-download пропускается (fallback), ошибка/таймаут пробрасывается воркеру (задача → `failed`).

### Тесты (`tests/test_predownload.py`)
- Покрытие `resolve_hf_repo` (HF-модель и fallback), скачивания с проверкой кэша и идемпотентности. Модель настраивается через env `HF_TEST_MODEL`. Прогон в контейнере: 4/4 PASS.

### Инфраструктура кэша (`db/hf_cache/`)
- Каталог с `.gitignore` (по паттерну проекта: игнор содержимого, трекинг README/.gitignore) и README.

### Документация (`services/trainer/README.md`)
- Новый раздел «Загрузка pretrained-весов» (что и почему), обновлены таблицы переменных окружения и этапов прогресса, блок отладки и карта `app/`.
