### PR TITLE
feat(frontend): отображение расхода токенов агентов

### DIFF
--- a/frontend/src/components/agents/DiscussionDetail.tsx
+++ b/frontend/src/components/agents/DiscussionDetail.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { agentHistoryService } from '../../services/agentHistoryService';
 import { agentsService } from '../../services/agentsService';
+import { metricsService } from '../../services/metricsService';
 import { useNotification } from '../../contexts/NotificationContext';
 import { usePolling } from '../../hooks';
 import { POLL_INTERVAL_DISCUSSION_MS } from '../../constants';
@@ -54,6 +55,24 @@ const DiscussionDetail: React.FC<Props> = ({ discussionId, onBack }) => {
     },
   );
 
+  // Токены агентов из metrics-сервиса. Метрики копятся по мере завершения crew,
+  // поэтому опрашиваем их пока дискуссия активна (как и ленту).
+  const { data: agentMetrics } = usePolling(
+    () => metricsService.getAgentMetrics(discussionId),
+    {
+      intervalMs: POLL_INTERVAL_DISCUSSION_MS,
+      continueWhile: () => isActive,
+      // Метрик может ещё не быть — не шумим уведомлениями об ошибке.
+      deps: [discussionId, isActive],
+    },
+  );
+
+  const tokenSummary = agentMetrics?.summary;
+  const tokensByResponse = useMemo(
+    () => new Map((agentMetrics?.responses ?? []).map(r => [r.response_id, r.metrics])),
+    [agentMetrics],
+  );
+
   const feed = useMemo(() => feedData ?? [], [feedData]);
   // Активный агент значим только пока дискуссия активна.
   const activeAgentRole = isActive ? deriveActiveAgentRole(feed) : null;
@@ -83,6 +102,7 @@ const DiscussionDetail: React.FC<Props> = ({ discussionId, onBack }) => {
         discussionId={discussionId}
         activeAgentRole={activeAgentRole}
         training={training}
+        tokenSummary={tokenSummary}
         actions={isActive ? (
           <button className="button danger small" onClick={handleStop} disabled={stopping}>
             <i className={`fas ${stopping ? `${ICONS.loading} fa-spin` : ICONS.cancelled}`}></i>
@@ -95,6 +115,7 @@ const DiscussionDetail: React.FC<Props> = ({ discussionId, onBack }) => {
         feed={feed}
         loading={feedLoading}
         active={isActive}
+        tokensByResponse={tokensByResponse}
       />
     </div>
   );

--- a/frontend/src/components/agents/DiscussionInfo.tsx
+++ b/frontend/src/components/agents/DiscussionInfo.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import type { DiscussionMeta } from '../../types/agentHistory';
 import { DISCUSSION_STATUS_LABELS, getDiscussionTitle, getDiscussionAgents, getPipelineLabel } from '../../types/agentHistory';
 import type { TrainingState, TrainingSummary } from './discussionFeed';
-import { formatDateTime } from '../../utils/format';
+import type { AgentTokenMetrics } from '../../services/metricsService';
+import { formatDateTime, formatCompact } from '../../utils/format';
 import { ICONS } from '../../constants/icons';
 import { useCopyToClipboard } from '../../hooks';
 import { Tooltip } from '../common/Tooltip';
@@ -14,6 +15,8 @@ interface Props {
   activeAgentRole?: string | null;
   // Сводка обучения для карточки «Сервис обучения» в секции исполнителей.
   training?: TrainingSummary;
+  // Суммарные токены, потраченные агентами дискуссии.
+  tokenSummary?: AgentTokenMetrics & { responses_count?: number };
   actions?: React.ReactNode;
 }
 
@@ -47,6 +50,7 @@ const DiscussionInfo: React.FC<Props> = ({
   discussionId,
   activeAgentRole = null,
   training = { state: 'idle', total: 0, currentName: null },
+  tokenSummary,
   actions,
 }) => {
   const copyToClipboard = useCopyToClipboard();
@@ -107,6 +111,19 @@ const DiscussionInfo: React.FC<Props> = ({
                 <div className="detail-field">
                   <span className="detail-label"><i className={`fas ${ICONS.tools}`}></i> Вызовов инструментов</span>
                   <span>{discussion.tool_calls_count}</span>
+                </div>
+              )}
+              {tokenSummary?.total_tokens != null && tokenSummary.total_tokens > 0 && (
+                <div className="detail-field">
+                  <span className="detail-label"><i className={`fas ${ICONS.tokens}`}></i> Токенов потрачено</span>
+                  <span title={`${tokenSummary.total_tokens.toLocaleString('ru-RU')} токенов`}>
+                    {formatCompact(tokenSummary.total_tokens)}
+                  </span>
+                  {(tokenSummary.prompt_tokens != null || tokenSummary.completion_tokens != null) && (
+                    <span className="detail-subnote">
+                      prompt {formatCompact(tokenSummary.prompt_tokens ?? 0)} / completion {formatCompact(tokenSummary.completion_tokens ?? 0)}
+                    </span>
+                  )}
                 </div>
               )}
               {discussion.tags.length > 0 && (

--- a/frontend/src/components/agents/DiscussionView.tsx
+++ b/frontend/src/components/agents/DiscussionView.tsx
@@ -6,6 +6,7 @@ import { prefersReducedMotion } from '../../utils/motion';
 import MessageBubble from './MessageBubble';
 import TrainingTaskCard from '../models/TrainingTaskCard';
 import type { FeedItem } from './discussionFeed';
+import type { AgentTokenMetrics } from '../../services/metricsService';
 import { ICONS } from '../../constants/icons';
 
 interface Props {
@@ -16,6 +17,8 @@ interface Props {
   loading?: boolean;
   // Если дискуссия активна — показываем индикатор «Агенты работают...».
   active?: boolean;
+  // Токены по response_id (из metrics-сервиса) — показываются на карточке ответа.
+  tokensByResponse?: Map<string, AgentTokenMetrics>;
 }
 
 // Иконка системного сообщения по типу.
@@ -28,7 +31,7 @@ const SYSTEM_ICONS: Record<SystemMessageType, string> = {
 // Насколько близко к низу страницы считаем, что пользователь «внизу», px.
 const SCROLL_BOTTOM_THRESHOLD = 120;
 
-const DiscussionView: React.FC<Props> = ({ discussionId, feed, loading = false, active = false }) => {
+const DiscussionView: React.FC<Props> = ({ discussionId, feed, loading = false, active = false, tokensByResponse }) => {
   const navigate = useNavigate();
 
   // Живой таймер длительности для активного этапа обучения: пока дискуссия
@@ -109,7 +112,7 @@ const DiscussionView: React.FC<Props> = ({ discussionId, feed, loading = false, 
                 <i className={`fas ${ICONS.agent}`}></i>
               </span>
               <div className="timeline-content">
-                <MessageBubble discussionId={discussionId} response={item.data} />
+                <MessageBubble discussionId={discussionId} response={item.data} tokens={tokensByResponse?.get(item.data.response_id)} />
               </div>
             </div>
           );

--- a/frontend/src/components/agents/MessageBubble.tsx
+++ b/frontend/src/components/agents/MessageBubble.tsx
@@ -4,13 +4,16 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { agentHistoryService } from '../../services/agentHistoryService';
 import type { AgentResponse, AgentStatus, Tool } from '../../types/agentHistory';
-import { formatDateTime, formatDuration, statusClass } from '../../utils/format';
+import type { AgentTokenMetrics } from '../../services/metricsService';
+import { formatDateTime, formatDuration, formatCompact, statusClass } from '../../utils/format';
 import { CollapseChevron, getDisclosureProps } from '../common/Collapse';
 import { ICONS } from '../../constants/icons';
 
 interface Props {
   discussionId: string;
   response: AgentResponse;
+  // Токены, потраченные этим агентом (из metrics-сервиса); может ещё не быть.
+  tokens?: AgentTokenMetrics;
 }
 
 // Подписи статусов запуска агента / инструмента.
@@ -97,7 +100,7 @@ const ToolItem: React.FC<{ tool: Tool; maxDuration: number }> = ({ tool, maxDura
   );
 };
 
-const MessageBubble: React.FC<Props> = ({ discussionId, response }) => {
+const MessageBubble: React.FC<Props> = ({ discussionId, response, tokens }) => {
   const [tools, setTools] = useState<Tool[] | 'loading' | 'error' | null>(null);
   const [collapsed, setCollapsed] = useState(true);
 
@@ -145,6 +148,11 @@ const MessageBubble: React.FC<Props> = ({ discussionId, response }) => {
             {response.task_name && <span><i className={`fas ${ICONS.task}`}></i> {response.task_name}</span>}
             {response.iteration != null && <span><i className={`fas ${ICONS.iteration}`}></i> итерация {response.iteration}</span>}
             {response.duration_ms != null && <span><i className={`fas ${ICONS.duration}`}></i> {formatDuration(response.duration_ms)}</span>}
+            {tokens?.total_tokens != null && tokens.total_tokens > 0 && (
+              <span title={`${tokens.total_tokens.toLocaleString('ru-RU')} токенов (prompt ${(tokens.prompt_tokens ?? 0).toLocaleString('ru-RU')} / completion ${(tokens.completion_tokens ?? 0).toLocaleString('ru-RU')})`}>
+                <i className={`fas ${ICONS.tokens}`}></i> {formatCompact(tokens.total_tokens)} токенов
+              </span>
+            )}
           </div>
 
           <div className="message-text markdown-body">

--- a/frontend/src/constants/icons.ts
+++ b/frontend/src/constants/icons.ts
@@ -87,6 +87,7 @@ export const ICONS = {
   dateUpdated: 'fa-rotate',
   dateFinished: 'fa-flag-checkered',
   duration: 'fa-clock',
+  tokens: 'fa-coins',          // потраченные LLM-токены
   elapsed: 'fa-stopwatch',     // длительность процесса (таймер обучения)
   iteration: 'fa-rotate',
   history: 'fa-clock-rotate-left',

--- a/frontend/src/services/metricsService.ts
+++ b/frontend/src/services/metricsService.ts
@@ -85,6 +85,28 @@ export interface ModelsCompareResponse {
   missing: string[];
 }
 
+// Токены, потраченные агентом (crew.usage_metrics из CrewAI). Поля опциональны:
+// метрики появляются только после завершения crew, у незавершённых их нет.
+export interface AgentTokenMetrics {
+  available?: boolean;
+  total_tokens?: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  successful_requests?: number;
+}
+
+export interface AgentResponseMetrics {
+  response_id: string;
+  metrics: AgentTokenMetrics;
+}
+
+// Метрики всех агентов дискуссии + просуммированная сводка (summary).
+export interface AgentDiscussionMetrics {
+  discussion_id: string;
+  responses: AgentResponseMetrics[];
+  summary: AgentTokenMetrics & { responses_count?: number };
+}
+
 interface MetricsStreamHandlers {
   onMetrics: (metrics: ModelMetrics) => void;
   onEnd?: (event: StreamEndEvent) => void;
@@ -113,6 +135,12 @@ export const metricsService = {
     const response = await fetch(`${BASE}/models/${modelId}/class-report`);
     if (response.status === 404) return null;
     return handleResponse<ClassReport>(response);
+  },
+
+  /** Метрики токенов агентов дискуссии (per-response + сводка). */
+  async getAgentMetrics(discussionId: string): Promise<AgentDiscussionMetrics> {
+    const response = await fetch(`${BASE}/agents/discussions/${discussionId}`);
+    return handleResponse<AgentDiscussionMetrics>(response);
   },
 
   /**

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -573,6 +573,12 @@ button:disabled,
   word-break: break-all;
 }
 
+/* Уточняющая подпись под значением поля (например, разбивка токенов prompt/completion) */
+.detail-subnote {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
 /* Поле, занимающее всю ширину сетки (например, классы) */
 .detail-field--full {
   grid-column: 1 / -1;

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -36,6 +36,10 @@ export const pluralRu = (n: number, [one, few, many]: [string, string, string]):
 export const formatMetricValue = (v: number): string =>
   Number.isInteger(v) ? String(v) : v.toFixed(4);
 
+// Компактное число: 297699 → «297,7K», 850 → «850». Для счётчиков (токены и т.п.).
+const compactFormatter = new Intl.NumberFormat('ru-RU', { notation: 'compact', maximumFractionDigits: 1 });
+export const formatCompact = (n: number): string => compactFormatter.format(n);
+
 // Форматирование длительности в мс/с (>= 1 с показываем в секундах).
 export const formatDuration = (ms: number): string =>
   ms >= 1000 ? `${(ms / 1000).toFixed(2)} с` : `${ms.toFixed(0)} мс`;


### PR DESCRIPTION
## 📌 Что было сделано?

Фронтенд теперь показывает расход LLM-токенов агентов: **суммарно по всей дискуссии** (шапка детального просмотра) и **по каждому агенту** (карточка его ответа в ленте). Бэкенд уже отдавал эти данные через `GET /agents/discussions/{id}` (metrics-сервис), но фронт их не использовал - задача чисто фронтендовая.

- **`metricsService.ts`** - типы `AgentTokenMetrics` / `AgentDiscussionMetrics` и метод `getAgentMetrics` (запрос per-response метрик + сводки по дискуссии).
- **`DiscussionDetail.tsx`** - `usePolling` метрик (опрос, пока дискуссия активна - токены копятся по мере завершения crew); сбор сводки и `Map<response_id → metrics>`.
- **`DiscussionInfo.tsx`** - поле «Токенов потрачено» в шапке: total крупно + разбивка `prompt / completion` приглушённой строкой ниже.
- **`DiscussionView.tsx` / `MessageBubble.tsx`** - токены агента на его карточке (chip с total; точные числа - в `title` по наведению). Сопоставление по `response_id`, который совпадает с agent_history.
- **`utils/format.ts`** - утилита `formatCompact` (`297699` → `297,7 тыс.`), чтобы крупные числа не растягивали верстку.
- **`constants/icons.ts`** - иконка `tokens` (`fa-coins`).
- **`styles/components.css`** - класс `.detail-subnote` для уточняющих подписей под значением поля.