### PR TITLE
Agents/fix/serper key and scout prompt

### DIFF
--- a/services/agents/.env.example
+++ b/services/agents/.env.example
@@ -1,0 +1,12 @@
+# Базовый URL LLM-провайдера (OpenAI-совместимый). По умолчанию OpenRouter.
+OPENAI_API_BASE=https://openrouter.ai/api/v1
+# Дефолтная модель агентов (можно переопределить в рантайме через /settings).
+OPENAI_MODEL_NAME=openai/gpt-5-nano
+# Ключ доступа к OpenRouter — обязателен для LLM-запросов и каталога моделей.
+OPENROUTER_API_KEY=sk-or-v1-...
+# Таймаут одного LLM-запроса (сек) и число авто-повторов litellm при таймауте/ошибке.
+LLM_REQUEST_TIMEOUT=600
+LLM_NUM_RETRIES=2
+# Ключ Serper (serper.dev) для интернет-поиска агента Internet Best-Practices Scout.
+# Пусто/не задано — SerperDevTool не подключается, Scout ищет без него.
+SERPER_API_KEY=

--- a/services/agents/app/core/crews/praxis_searcher/config/agent.yaml
+++ b/services/agents/app/core/crews/praxis_searcher/config/agent.yaml
@@ -2,8 +2,11 @@ praxis_searcher:
   role: Internet Best-Practices Scout
   goal: Search, extract and structure the most up-to-date ML best practices for a specific query.
   backstory: >
-    You are a specialized scout of ML best practices.
-    You dig deep into arXiv, PapersWithCode, GitHub, HuggingFace, official blogs
-    (OpenAI, DeepMind, Meta, Google), Kaggle discussions and Reddit.
-    You always return concrete examples, links, key takeaways and why a practice
-    is likely to work for the current task.
+    You are a specialized scout of ML best practices for image-classification training.
+    Your toolbox: a web search engine (when available), a website scraper, and an arXiv
+    paper search. You work in three steps: search the web and arXiv for the query,
+    pick the most promising results, then open them with the scraper to extract concrete
+    details. You favour primary sources — arXiv papers, official repositories and docs,
+    authoritative engineering blogs. For every recommendation you give a concrete example,
+    the real URL you actually opened, the key takeaway, and why it is likely to work for
+    the current task.

--- a/services/agents/app/core/crews/praxis_searcher/config/task.yaml
+++ b/services/agents/app/core/crews/praxis_searcher/config/task.yaml
@@ -1,15 +1,21 @@
 praxis_search_task:
   agent: praxis_searcher
   description: |
-    Run a search for the query:
+    Search for the query (use English search terms):
     {search_query}
 
     Additional context:
     {context}
 
-    Find the most relevant best practices, articles, repositories and cases.
+    Steps:
+    1. Search the web and arXiv for relevant best practices, papers, repositories and cases.
+    2. Select the most relevant results and open the promising ones with the scraper to
+       extract concrete details (settings, numbers, code).
+    3. If the web search tool is unavailable, rely on arXiv search and on scraping the URLs
+       you find or that are given in the context.
   expected_output: |
     Return the result strictly in the PraxisSearchOutput Pydantic model format:
-    - text: a detailed description of the practices found
-    - sources: a list of sources with url, title, short_description
+    - text: a detailed description of the practices found, with concrete settings/examples
+    - sources: a list of sources you actually opened — url, title, short_description,
+      relevance_score (1-10)
     - summary: a short overview of the most important findings

--- a/services/agents/app/core/crews/praxis_searcher/tools.py
+++ b/services/agents/app/core/crews/praxis_searcher/tools.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 from crewai.tools import BaseTool
 from crewai_tools import (
@@ -8,11 +9,13 @@ from crewai_tools import (
 
 from ..utils import get_tools_with_tracking
 
-_tool_instances = [
-    SerperDevTool(),
+_tool_instances: List[BaseTool] = [
     ScrapeWebsiteTool(),
     ArxivPaperTool(),
 ]
+# ponytail: Serper подключаем только при наличии ключа — иначе SerperDevTool падает с KeyError
+if os.getenv("SERPER_API_KEY"):
+    _tool_instances.insert(0, SerperDevTool())
 
 def get_tools(
     agent_role: str


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
- `SerperDevTool` подключается к scout только когда задан `SERPER_API_KEY` - без ключа агент работает на `ScrapeWebsiteTool` + `ArxivPaperTool` и не падает с `KeyError` (`crews/praxis_searcher/tools.py`)
- Добавлен `services/agents/.env.example` с описанием переменных LLM (`OPENAI_API_BASE`, `OPENAI_MODEL_NAME`, `OPENROUTER_API_KEY`) и `SERPER_API_KEY`
- `backstory` приведён к реальным возможностям (web search / scraper / arXiv) с явным 3-шаговым workflow; убран список источников без инструментов (PapersWithCode, GitHub, HuggingFace, Reddit, Kaggle), провоцировавший выдуманные ссылки (`crews/praxis_searcher/config/agent.yaml`)
- `task`: English-запросы для поиска, шаг scrape для конкретики, fallback на arXiv+scrape без web-поиска, добавлен `relevance_score (1-10)` в expected_output (`crews/praxis_searcher/config/task.yaml`)