### PR TITLE
Frontend bundle/render optimizations and trainer non-blocking loading

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,42 +1,37 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-// BrowserRouter — обёртка для приложения, которая обеспечивает работу маршрутизации
-// Routes и Route — компоненты для декларативного описания маршрутов.
-
+import { lazy, Suspense } from 'react';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { NotificationProvider } from './contexts/NotificationContext';
-// Провайдер контекста уведомлений. Он хранит глобальное состояние списка уведомлений
-// и предоставляет функции для показа/скрытия.
-
 import NotificationToast from './components/notification/NotificationToast';
-// Компонент, который отображает всплывающие уведомления (тосты) в правом верхнем углу.
-// Он подписывается на контекст уведомлений и рисует все активные уведомления.
-
 import Header from './components/layout/Header';
 import Footer from './components/layout/Footer';
+import ErrorBoundary from './components/common/ErrorBoundary';
 
-import Home from './pages/Home';
-import Datasets from './pages/Datasets';
-import DatasetDetail from './pages/DatasetDetail';
-import DatasetCompare from './pages/DatasetCompare';
-import Models from './pages/Models';
-import ModelDetail from './pages/ModelDetail';
-import ModelCompare from './pages/ModelCompare';
-import Agents from './pages/Agents';
-import AgentDiscussion from './pages/AgentDiscussion';
+// Страницы грузятся лениво: каждая — отдельный чанк, тяжёлые либы (antd, recharts,
+// react-markdown) не попадают в начальный бандл, а подтягиваются при переходе на роут.
+const Home = lazy(() => import('./pages/Home'));
+const Datasets = lazy(() => import('./pages/Datasets'));
+const DatasetDetail = lazy(() => import('./pages/DatasetDetail'));
+const DatasetCompare = lazy(() => import('./pages/DatasetCompare'));
+const Models = lazy(() => import('./pages/Models'));
+const ModelDetail = lazy(() => import('./pages/ModelDetail'));
+const ModelCompare = lazy(() => import('./pages/ModelCompare'));
+const Agents = lazy(() => import('./pages/Agents'));
+const AgentDiscussion = lazy(() => import('./pages/AgentDiscussion'));
 
 import './styles/App.css';
 
-function App() {
+// Содержимое внутри роутера: отдельный компонент, чтобы вызвать useLocation.
+// key={pathname} перемонтирует ErrorBoundary при смене роута — иначе после краша
+// рендера hasError остаётся true навсегда и навигация по ссылкам не спасает.
+function Layout() {
+  const { pathname } = useLocation();
   return (
-    <NotificationProvider>
-      <BrowserRouter>
-        <div className="app-wrapper">
-          <Header />
-          <main id="main-content" className="main-content">
+    <div className="app-wrapper">
+      <Header />
+      <main id="main-content" className="main-content">
+        <ErrorBoundary key={pathname}>
+          <Suspense fallback={<div className="route-loading">Загрузка…</div>}>
             <Routes>
-              {/*
-                Route определяет соответствие между путём URL и компонентом,
-                который должен отображаться.
-              */}
               <Route path="/" element={<Home />} />
               <Route path="/datasets" element={<Datasets />} />
               <Route path="/datasets/:id" element={<DatasetDetail />} />
@@ -47,10 +42,20 @@ function App() {
               <Route path="/agents" element={<Agents />} />
               <Route path="/agents/discussion/:discussionId" element={<AgentDiscussion />} />
             </Routes>
-          </main>
-          <Footer />
-          <NotificationToast />
-        </div>
+          </Suspense>
+        </ErrorBoundary>
+      </main>
+      <Footer />
+      <NotificationToast />
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <NotificationProvider>
+      <BrowserRouter>
+        <Layout />
       </BrowserRouter>
     </NotificationProvider>
   );

--- a/frontend/src/components/agents/DiscussionView.tsx
+++ b/frontend/src/components/agents/DiscussionView.tsx
@@ -39,9 +39,13 @@ const DiscussionView: React.FC<Props> = ({ discussionId, feed, loading = false, 
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     if (!active) return;
-    setNow(Date.now());
-    const timer = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(timer);
+    const tick = () => setNow(Date.now());
+    const first = setTimeout(tick, 0); // освежить «сейчас» при активации, но не синхронно в эффекте
+    const timer = setInterval(tick, 1000);
+    return () => {
+      clearTimeout(first);
+      clearInterval(timer);
+    };
   }, [active]);
 
   // Автоскролл: если пользователь у низа страницы, новая запись в ленте плавно

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+// Ловит неперехваченные ошибки рендера дочерних компонентов, чтобы падение
+// одной страницы не превращало всё приложение в белый экран. Header/Footer/тосты
+// живут выше по дереву и переживают сбой — пользователь может уйти на другой роут.
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Необработанная ошибка рендера:', error, info.componentStack);
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <div style={{ padding: '3rem 1rem', textAlign: 'center' }}>
+        <h2>Что-то пошло не так</h2>
+        <p>Страница не смогла отобразиться. Попробуйте перезагрузить.</p>
+        <button type="button" onClick={() => window.location.reload()}>
+          Перезагрузить
+        </button>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/models/TrainingTaskProgress.tsx
+++ b/frontend/src/components/models/TrainingTaskProgress.tsx
@@ -45,9 +45,13 @@ const TrainingTaskProgress: React.FC<TrainingTaskProgressProps> = ({ modelId }) 
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     if (!active) return;
-    setNow(Date.now());
-    const timer = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(timer);
+    const tick = () => setNow(Date.now());
+    const first = setTimeout(tick, 0); // освежить «сейчас» при активации, но не синхронно в эффекте
+    const timer = setInterval(tick, 1000);
+    return () => {
+      clearTimeout(first);
+      clearInterval(timer);
+    };
   }, [active]);
 
   const handleCancel = async () => {

--- a/frontend/src/components/models/curveChart.tsx
+++ b/frontend/src/components/models/curveChart.tsx
@@ -90,7 +90,10 @@ const CurveTooltip: React.FC<{
  * Отрисовка одного графика кривых; используется и в сетке,
  * и в увеличенном оверлее (там выше порог точек и высота контейнера).
  */
-export const CurveChartView: React.FC<{
+// Обёрнут в React.memo: один график recharts — дорогая отрисовка, а в сетке props
+// стабильны (из мемоизированного gridItems), так что несвязанные ре-рендеры родителя
+// (reportOpen, zoom, polling) не перерисовывают сетку.
+export const CurveChartView = React.memo(({ chart, series, checkpoints, height, dotLimit, large, highlightKey }: {
   chart: EpochChart;
   /** Серии графика — только те, у которых есть значения в rows. */
   series: CurveSeries[];
@@ -103,7 +106,7 @@ export const CurveChartView: React.FC<{
   large?: boolean;
   /** Ключ выделенной серии (hover по легенде): остальные кривые приглушаются. */
   highlightKey?: string | null;
-}> = ({ chart, series, checkpoints, height, dotLimit, large, highlightKey }) => {
+}) => {
   // Цвета сетки/осей — через CSS-класс (mcmp-chart-themed), чтобы следовали теме.
   const dim = (key: string) => (highlightKey == null || highlightKey === key ? 1 : 0.18);
   const meta = getMetricMeta(chart.name);
@@ -204,7 +207,7 @@ export const CurveChartView: React.FC<{
       </LineChart>
     </ResponsiveContainer>
   );
-};
+});
 
 /**
  * Сетка графиков с пользовательским порядком (drag and drop за ручку

--- a/frontend/src/components/notification/NotificationToast.tsx
+++ b/frontend/src/components/notification/NotificationToast.tsx
@@ -1,15 +1,8 @@
 import React from 'react';
-// Импортируем хук для доступа к контексту уведомлений.
 import { useNotification } from '../../contexts/NotificationContext';
 import { ICONS } from '../../constants/icons';
-// Подключаем стили для компонента уведомлений.
 import './NotificationToast.css';
 
-/**
- * Возвращает класс иконки Font Awesome в зависимости от типа уведомления.
- * @param type - тип уведомления ('error', 'success', 'warning', 'info').
- * @returns класс иконки Font Awesome.
- */
 const getIcon = (type: string) => {
   switch (type) {
     case 'error': return ICONS.error;
@@ -20,32 +13,19 @@ const getIcon = (type: string) => {
   }
 };
 
-/**
- * Компонент для отображения всплывающих уведомлений (тостов).
- * Использует контекст уведомлений для получения активных уведомлений
- * и функции их удаления. Рендерит каждый тост в виде карточки с иконкой,
- * текстом и кнопкой закрытия.
- */
 const NotificationToast: React.FC = () => {
-  // Получаем из контекста массив уведомлений и функцию удаления по id.
   const { notifications, removeNotification } = useNotification();
 
-  // Если нет уведомлений, ничего не рендерим (экономим место в DOM).
   if (notifications.length === 0) return null;
 
   return (
-    // Контейнер для всех тостов. Фиксированное позиционирование, выравнивание по правому краю.
     <div className="notification-container">
       {notifications.map(n => (
-        // Каждый тост – отдельный блок. Класс формируется на основе типа (например, notification-error).
         <div key={n.id} className={`notification notification-${n.type}`}>
           <div className="notification-content">
-            {/* Иконка, соответствующая типу */}
             <span className="notification-icon"><i className={`fas ${getIcon(n.type)}`}></i></span>
-            {/* Текст сообщения */}
             <span className="notification-message">{n.message}</span>
           </div>
-          {/* Кнопка закрытия – при клике удаляем уведомление по id */}
           <button className="notification-close" onClick={() => removeNotification(n.id)}>
             <i className={`fas ${ICONS.close}`}></i>
           </button>

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -1,43 +1,25 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
 import type { ReactNode } from 'react';
 
-// Определяем возможные типы уведомлений. Это union строковых литералов.
-// Используется для стилизации и определения иконки в компоненте Toast.
 type NotificationType = 'error' | 'success' | 'info' | 'warning';
 
-// Интерфейс одного уведомления:
-// - id – уникальный идентификатор (для удаления из массива и ключа в списке)
-// - message – текст сообщения
-// - type – тип (для визуального оформления)
 interface Notification {
   id: string;
   message: string;
   type: NotificationType;
 }
 
-// Тип для значения, которое будет храниться в контексте:
-// - notifications – массив активных уведомлений
-// - showNotification – функция для добавления нового уведомления
-// - removeNotification – функция для удаления уведомления по id
 interface NotificationContextType {
   notifications: Notification[];
   showNotification: (message: string, type?: NotificationType) => void;
   removeNotification: (id: string) => void;
 }
 
-// Создаём сам контекст с начальным значением undefined.
-// TypeScript будет требовать проверку на undefined при использовании useContext,
-// чтобы гарантировать, что контекст используется внутри провайдера.
 const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
 
-// Компонент-провайдер. Он оборачивает часть приложения, где нужны уведомления.
-// Принимает children (ReactNode) – вложенные компоненты.
 export const NotificationProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  // Состояние: массив уведомлений. Изначально пустой.
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
-  // Функция для показа уведомления.
-  // Принимает текст и необязательный тип (по умолчанию 'error').
   const removeNotification = useCallback((id: string) => {
     setNotifications(prev => prev.filter(n => n.id !== id));
   }, []);
@@ -48,7 +30,6 @@ export const NotificationProvider: React.FC<{ children: ReactNode }> = ({ childr
     setTimeout(() => removeNotification(id), 5000);
   }, [removeNotification]);
 
-  // Провайдер передаёт дочерним компонентам объект с текущими уведомлениями и функциями.
   return (
     <NotificationContext.Provider value={{ notifications, showNotification, removeNotification }}>
       {children}
@@ -59,7 +40,6 @@ export const NotificationProvider: React.FC<{ children: ReactNode }> = ({ childr
 // eslint-disable-next-line react-refresh/only-export-components
 export const useNotification = () => {
   const context = useContext(NotificationContext);
-  // Если контекст undefined – значит, хук вызвали вне провайдера. Выбрасываем ошибку.
   if (!context) throw new Error('useNotification must be used within NotificationProvider');
   return context;
 };

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -36,6 +36,10 @@
 .hero-logo__mark {
   filter: drop-shadow(0 14px 34px var(--color-accent-glow-strong));
   animation: hero-logo-float 6s ease-in-out 0.7s infinite;
+  /* Удерживаем элемент на собственном GPU-слое: при возврате на вкладку браузера
+     слой не пересоздаётся и drop-shadow/градиенты SVG не мерцают. */
+  backface-visibility: hidden;
+  will-change: transform, filter;
 }
 
 @keyframes hero-logo-in {

--- a/frontend/src/services/agentHistoryService.ts
+++ b/frontend/src/services/agentHistoryService.ts
@@ -1,4 +1,3 @@
-// Импортируем типы для дискуссий, ответов агентов, системных сообщений и инструментов.
 import type {
   AgentResponse,
   DiscussionListParams,
@@ -6,10 +5,8 @@ import type {
   SystemMessage,
   Tool,
 } from '../types/agentHistory';
-import { handleResponse, serviceUrl } from './http';
+import { handleResponse, serviceUrl, buildUrl } from './http';
 
-// Базовый URL сервиса истории агентов берётся из переменной окружения
-// VITE_AGENT_HISTORY, если её нет – localhost:6410.
 const AGENT_HISTORY_URL = serviceUrl(import.meta.env.VITE_AGENT_HISTORY, 'localhost:6410');
 
 /**
@@ -21,12 +18,13 @@ export const agentHistoryService = {
    * GET /discussions?status=&pipeline=&skip=&limit=
    */
   async getDiscussions(params: DiscussionListParams = {}): Promise<DiscussionMeta[]> {
-    const url = new URL(`${AGENT_HISTORY_URL}/discussions`);
-    if (params.status) url.searchParams.append('status', params.status);
-    if (params.pipeline) url.searchParams.append('pipeline', params.pipeline);
-    if (params.skip !== undefined) url.searchParams.append('skip', String(params.skip));
-    if (params.limit !== undefined) url.searchParams.append('limit', String(params.limit));
-    const response = await fetch(url.toString());
+    const url = buildUrl(`${AGENT_HISTORY_URL}/discussions`, {
+      status: params.status,
+      pipeline: params.pipeline,
+      skip: params.skip,
+      limit: params.limit,
+    });
+    const response = await fetch(url);
     return handleResponse<DiscussionMeta[]>(response);
   },
 

--- a/frontend/src/services/agentsService.ts
+++ b/frontend/src/services/agentsService.ts
@@ -2,8 +2,6 @@
 import { handleResponse, serviceUrl } from './http';
 import type { LlmSettings } from '../types/llm';
 
-// Базовый URL сервиса агентов берётся из переменной окружения VITE_AGENTS,
-// если её нет – localhost:6400.
 const AGENTS_URL = serviceUrl(import.meta.env.VITE_AGENTS, 'localhost:6400');
 
 /** Параметры запуска пайплайна development. */

--- a/frontend/src/services/datasetService.ts
+++ b/frontend/src/services/datasetService.ts
@@ -1,7 +1,7 @@
 // Импортируем типы для датасетов, новых датасетов, новых версий и существующих версий.
 import type { Dataset, NewDataset, NewVersion, Version, VersionSplitsResponse } from '../types/dataset';
 import type { FilesDiffResponse, VersionComparisonResponse } from '../types/datasetComparison';
-import { handleResponse, serviceUrl } from './http';
+import { handleResponse, serviceUrl, buildUrl } from './http';
 
 // Базовый URL сервиса datasets берётся из переменной окружения VITE_DMS, по умолчанию localhost:6500.
 const DMS_URL = serviceUrl(import.meta.env.VITE_DMS, 'localhost:6500');
@@ -65,9 +65,10 @@ export const datasetService = {
    * POST /datasets/{datasetId}/default_version?default_version={versionId}
    */
   async setDefaultVersion(datasetId: string, versionId: string): Promise<boolean> {
-    const url = new URL(`${DMS_URL}/datasets/${datasetId}/default_version`);
-    url.searchParams.append('default_version', versionId);
-    const response = await fetch(url.toString(), { method: 'POST' });
+    const url = buildUrl(`${DMS_URL}/datasets/${datasetId}/default_version`, {
+      default_version: versionId,
+    });
+    const response = await fetch(url, { method: 'POST' });
     return handleResponse<boolean>(response);
   },
 

--- a/frontend/src/services/http.ts
+++ b/frontend/src/services/http.ts
@@ -9,6 +9,22 @@ export const serviceUrl = (envValue: string | undefined, fallback: string): stri
   `http://${envValue ?? fallback}`;
 
 /**
+ * Собирает URL с query-параметрами, пропуская пустые (null/undefined/'').
+ * @param base базовый URL без query, напр. `${ML_MODELS_URL}/models`
+ * @param params пары имя→значение; пустые значения не добавляются
+ */
+export const buildUrl = (
+  base: string,
+  params: Record<string, string | number | undefined | null>,
+): string => {
+  const url = new URL(base);
+  for (const [k, v] of Object.entries(params)) {
+    if (v != null && v !== '') url.searchParams.append(k, String(v));
+  }
+  return url.toString();
+};
+
+/**
  * Универсальная обработка HTTP-ответа.
  * @returns данные типа T; для пустых ответов (например, 204) — true.
  * @throws Error с текстом из тела ответа (FastAPI: detail/message) или статусом.

--- a/frontend/src/services/metricsService.ts
+++ b/frontend/src/services/metricsService.ts
@@ -154,10 +154,20 @@ export const metricsService = {
   subscribeModelMetrics(modelId: string, handlers: MetricsStreamHandlers): () => void {
     const source = new EventSource(`${BASE}/models/${modelId}/stream`);
     source.addEventListener('metrics', (event: MessageEvent) => {
-      handlers.onMetrics(JSON.parse(event.data) as ModelMetrics);
+      try {
+        handlers.onMetrics(JSON.parse(event.data) as ModelMetrics);
+      } catch (error) {
+        console.error('Битый JSON в SSE-событии metrics:', error);
+        handlers.onError?.(event);
+      }
     });
     source.addEventListener('end', (event: MessageEvent) => {
-      handlers.onEnd?.(JSON.parse(event.data) as StreamEndEvent);
+      try {
+        handlers.onEnd?.(JSON.parse(event.data) as StreamEndEvent);
+      } catch (error) {
+        console.error('Битый JSON в SSE-событии end:', error);
+        handlers.onError?.(event);
+      }
     });
     source.onerror = (event) => handlers.onError?.(event);
     return () => source.close();

--- a/frontend/src/services/mlModelsService.ts
+++ b/frontend/src/services/mlModelsService.ts
@@ -1,4 +1,3 @@
-// Импортируем типы для моделей, версий, файлов и параметров запроса.
 import type {
   MLModel,
   MLModels,
@@ -9,9 +8,8 @@ import type {
   ModelsQuery,
   VersionsQuery,
 } from '../types/mlModels';
-import { handleResponse, serviceUrl } from './http';
+import { handleResponse, serviceUrl, buildUrl } from './http';
 
-// Базовый URL сервиса ml_models берётся из VITE_ML_MODELS, по умолчанию localhost:6300.
 const ML_MODELS_URL = serviceUrl(import.meta.env.VITE_ML_MODELS, 'localhost:6300');
 
 /**
@@ -23,13 +21,14 @@ export const mlModelsService = {
    * GET /models?dataset_id&status&name&limit&offset
    */
   async getModels(query: ModelsQuery = {}): Promise<MLModels> {
-    const url = new URL(`${ML_MODELS_URL}/models`);
-    if (query.dataset_id) url.searchParams.append('dataset_id', query.dataset_id);
-    if (query.status) url.searchParams.append('status', query.status);
-    if (query.name) url.searchParams.append('name', query.name);
-    if (query.limit != null) url.searchParams.append('limit', String(query.limit));
-    if (query.offset != null) url.searchParams.append('offset', String(query.offset));
-    const response = await fetch(url.toString());
+    const url = buildUrl(`${ML_MODELS_URL}/models`, {
+      dataset_id: query.dataset_id,
+      status: query.status,
+      name: query.name,
+      limit: query.limit,
+      offset: query.offset,
+    });
+    const response = await fetch(url);
     return handleResponse<MLModels>(response);
   },
 
@@ -38,14 +37,15 @@ export const mlModelsService = {
    * GET /versions?dataset_id&status&name&model_id&limit&offset
    */
   async getVersions(query: VersionsQuery = {}): Promise<MLModelVersions> {
-    const url = new URL(`${ML_MODELS_URL}/versions`);
-    if (query.dataset_id) url.searchParams.append('dataset_id', query.dataset_id);
-    if (query.status) url.searchParams.append('status', query.status);
-    if (query.name) url.searchParams.append('name', query.name);
-    if (query.model_id) url.searchParams.append('model_id', query.model_id);
-    if (query.limit != null) url.searchParams.append('limit', String(query.limit));
-    if (query.offset != null) url.searchParams.append('offset', String(query.offset));
-    const response = await fetch(url.toString());
+    const url = buildUrl(`${ML_MODELS_URL}/versions`, {
+      dataset_id: query.dataset_id,
+      status: query.status,
+      name: query.name,
+      model_id: query.model_id,
+      limit: query.limit,
+      offset: query.offset,
+    });
+    const response = await fetch(url);
     return handleResponse<MLModelVersions>(response);
   },
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,5 +6,20 @@ export default defineConfig({
   server: {
     port: 6001,
     host: '0.0.0.0'
-  }
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        // Тяжёлые vendor-либы — в отдельные чанки: кэшируются браузером между деплоями,
+        // не инвалидируются при каждом изменении кода приложения. Порядок важен:
+        // react-markdown/recharts проверяем до react (react-router тоже идёт в react).
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return;
+          if (id.includes('recharts')) return 'recharts';
+          if (id.includes('react-markdown') || id.includes('remark')) return 'markdown';
+          if (id.includes('react')) return 'react';
+        },
+      },
+    },
+  },
 })

--- a/services/trainer/app/core/__init__.py
+++ b/services/trainer/app/core/__init__.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from app.api.schemas import TaskParams
 from app.service.tasker import tasker_service
 from app.service.metrices import MetricesClient, send_checkpoint_info
@@ -47,7 +49,10 @@ async def training_model(config: TaskParams, model_id: str):
 
     # Загружаем данные
     await tasker_service.update_status_task(percentages=PROGRESS_DATA_LOADING, status_info="Загрузка данных...")
-    train_loader, val_loader, test_loader, classes = create_dataloaders(config.data_loader_params)
+    train_loader, val_loader, test_loader, classes = await asyncio.to_thread(
+        create_dataloaders,
+        config.data_loader_params
+    )
     await tasker_service.update_status_task(percentages=PROGRESS_DATA_READY, status_info="Данные загружены.")
 
     # Предзагрузка весов pretrained-модели в кэш (отдельный этап с видимым прогрессом)
@@ -61,10 +66,12 @@ async def training_model(config: TaskParams, model_id: str):
 
     # Загружаем модель (веса берутся из кэша мгновенно)
     await tasker_service.update_status_task(percentages=PROGRESS_MODEL_LOADING, status_info="Загрузка модели...")
-    model = get_model(
-        config.model_params,
-        num_classes = len(classes)
-    ).to(device)
+    model = await asyncio.to_thread(
+        lambda: get_model(
+            config.model_params,
+            num_classes = len(classes)
+        ).to(device)
+    )
     await tasker_service.update_status_task(percentages=PROGRESS_MODEL_READY, status_info=f"Модель {config.model_params.type} загружена.")
 
     await tasker_service.update_status_task(percentages=PROGRESS_METRICS_SETUP, status_info="Настройка метрик...")

--- a/services/trainer/app/core/trainer/train_model.py
+++ b/services/trainer/app/core/trainer/train_model.py
@@ -176,7 +176,7 @@ class Trainer:
 
         self.model.train()
 
-        for batch in self._tqdm_loader(self.train_loader, "Тренировка"):
+        for batch in self._iter_with_progress(self.train_loader, "Тренировка"):
 
             inputs, labels = batch
 
@@ -235,7 +235,7 @@ class Trainer:
         self.model.eval()
 
         with torch.no_grad():
-            for batch in self._tqdm_loader(self.val_loader, "Валидация"):
+            for batch in self._iter_with_progress(self.val_loader, "Валидация"):
                 inputs, labels = batch
 
                 inputs = inputs.to(self.device)
@@ -284,6 +284,15 @@ class Trainer:
 
         self._metric_service.compute('test')
         self._metric_service.send_class_report()
+
+    def _iter_with_progress(self, data_loader: DataLoader, desc: str):
+        """Итерация по батчам с логом прогресса каждые ~5% (tqdm не виден в контейнере)"""
+        total = len(data_loader)
+        step = max(1, total // 20)  # 5% = 1/20; при <20 батчах — каждый батч
+        for i, batch in enumerate(self._tqdm_loader(data_loader, desc), start=1):
+            yield batch
+            if i % step == 0 or i == total:
+                logger.info(f"{desc}: {round(i * 100 / total)}% ({i}/{total} батчей)")
 
     def _tqdm_loader(self, data_loader: DataLoader, desc: str = "process") -> tqdm:
         """Получение обьекта tqdm"""


### PR DESCRIPTION
## 📌 Что было сделано?

Набор незакоммиченных улучшений frontend и trainer, разнесённый по атомарным коммитам. Фронт: ленивая загрузка роутов и разбивка vendor-чанков, единый хелпер построения URL, устойчивость SSE-потока метрик и меньше мерцания/лишних ре-рендеров. Trainer: блокирующая загрузка данных/модели уходит в отдельные потоки, добавлен видимый в контейнере лог прогресса по батчам.

### frontend (бандл и устойчивость рендера)
- Роуты грузятся лениво (`lazy`/`Suspense`), тяжёлые vendor-либы (recharts, react-markdown, react) выносятся в отдельные кэшируемые чанки через `manualChunks` (`App.tsx`, `vite.config.ts`)
- `ErrorBoundary` оборачивает контент роута; `key={pathname}` перемонтирует его при навигации - иначе после краша рендера `hasError` оставался бы `true` навсегда (`components/common/ErrorBoundary.tsx`, `App.tsx`)
- Защита SSE-потока метрик: `try/catch` вокруг `JSON.parse` событий `metrics`/`end`, битый кадр уходит в `onError` и не рвёт подписку (`services/metricsService.ts`)

### frontend (построение URL)
- Хелпер `buildUrl` собирает URL с query-параметрами, отбрасывая пустые (`null`/`undefined`/`''`); заменил ручную сборку `new URL` + `searchParams.append` (`services/http.ts`, `agentHistoryService.ts`, `datasetService.ts`, `mlModelsService.ts`)

### frontend (мерцание и ре-рендеры)
- Таймеры «сейчас» в живых вьюхах: `setTimeout(0)` вместо синхронного `setNow` в эффекте - не дёргает рендер при активации (`DiscussionView.tsx`, `TrainingTaskProgress.tsx`)
- `CurveChartView` обёрнут в `React.memo`: график recharts дорог в отрисовке, props в сетке стабильны, несвязанные ре-рендеры родителя больше не перерисовывают сетку (`curveChart.tsx`)
- Лого на главной удерживается на собственном GPU-слое (`backface-visibility`/`will-change`), чтобы при возврате на вкладку не мерцали `drop-shadow`/градиенты (`pages/Home.css`)
- Чистка избыточных комментариев в модуле уведомлений (`NotificationToast.tsx`, `NotificationContext.tsx`)

### trainer
- `create_dataloaders` и `get_model().to(device)` уходят в `asyncio.to_thread` - блокирующая загрузка данных/весов больше не вешает event loop сервиса (`core/__init__.py`)
- `_iter_with_progress`: лог прогресса каждые ~5% батчей на тренировке и валидации (tqdm не виден в контейнере) (`core/trainer/train_model.py`)
