### PR TITLE
Agents/feat/auto training iterations

### DIFF
--- a/frontend/src/components/agents/RunPipelineForm.tsx
+++ b/frontend/src/components/agents/RunPipelineForm.tsx
@@ -77,7 +77,7 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
   const [tagList, setTagList] = useState<string[]>([]);
   // Запрещённые гипотезы добавляются по одной в список.
   const [deniedList, setDeniedList] = useState<string[]>([]);
-  const [maxIter, setMaxIter] = useState(2);
+  const [maxIter, setMaxIter] = useState(0);
 
   const [submitting, setSubmitting] = useState(false);
 
@@ -340,14 +340,14 @@ const RunPipelineForm: React.FC<Props> = ({ onStarted }) => {
           )}
           {workflow === 'development' && (
             <div className="form-field">
-              <label htmlFor="run-max-iter">Попыток обучения</label>
+              <label htmlFor="run-max-iter">Попыток обучения (0 = агент решает сам)</label>
               <input
                 id="run-max-iter"
                 className="no-spinner"
                 type="number"
-                min={1}
+                min={0}
                 value={maxIter}
-                onChange={(e) => setMaxIter(Math.max(1, Number(e.target.value) || 1))}
+                onChange={(e) => setMaxIter(Math.max(0, Number(e.target.value) || 0))}
                 disabled={submitting}
               />
             </div>

--- a/services/agents/.env.example
+++ b/services/agents/.env.example
@@ -5,7 +5,7 @@ OPENAI_MODEL_NAME=openai/gpt-5-nano
 # Ключ доступа к OpenRouter — обязателен для LLM-запросов и каталога моделей.
 OPENROUTER_API_KEY=sk-or-v1-...
 # Таймаут одного LLM-запроса (сек) и число авто-повторов litellm при таймауте/ошибке.
-LLM_REQUEST_TIMEOUT=600
+LLM_REQUEST_TIMEOUT=120
 LLM_NUM_RETRIES=2
 # Ключ Serper (serper.dev) для интернет-поиска агента Internet Best-Practices Scout.
 # Пусто/не задано — SerperDevTool не подключается, Scout ищет без него.

--- a/services/agents/app/api/routers/analytic.py
+++ b/services/agents/app/api/routers/analytic.py
@@ -52,7 +52,7 @@ def analyze_ml_metric(
                 model_id=model_id,
                 verbose=True
             )
-        return result
+        return result.to_history_text()
     except Exception as e:
         raise HTTPException(
             status_code=500,

--- a/services/agents/app/api/routers/full_pipeline.py
+++ b/services/agents/app/api/routers/full_pipeline.py
@@ -34,7 +34,7 @@ _DEVELOPMENT_AGENT_ROLES = [
 
 class DevelopmentRequest(BasePipelineRequest):
     denied_hypotheses_info: List[str] = Field(default_factory=list, description="Гипотезы и практики, которые нужно избегать")
-    max_iter: int = Field(2, description="Количество попыток обучения")
+    max_iter: int = Field(0, ge=0, description="Количество попыток обучения. 0 — агент определяет сам")
 
 
 @routers.get(
@@ -48,7 +48,7 @@ def development(
     deployment_constraints: Optional[str] = Query(None, description="Технические возможности прода. Если не указано — агенты сами минимизируют затраты"),
     business_requirements: Optional[str] = Query(None, description="Описание бизнес требований. Если не указано — агенты сами максимизируют качество"),
     denied_hypotheses_info: List[str] = Query(default_factory=list, description="Гипотезы и практики, которые нужно избегать"),
-    max_iter: int = Query(2, description="Количество попыток обучения"),
+    max_iter: int = Query(0, ge=0, description="Количество попыток обучения. 0 — агент определяет сам"),
     model_id: Optional[str] = Query(None, description="ID существующей модели — новые версии создаются под ней"),
     llm_model: Optional[str] = Query(None, description="Модель LLM на этот запуск (override глобальной настройки)")
 ):

--- a/services/agents/app/config/__init__.py
+++ b/services/agents/app/config/__init__.py
@@ -111,7 +111,7 @@ class ConfigBaseLLM:
     LLM_TEMPERATURE_SUPPORTED = os.getenv("LLM_TEMPERATURE_SUPPORTED", "true").lower() != "false"
     # Таймаут одного LLM-запроса (сек). Без него litellm ждёт ответ бесконечно,
     # и подвисший запрос к провайдеру вешает весь шаг пайплайна.
-    LLM_REQUEST_TIMEOUT = _env_float("LLM_REQUEST_TIMEOUT", 600)
+    LLM_REQUEST_TIMEOUT = _env_float("LLM_REQUEST_TIMEOUT", 120)
     # Сколько раз litellm автоматически повторит запрос при таймауте/временной ошибке.
     LLM_NUM_RETRIES = _env_int("LLM_NUM_RETRIES", 2)
 

--- a/services/agents/app/core/crews/dataset_analyst/dataset_analyst.py
+++ b/services/agents/app/core/crews/dataset_analyst/dataset_analyst.py
@@ -57,7 +57,7 @@ class DatasetAnalystCrew:
             llm=get_llm_precise(),
             tools=get_tools(AGENT_ROLE),
             allow_delegation=False,
-            max_iter=8,
+            max_iter=5,
         )
 
     @task

--- a/services/agents/app/core/crews/metrics_analyst/__init__.py
+++ b/services/agents/app/core/crews/metrics_analyst/__init__.py
@@ -1,3 +1,3 @@
-from .metrics_analyst import run_metrics_analyst, AGENT_ROLE
+from .metrics_analyst import run_metrics_analyst, MetricsAnalystResponse, AGENT_ROLE
 
-__all__ = ['run_metrics_analyst', 'AGENT_ROLE']
+__all__ = ['run_metrics_analyst', 'MetricsAnalystResponse', 'AGENT_ROLE']

--- a/services/agents/app/core/crews/metrics_analyst/config/task.yaml
+++ b/services/agents/app/core/crews/metrics_analyst/config/task.yaml
@@ -17,14 +17,18 @@ metrics_analysis_task:
     - Analyze model quality
     - Explain the meaning of the metrics
     - Identify the model's weak points
-    - Give a conclusion about production readiness
+    - Compare the metrics against the Business requirements above and decide
+      whether the requirements are met — i.e. whether another training stage
+      is needed (requirements_met=false) or the model is good enough
+      (requirements_met=true)
 
     IMPORTANT:
     - Use only the real metrics returned by tools
-    - If the data is insufficient, say so
+    - If the data is insufficient, say so and set requirements_met=false
 
   expected_output: >
-    A structured analysis of the model:
-    - Quality interpretation
-    - Weak points
-    - Conclusion about readiness for use
+    A structured verdict with fields:
+    - requirements_met (bool): true if the model satisfies the business
+      requirements and no further training stage is needed; false otherwise
+    - reason (str): justification of the verdict against the requirements
+    - analysis (str): detailed interpretation of the metrics and weak points

--- a/services/agents/app/core/crews/metrics_analyst/metrics_analyst.py
+++ b/services/agents/app/core/crews/metrics_analyst/metrics_analyst.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 from typing import List
+from pydantic import Field
 from crewai import Agent, Crew, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 
 from .tools import get_tools
-from ..utils import get_agent_role_from_config, run_crew_with_tracking, extract_raw_text, with_modifier
+from ..utils import (
+    get_agent_role_from_config, run_crew_with_tracking,
+    AgentOutput, first_task_pydantic, with_modifier,
+)
 from app.logs import get_logger
 from app.core.llm import get_llm_precise
 
@@ -15,6 +19,29 @@ AGENT_ROLE = get_agent_role_from_config(
     "metrics_analyst",
     Path(__file__)
 )
+
+class MetricsAnalystResponse(AgentOutput):
+    """Формат ответа аналитика метрик."""
+    requirements_met: bool = Field(
+        description="Достигнуты ли требования пользователя. "
+        "True — модель удовлетворяет требованиям, новый этап обучения не нужен. "
+        "False — требования не достигнуты, нужен ещё этап обучения."
+    )
+    reason: str = Field(description="Обоснование вердикта по требованиям.")
+    analysis: str = Field(description="Развёрнутый разбор метрик модели и её слабых мест.")
+
+    def to_history_text(self) -> str:
+        verdict = (
+            "✅ Требования достигнуты — новый этап не нужен"
+            if self.requirements_met
+            else "🟥 Требования не достигнуты — нужен ещё этап обучения"
+        )
+        return "\n\n".join([
+            "## 📊 Анализ метрик",
+            f"**Вердикт:** {verdict}",
+            f"**Обоснование:**\n{self.reason}",
+            f"**Разбор метрик:**\n{self.analysis}",
+        ])
 
 @CrewBase
 class MetricAnalystCrew:
@@ -33,13 +60,14 @@ class MetricAnalystCrew:
             llm=get_llm_precise(),
             tools=get_tools(AGENT_ROLE),
             allow_delegation=False,
-            max_iter=8,
+            max_iter=5,
         )
 
     @task
     def metrics_analysis_task(self) -> Task:
         return Task(
-            config=self.tasks_config["metrics_analysis_task"] # type: ignore[index]
+            config=self.tasks_config["metrics_analysis_task"], # type: ignore[index]
+            output_pydantic=MetricsAnalystResponse,
         )
 
     @crew
@@ -58,9 +86,10 @@ def run_metrics_analyst(
         model_id: str,
         business_goal: str,
         verbose: bool = False
-    ) -> str:
+    ) -> MetricsAnalystResponse:
     """
-    Агент аналитик метрик анализирует результаты работы ML модели.
+    Агент аналитик метрик анализирует результаты работы ML модели и решает,
+    достигнуты ли требования пользователя (нужен ли ещё этап обучения).
 
     Args:
         model_id: Id модели для анализа
@@ -75,4 +104,13 @@ def run_metrics_analyst(
         inputs={"model_id": model_id, "business_goal": business_goal},
     )
 
-    return extract_raw_text(crew_output) if crew_output is not None else ""
+    result = first_task_pydantic(crew_output)
+    if isinstance(result, MetricsAnalystResponse):
+        return result
+    # LLM не вернул структуру — считаем требования не достигнутыми, чтобы пайплайн
+    # не остановился на непроверенной модели.
+    return MetricsAnalystResponse(
+        requirements_met=False,
+        reason="Аналитик метрик не вернул структурированный вердикт.",
+        analysis="",
+    )

--- a/services/agents/app/core/crews/ml_debuger/ml_debuger.py
+++ b/services/agents/app/core/crews/ml_debuger/ml_debuger.py
@@ -57,7 +57,7 @@ class MLDebugerCrew:
             llm=get_llm_precise(),
             tools=get_tools(AGENT_ROLE),
             allow_delegation=False,
-            max_iter=8,
+            max_iter=5,
         )
 
     @task

--- a/services/agents/app/core/crews/ml_engeneer/ml_engeneer.py
+++ b/services/agents/app/core/crews/ml_engeneer/ml_engeneer.py
@@ -74,7 +74,7 @@ class MLEngineerCrew:
             llm=get_llm_precise(),
             tools=get_tools(AGENT_ROLE),
             allow_delegation=False,
-            max_iter=8,
+            max_iter=5,
         )
 
     @task

--- a/services/agents/app/core/crews/ml_engeneer_quick/ml_engeneer_quick.py
+++ b/services/agents/app/core/crews/ml_engeneer_quick/ml_engeneer_quick.py
@@ -39,7 +39,7 @@ class MLEngineerQuickCrew:
             llm=get_llm_precise(),
             tools=get_tools(AGENT_ROLE),
             allow_delegation=False,
-            max_iter=8,
+            max_iter=5,
         )
 
     @task

--- a/services/agents/app/core/crews/praxis_searcher/praxis_searcher.py
+++ b/services/agents/app/core/crews/praxis_searcher/praxis_searcher.py
@@ -71,7 +71,7 @@ class PraxisSearcherCrew:
             verbose=True,
             llm=get_llm_precise(),
             allow_delegation=False,
-            max_iter=15,
+            max_iter=5,
             tools=get_tools(AGENT_ROLE)
         )
 

--- a/services/agents/app/core/crews/reporter/reporter.py
+++ b/services/agents/app/core/crews/reporter/reporter.py
@@ -46,7 +46,7 @@ class ReporterCrew:
             llm=get_llm_precise(),
             tools=get_tools(AGENT_ROLE),
             allow_delegation=False,
-            max_iter=8,
+            max_iter=5,
         )
 
     @task

--- a/services/agents/app/core/crews/researcher/researcher.py
+++ b/services/agents/app/core/crews/researcher/researcher.py
@@ -57,7 +57,7 @@ class ResearcherCrew:
             verbose=True,
             llm=get_llm_creative(),
             allow_delegation=False,
-            max_iter=15,
+            max_iter=5,
             tools= get_tools(AGENT_ROLE)
         )
 

--- a/services/agents/app/core/development.py
+++ b/services/agents/app/core/development.py
@@ -16,6 +16,9 @@ from .pipeline import (
 
 logger = get_logger(__name__)
 
+# ponytail: предохранитель в авто-режиме (max_iter=0), поднять если мало
+AUTO_ATTEMPTS_CAP = 5
+
 def development_models(
     dataset_id: str,
     dataset_version_id: str,
@@ -23,7 +26,7 @@ def development_models(
     deployment_constraints: str | None = None,
     business_requirements: str | None = None,
     denied_hypotheses_info: List[str] = [],
-    max_iter: int = 2,
+    max_iter: int = 0,
     model_id: str | None = None,
     verbose: bool = False
 ):
@@ -39,7 +42,9 @@ def development_models(
         business_requirements: Требования бизнеса к модели
             (опционально; без них агенты максимизируют качество сами)
         denied_hypotheses_info: Какие гипотезы стоит откинуть сразу (опицонально)
-        max_iter: Количество версий разработанной модели (опицонально)
+        max_iter: Количество попыток обучения. >0 — ровно столько попыток (без
+            досрочного стопа). 0 (по умолчанию) — агент сам определяет количество:
+            цикл идёт до достижения требований, но не больше AUTO_ATTEMPTS_CAP.
         model_id: ID существующей модели — новые версии создаются под ней (опицонально)
         verbose: Логирование (опицонально)
     """
@@ -74,11 +79,17 @@ def development_models(
     logger.info("✅ Анализ датасета")
     agent_history_client.info("Анализ датасета завершён: данные готовы к обучению.")
 
-    for iter in range(1, max_iter+1):
+    # max_iter == 0 — агент сам решает: крутим до достижения требований, но не
+    # больше AUTO_ATTEMPTS_CAP. max_iter > 0 — ровно столько попыток без раннего стопа.
+    auto_mode = max_iter <= 0
+    effective_max = AUTO_ATTEMPTS_CAP if auto_mode else max_iter
+    total_display = f"авто (макс. {AUTO_ATTEMPTS_CAP})" if auto_mode else str(max_iter)
+
+    for iter in range(1, effective_max + 1):
         raise_if_cancelled()
         iteration_context.set(iter)
 
-        info_start_iter = f"Полный цикл обучения №{iter} из {max_iter}"
+        info_start_iter = f"Полный цикл обучения №{iter} из {total_display}"
         agent_history_client.info(f"{info_start_iter}. Этап рассуждения агентов.")
         logger.info(
             f"\n{'='*100}"
@@ -127,7 +138,7 @@ def development_models(
         logger.info("")
         training_res = train_and_debug(training_input)
 
-        info_final_iter_1_line = f"Полный цикл обучения №{iter} из {max_iter}"
+        info_final_iter_1_line = f"Полный цикл обучения №{iter} из {total_display}"
         info_final_iter_2_line =  "завершился с результатом:"
         if training_res.is_completed_successfully:
             logger.info(
@@ -137,7 +148,39 @@ def development_models(
                 f"\n{'✅ Модель успешно обучена':^100}"
                 f"\n{'='*100}"
             )
-            agent_history_client.info(f"Цикл обучения №{iter} из {max_iter} завершён: модель успешно обучена.")
+            agent_history_client.info(f"Цикл обучения №{iter} из {total_display} завершён: модель успешно обучена.")
+
+            # Аналитик метрик решает, достигнуты ли требования пользователя.
+            # В авто-режиме (max_iter=0) достигнутые требования = досрочный стоп.
+            # При фикс. количестве попыток цикл не прерываем (делаем ровно max_iter),
+            # но разбор всё равно отдаём следующей попытке как контекст для улучшения.
+            metrics_verdict = run_metrics_analyst(
+                model_id=training_res.version_id,
+                business_goal=business_requirements,
+                verbose=verbose
+            )
+            if metrics_verdict.requirements_met:
+                agent_history_client.info("Аналитик метрик: требования достигнуты.")
+                if auto_mode:
+                    logger.info("✅ Требования достигнуты — дальнейшие попытки не нужны.")
+                    agent_history_client.info(
+                        "Агент сам определил количество попыток — требования закрыты, "
+                        "останавливаем цикл."
+                    )
+                    break
+            else:
+                agent_history_client.warning(
+                    "Аналитик метрик: требования не достигнуты — нужен ещё этап обучения."
+                )
+                ml_model = ml_engin_out.ml_model
+                what_trained = f"{ml_model.type} — {ml_model.description_model}" if ml_model else "модель"
+                denied_hypotheses_info.append(
+                    "Модель успешно обучилась, но требования пользователя не достигнуты.\n"
+                    f"Что обучали: {what_trained}\n"
+                    f"Вердикт аналитика: {metrics_verdict.reason}\n"
+                    f"Разбор метрик:\n{metrics_verdict.analysis}\n"
+                    "Учти это и предложи конфигурацию, которая закроет слабые места."
+                )
 
         elif training_res.is_cancelled:
             # Человек вручную остановил обучение — это не сбой. Пайплайн не прерываем:
@@ -151,7 +194,7 @@ def development_models(
                 f"\n{'='*100}"
             )
             agent_history_client.warning(
-                f"Цикл обучения №{iter} из {max_iter}: обучение остановлено пользователем. "
+                f"Цикл обучения №{iter} из {total_display}: обучение остановлено пользователем. "
                 "Разбираем частичные метрики, чтобы понять причину."
             )
 
@@ -165,7 +208,7 @@ def development_models(
                     model_id=training_res.version_id,
                     business_goal=business_requirements,
                     verbose=verbose
-                )
+                ).to_history_text()
 
             denied_hypotheses_info.append(
                 "Человек вручную остановил обучение этой конфигурации (это не ошибка обучения).\n"
@@ -185,7 +228,7 @@ def development_models(
                 f"\n{'='*100}"
             )
             agent_history_client.warning(
-                f"Цикл обучения №{iter} из {max_iter} провалился: {training_res.error}"
+                f"Цикл обучения №{iter} из {total_display} провалился: {training_res.error}"
             )
             # Сообщаем следующей итерации о провале обучения, чтобы исследователь и
             # ML инженер не повторили то же решение.

--- a/services/agents/app/core/quick_pipeline.py
+++ b/services/agents/app/core/quick_pipeline.py
@@ -118,7 +118,7 @@ def quick_training_models(
             verbose=verbose
         )
         agent_history_client.info("Быстрый пайплайн завершён (обучение остановлено пользователем).")
-        return analysis
+        return analysis.to_history_text()
 
     if not training_res.is_completed_successfully:
         logger.info(f"🟥 Обучение провалилось: {training_res.error}")
@@ -135,4 +135,4 @@ def quick_training_models(
     )
 
     agent_history_client.info("Быстрый пайплайн завершён.")
-    return analysis
+    return analysis.to_history_text()


### PR DESCRIPTION
## 📌 Что было сделано?
Краткое описание изменений:
- `run_metrics_analyst` возвращает `MetricsAnalystResponse`
  (`requirements_met` / `reason` / `analysis`) вместо сырого текста.
- `task.yaml`: задача аналитика - сравнить метрики с business requirements
  и решить, нужен ли ещё этап обучения.
- Потребители (`analytic` router, `quick_pipeline`) переведены на
  `to_history_text()`.
- Fallback: если LLM не вернул структуру - `requirements_met=false`,
  чтобы пайплайн не закрылся на непроверенной модели.
- `max_iter=0` (новый дефолт) - агент сам определяет число попыток:
  крутит до достижения требований, но не больше `AUTO_ATTEMPTS_CAP=5`.
- `max_iter>0` - ровно столько попыток, без раннего стопа.
- В авто-режиме достигнутые требования = досрочный стоп; иначе вердикт
  аналитика уходит следующей попытке как контекст для улучшения.
- API (`full_pipeline`) и форма запуска на frontend обновлены
  (`min=0`, подпись «0 = агент решает сам»).
- `max_iter` агентов 8/15 → 5.
- `LLM_REQUEST_TIMEOUT` 600 → 120 (+ `.env.example`).